### PR TITLE
feat: Apple Silicon FP8/INT8 acceleration — default-on, hardware-gated

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,32 @@
+# Keep the published Registry package to what ComfyUI actually needs at runtime.
+# Syntax matches .gitignore. Everything under _patches/ (incl. the .mm kernel
+# sources built on demand), __init__.py, prestartup_script.py, requirements.txt,
+# README.md and LICENSE are kept.
+
+# Test suite + dev/research harnesses
+tests/
+dev/
+docs/
+conftest.py
+
+# Repo tooling / CI (runs on GitHub, not shipped in the node package)
+.github/
+.claude/
+.omc/
+.serena/
+.ruff_cache/
+.pytest_cache/
+.mcp.json
+
+# Session write-ups & long-form docs (not needed to run the node)
+SESSION_*.md
+*_FINDINGS.md
+INVESTIGATION_FACTS.md
+ISSUE_*.md
+BLOG_POST.md
+blog-*.md
+
+# Junk
+__pycache__/
+*.pyc
+.DS_Store

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -1,0 +1,36 @@
+name: Publish to Comfy Registry
+
+# Publishes the node to https://registry.comfy.org (which ComfyUI-Manager reads)
+# whenever the version in pyproject.toml changes on the default branch.
+#
+# One-time setup:
+#   1. Create a publisher at https://registry.comfy.org and note your PublisherId
+#      (already set in pyproject.toml [tool.comfy].PublisherId).
+#   2. Create an API key at https://registry.comfy.org/nodes and add it to this repo
+#      as a secret named REGISTRY_ACCESS_TOKEN
+#      (Settings -> Secrets and variables -> Actions -> New repository secret).
+# After that, bump [project].version in pyproject.toml and push to main to publish.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  publish-node:
+    name: Publish custom node to registry
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'pawel-mazurkiewicz' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Publish custom node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -22,6 +22,11 @@ on:
 permissions:
   contents: read
 
+# Never let two publishes race (e.g. rapid pushes); the latest version wins.
+concurrency:
+  group: comfy-registry-publish
+  cancel-in-progress: false
+
 jobs:
   publish-node:
     name: Publish custom node to registry
@@ -30,7 +35,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Publish custom node
-        uses: Comfy-Org/publish-node-action@v1
+        # Pinned to a full commit SHA (supply-chain hardening); bump deliberately.
+        uses: Comfy-Org/publish-node-action@7578cdb0c1410f2515e6f9b1443c6859cab94f05  # 1.0.1
         with:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,19 +9,20 @@
 
 - **What:** one ComfyUI custom node that patches MPS at startup so FP8/INT8
   diffusion models (FLUX, SD3.5, Ideogram 4, Krea2, …) **run on Apple Silicon
-  instead of crashing** — plus Metal flash-attention and opt-in **bit-exact
-  fp8/int8 Metal matmul kernels** for speed. No model conversion; every patch is
-  a no-op on machines that don't need it.
+  instead of crashing** — plus Metal flash-attention and **bit-exact fp8/int8
+  Metal matmul + fused-norm + RoPE kernels** for speed. No model conversion; every
+  patch is a no-op on machines that don't need it.
 - **Install:** ComfyUI Manager → search *AppleSilicon-FP8*; or `git clone` into
   `ComfyUI/custom_nodes/` and `pip install -r requirements.txt`. The one required
   dependency (`mtlflashattn`) installs automatically. Restart ComfyUI.
-- **Extra speed (opt-in, needs a recent macOS + M5):** the native matmul kernels
-  compile against **Metal 4.1** (a current-macOS language version — developed and
-  tested on the **macOS 27 dev beta**), and int8 additionally needs an **M5** GPU
-  for its cooperative TensorOps. Where supported, install `ninja` and set
-  `ASFP8_INT8_EXT=1` (int8) and/or `ASFP8_FP8_EXT=1` (fp8) before launching. They
-  JIT-build on first use and **fall back automatically** if the OS/GPU/toolchain
-  can't build them.
+- **Speedups are ON by default — but gated on the hardware/software that can run
+  them.** Every acceleration patch self-detects capability at startup and only
+  activates where it's supported; everywhere else it stays inert (nothing to
+  configure, nothing breaks). The startup log prints a one-line capability summary
+  so you can see exactly which tier is active on your machine. The heavier matmul
+  kernels compile against **Metal 4.1** (developed on **macOS 27**) and need an
+  **M5** GPU plus `ninja` to build — so on M1–M4 or older macOS they simply don't
+  engage. Any env var below can force a patch on or off regardless of the probe.
 
 ## Quick start — by machine
 
@@ -32,42 +33,47 @@ render, flash-attention accelerates long-context attention, and the psutil /
 PiD-black-image / WanVideo-blockswap crashes are gone. No environment variables,
 no Metal 4.1, no specific GPU generation needed. This is all most people want.
 
-The opt-in *native* matmul kernels (`ASFP8_*_EXT`) below are the only thing with
-extra requirements, on **two axes**:
+The heavier *native* matmul kernels (`ASFP8_FP8_EXT`, `ASFP8_FP8_NATIVE`,
+`ASFP8_INT8_EXT`) are on by default too, but only actually engage where two axes
+are satisfied:
 
 - **OS / Metal:** they compile against **Metal 4.1** (current-macOS language
-  version; developed on the **macOS 27 dev beta**). Older macOS → the build fails
-  and the kernel falls back. Needs Xcode command-line tools (the Metal compiler).
+  version; developed on **macOS 27**). Older macOS → the capability probe fails
+  and the kernel stays inert. Needs Xcode command-line tools (the Metal compiler)
+  and `ninja` to build the ObjC++ extension.
 - **GPU:** the **int8** kernel needs an **M5** (Metal 4 cooperative TensorOps);
-  the **fp8** kernel needs Metal 4.1's fp8 format type. Anything unsupported falls
-  back automatically.
+  the **fp8** kernel needs Metal 4.1's fp8 format type. Anything unsupported is
+  detected up front and skipped.
 
-**M1 / M2 / M3 / M4 — stay on the defaults.** The int8 kernel is M5-only and won't
-engage; leave `ASFP8_*_EXT` off. You still get the full compatibility layer: FP8
-matmuls run accelerated via bf16 decode on `simdgroup_matrix`, and int8 runs
-comfy's (fixed) weight-only path.
+**M1 / M2 / M3 / M4 — nothing to do.** The M5-class matmul kernels self-detect as
+unsupported and never build, so there's no failed-compile noise and no config.
+You still get the full compatibility layer plus the compile_shader speedups that
+*don't* need Metal 4.1 (fused RMSNorm #18, fused RoPE #21): FP8 matmuls run
+accelerated via bf16 decode on `simdgroup_matrix`, and int8 runs comfy's (fixed)
+weight-only path.
 
-**M5 / M5 Pro / M5 Max on a recent macOS — turn on the kernels for the real
-speedups:**
+**M5 / M5 Pro / M5 Max on a recent macOS — just install the build toolchain and
+the kernels turn themselves on:**
 
 ```bash
 xcode-select --install                 # if not already installed (Metal toolchain)
 pip install ninja                      # or:  pip install 'comfyui-applesilicon-fp8[kernels]'
-
-# enable per model type — set before launching ComfyUI:
-export ASFP8_INT8_EXT=1   # int8 models  (e.g. Krea2 convrot int8mixed) → ~24% faster renders
-export ASFP8_FP8_EXT=1    # fp8 models   (e.g. FLUX / SD3.5 fp8_scaled) → ~1.2–2.1× on the matmul
+# ...then launch ComfyUI. The int8 (#17) and fp8-native (#3/#20) kernels detect
+# M5 + Metal 4.1 + ninja and activate automatically — no env vars required.
 ```
 
-Each kernel builds on the first eligible matmul (watch the startup log for the
-`int8_kernel` / fp8 lines) and silently falls back to the compatible path on any
-failure — including too-old macOS — so it's safe to leave enabled.
+Each kernel builds on first use (watch the startup log for the capability summary
+and the `int8_kernel` / fp8 lines) and silently stays inert on any failure —
+including too-old macOS or missing `ninja` — so the defaults are safe everywhere.
+To force a kernel off on a supported machine, set its env var to `off` (e.g.
+`ASFP8_INT8_EXT=off`); to force a build attempt anyway, set it to `1`.
 
 It started as an FP8 compatibility layer and has grown into a broader Apple
 Silicon quantization layer: it keeps FP8 **and INT8** diffusion models running on
-MPS, and ships opt-in **bit-exact Metal matmul kernels** that beat the default
-path (fp8-native `_scaled_mm` ~1.2–2.1×; int8 W8A8 ~1.9× on the matmul, ~24%
-faster end-to-end on Krea2 convrot int8mixed).
+MPS, and ships **bit-exact Metal matmul kernels** (on by default where the
+hardware supports them) that beat the default path (fp8-native `_scaled_mm`
+~1.2–2.1×; int8 W8A8 ~1.9× on the matmul, ~24% faster end-to-end on Krea2 convrot
+int8mixed) plus compile_shader fused kernels (RMSNorm, RoPE) that need no Metal 4.1.
 
 If you're on a Mac and FP8 models die with
 `Trying to convert Float8_e4m3fn to the MPS backend but it does not have support for that dtype`,
@@ -87,20 +93,22 @@ on Apple Silicon. This trades some peak throughput for "it actually runs."
 
 It also handles **INT8** checkpoints (e.g. **Krea2 convrot int8mixed**): comfy's
 int8 path runs weight-only on MPS (dequantize the int8 weight to bf16, and for
-convrot models un-rotate the whole weight in fp32, every step), so the opt-in
-int8 kernel switches it to the W8A8 path the format was designed for — rotate the
-*activation* online, then a real int8×int8 matmul — which is both correct and
-faster.
+convrot models un-rotate the whole weight in fp32, every step), so — on an M5 with
+the toolchain — the int8 kernel switches it to the W8A8 path the format was
+designed for — rotate the *activation* online, then a real int8×int8 matmul —
+which is both correct and faster.
 
 It's a single ComfyUI custom node that applies a few targeted runtime patches at
 startup. No model conversion. FP8 matmuls decode (bit-exact) to bf16 and run on
 Apple's matrix units (Neural Accelerators on M5+, simdgroup_matrix on M1–M4); the
-opt-in kernels go further and run fp8/int8 matmuls natively on those units. The
-only required dependency is
+native matmul kernels go further and run fp8/int8 matmuls directly on those units
+where the hardware allows. The only required dependency is
 [`mtlflashattn`](https://github.com/pawel-mazurkiewicz/mtlflashattn) (the Metal
 flash-attention kernels — Apple Silicon only, installed automatically); the
-opt-in matmul kernels additionally need `ninja` (the `[kernels]` extra). Each
-patch is a no-op on machines that don't need it.
+native matmul kernels additionally need `ninja` (the `[kernels]` extra) and stay
+inert without it. Each patch is a no-op on machines that don't need it, and every
+speedup is gated on a startup capability probe (see the banner in
+[Verify it's active](#verify-its-active)).
 
 > Tested on: Apple M-series, macOS 27 dev beta, PyTorch 2.11, Python 3.12, ComfyUI Desktop.
 
@@ -110,7 +118,7 @@ patch is a no-op on machines that don't need it.
 |---|---------|-------|-----|
 | 1 | `RuntimeError: host_statistics64(HOST_VM_INFO64) ... array not large enough` — renders crash partway through | psutil's prebuilt C extension doesn't match the kernel on recent macOS betas; `virtual_memory()` fails ~99% of calls, and ComfyUI calls it every node | Replace `psutil.virtual_memory()` with a `vm_stat` + `sysctl`-based equivalent that doesn't use the broken syscall |
 | 2 | `TypeError: ... convert Float8_e4m3fn ...` (e.g. **Ideogram 4**) or `RuntimeError: Undefined type Float8_e4m3fn` from a **mixed-precision / NVFP4 checkpoint** (e.g. **LTX**'s Gemma3 text encoder) | comfy_kitchen's eager backend dequantizes per-tensor FP8 with a plain `x.to(bfloat16)` cast MPS can't do; its newer microscaling layouts (NVFP4/MXFP8) unswizzle FP8 block-scales with a reshape-after-transpose, and MPS can't make a non-contiguous FP8 tensor contiguous | Decode per-tensor FP8 with a lookup-table + gather (bit-identical, on GPU); route the NVFP4/MXFP8 block-scale dequant (`dequantize_nvfp4`/`dequantize_mxfp8`) through the CPU and move the float result back (bit-exact) |
-| 3 | `scaled_mm not implemented for MPS` / FP8 cast errors from **FLUX / SD3.5** (and Krea2 `fp8_scaled`) | `torch._scaled_mm` has no FP8 kernel on MPS | Patch `torch._scaled_mm` to decode FP8 → float and run a native MPS matmul. **Opt-in (`ASFP8_FP8_EXT=1`):** large fp8×fp8 matmuls (the real scaled-fp8 seam) skip both bf16 decodes and run a Metal 4.1 fp8-native `matmul2d` instead — bit-exact, ~1.2–2.1× faster; falls back automatically |
+| 3 | `scaled_mm not implemented for MPS` / FP8 cast errors from **FLUX / SD3.5** (and Krea2 `fp8_scaled`) | `torch._scaled_mm` has no FP8 kernel on MPS | Patch `torch._scaled_mm` to decode FP8 → float and run a native MPS matmul. **On by default where supported (M5 + Metal 4.1 + `ninja`; `ASFP8_FP8_EXT=off` to disable):** large fp8×fp8 matmuls (the real scaled-fp8 seam) skip both bf16 decodes and run a Metal 4.1 fp8-native `matmul2d` instead — bit-exact, ~1.2–2.1× faster; stays inert / falls back automatically on unsupported machines |
 | 4 | **PiD (Pixel Diffusion Decoder) outputs a fully black image at ≥2048px** (`RuntimeWarning: invalid value encountered in cast`) | `torch.nn.functional.rms_norm` silently returns garbage on MPS once the normalization row count exceeds ~2²² (~4.19M); PiD's pixel blocks cross that at 2048px+, producing NaN → black | Compute `rms_norm` with the exact manual fp32 formula on MPS for large row counts; the fused fast path is kept for normal sizes and all non-MPS devices |
 | 5 | **Large attention SIGKILLs the render** (SeedVR2 4K DiT, long-context global attention), **or attention is slow / numerically wrong** on MPS past ~4k tokens | MPS fused `scaled_dot_product_attention` materializes the full `Lq×Lk` score matrix (memory grows `O(B·H·Lq·Lk)`) and is silently inaccurate at length; there is no flash-attention on MPS | Back `F.scaled_dot_product_attention` (and `import flash_attn`) with [`mtlflashattn`](https://github.com/pawel-mazurkiewicz/mtlflashattn): Metal flash kernels (simdgroup_matrix / M5 TensorOps) that never form the score matrix and run **3–4× faster than fused SDPA** at length. Gated so small attention stays on stock |
 | 6 | `TypeError: ... convert Float8_e4m3fn to the MPS backend ...` from an **FP8 `UNETLoader` checkpoint** (e.g. Lens, FLUX fp8) at sampling time | ComfyUI's `manual_cast` layers store weight **and bias** as raw FP8 and cast them up per forward; MPS can cast neither *to* nor *from* FP8 on-device (the bias crashes first, the weight would crash next) | Take over `comfy.ops.cast_bias_weight` on the plain MPS path and LUT-decode weight + bias to the compute dtype (QuantizedTensor params routed via `dequantize()`) |
@@ -123,7 +131,11 @@ patch is a no-op on machines that don't need it.
 | 13 | **INT8 models run, but ~3-5× too slow** on MPS (e.g. Krea2 `int8_mixed` at ~140 s/step) | The `int8-fast` node's wide-batch path (image diffusion = thousands of tokens) quantizes activations to int8 and matmuls via `torch._int_mm` — which on MPS is float32 (patch #12), losing bf16 throughput and doubling the working set on top of a multi-GB model | On MPS, route int8-fast's `int8_forward_dynamic[_per_row]` through its own small-batch path: dequantize the int8 weight to bf16 and use MPS's native (double-buffered) bf16 GEMM. ~3.5-4.7× faster on FLUX-shaped Linears, equal-or-better accuracy (weight-only int8). Patched via a post-import hook since int8-fast loads after this node |
 | 14 | **MLX-backed Qwen3-VL `TextGenerate`** — Krea2 prompt-expansion runs an eager autoregressive Qwen3-VL-4B loop (~50 s on MPS) | The generation loop runs token-by-token inside a Python `for` loop using PyTorch MPS ops; there is no batched Metal kernel for autoregressive decoding, so each forward pass pays per-token dispatch overhead (~1 s/token) | On MPS, with `mlx-vlm` installed, route the generation loop through MLX (`mlx-community/Qwen3-VL-4B-Instruct-4bit`): MLX's native autoregressive engine amortises dispatch cost with a fused Metal decode loop and KV-cache on the GPU. Text-only; conditioning encode is untouched. Eager fallback if MLX is absent or errors. |
 | 16 | `RuntimeError: Undefined type Float8_e4m3fn` from **NVFP4/MXFP8 mixed-precision quant or dequant** (e.g. on-the-fly nvfp4 re-quant of an LTX text encoder, or loading such a checkpoint) | MPS has no copy kernel for FP8 with non-trivial strides: materialising a *non-contiguous* fp8 tensor (`reshape` after `transpose`, `.contiguous()`/`clone()` of a strided fp8 view) crashes. comfy's block-scale swizzles (`comfy.float.to_blocked`/`from_blocked`, comfy_kitchen's NVFP4/MXFP8 dequant) hit this in many places | Fix the primitive once: wrap the materialising Tensor methods (`reshape`/`contiguous`/`clone`) so that, only for FP8 tensors on MPS, the op falls back to CPU and the result returns to the device. Bit-exact (pure data rearrangement); no-op for every non-FP8 tensor. Covers all current and future call sites. Disable with `ASFP8_DISABLE=fp8_mps_strided` |
-| 17 | **INT8 models run correctly but leave performance on the table** on MPS (e.g. **Krea2 convrot int8mixed**): comfy's int8 path is weight-only (W8A16), so every step dequantizes the int8 weight to bf16 — and for convrot checkpoints un-rotates the *entire* weight in fp32 — which dominates GPU time | comfy disables the real int8 matmul on non-CUDA (no `torch._int_mm` Metal kernel), so int8 only buys storage; the per-step fp32 weight dequant + Hadamard un-rotation is pure overhead, and naively enabling comfy's W8A8 forward pre-quantizes activations *tensorwise before* convrot (≈16% error → garbage) | **Opt-in (`ASFP8_INT8_EXT=1`):** route int8 convrot Linears through the W8A8 path the format intends — rotate the *activation* online, per-row quantize it, then a **bit-exact INT8×INT8→INT32 Metal kernel** (Metal 4 cooperative TensorOps, M5+) — and skip comfy's weight dequant/un-rotation entirely. The kernel runs ~1.85× over bf16 / ~7× over the fp32 `_int_mm` fallback (with the per-row rescale + bias **fused into the store epilogue** so the int32 product never hits global memory); ~24% faster Krea2 renders at matching quality. Kernel ported from [Cider](https://github.com/Mininglamp-AI/cider) (MIT). Falls back to comfy's path if the kernel can't build |
+| 17 | **INT8 models run correctly but leave performance on the table** on MPS (e.g. **Krea2 convrot int8mixed**): comfy's int8 path is weight-only (W8A16), so every step dequantizes the int8 weight to bf16 — and for convrot checkpoints un-rotates the *entire* weight in fp32 — which dominates GPU time | comfy disables the real int8 matmul on non-CUDA (no `torch._int_mm` Metal kernel), so int8 only buys storage; the per-step fp32 weight dequant + Hadamard un-rotation is pure overhead, and naively enabling comfy's W8A8 forward pre-quantizes activations *tensorwise before* convrot (≈16% error → garbage) | **On by default where supported (M5 + Metal 4.1 + `ninja`; `ASFP8_INT8_EXT=off` to disable):** route int8 convrot Linears through the W8A8 path the format intends — rotate the *activation* online, per-row quantize it, then a **bit-exact INT8×INT8→INT32 Metal kernel** (Metal 4 cooperative TensorOps, M5+) — and skip comfy's weight dequant/un-rotation entirely. The kernel runs ~1.85× over bf16 / ~7× over the fp32 `_int_mm` fallback (with the per-row rescale + bias **fused into the store epilogue** so the int32 product never hits global memory); ~24% faster Krea2 renders at matching quality. Kernel ported from [Cider](https://github.com/Mininglamp-AI/cider) (MIT). Stays inert / falls back to comfy's path where unsupported |
+| 18 | **DiT adaLN tail (RMSNorm + modulation + residual) is several separate MPS passes** | Each of rmsnorm, the `(1+scale)·x+shift` affine, and the residual add is its own kernel launch + full read/write of the activation | **On by default where supported (any MPS with `compile_shader`; `ASFP8_FUSED_NORM=off` to disable):** fuse the whole tail into **one** `compile_shader` pass (fp32 reduction, 64-bit indexing — also supersedes patch #4's >2²¹-row correctness fallback). No Metal 4.1 / M5 needed |
+| 19 | **VAE / SeedVR2 conv3d decode is slow (or OOMs non-tiled) on MPS** | Stock MPS `conv3d` doesn't use the tensor units and materialises large intermediates | **On by default where supported (M5 / Metal 4.1; `ASFP8_CONV_IM2COL=off` to disable):** run conv3d as im2col + `matmul2d` on the tensor units (~2.7× vs stock conv3d, ~31% faster SeedVR2), with the patch buffer capped at `ASFP8_CONV_TILE_MB`. conv2d stays off unless opted in (`=2d`/`=2d,3d`); falls back per-conv on any unsupported shape |
+| 20 | **FP8 `mixed_precision_ops` Linear decodes fp8→bf16 every step** (Ideogram-4-style eager fp8 checkpoints) | The weight is stored fp8 but each forward LUT-decodes it to bf16 before the matmul | **On by default where supported (M5 + Metal 4.1 + `ninja`; `ASFP8_FP8_NATIVE=off` to disable):** route wide fp8 Linears (min_dim ≥ 8192) through a native fp8-e4m3 `matmul2d` — half activation × fp8 weight on the tensor units — bypassing the per-step decode. Seam confirmed via a live Flux-2 probe; falls back per-call otherwise |
+| 21 | **Rotary position embedding is a chain of small MPS ops per attention block** | `apply_rope` / `apply_rope_split_half` do the interleave/rotate as several elementwise kernels | **On by default where supported (any MPS with `compile_shader`; `ASFP8_ROPE_FAST=off` to disable):** fuse `comfy_kitchen`'s `apply_rope` / `apply_rope_split_half` into **one** `compile_shader` kernel (~6–17×/call over eager; fp32 math, no Metal 4.1/M5). **#21b** additionally retargets the *real* `comfy.ldm.flux` / `llama` rope on live models — higher-risk, so **opt-in** via `ASFP8_ROPE_COMFY_RETARGET=1` |
 
 ### How the FP8 trick works
 
@@ -150,9 +162,11 @@ Then restart ComfyUI.
 
 ## Verify it's active
 
-At startup you'll see (only the lines relevant to your machine):
+At startup you'll see a capability summary (which acceleration tier is active on
+your machine), then only the patch lines relevant to it:
 
 ```
+[AppleSilicon-FP8] capabilities: macOS=27.0, torch=2.11.0, mps=yes, compile_shader=yes, tensor_ops(M5/Metal4)=yes, ninja=yes
 [AppleSilicon-FP8/psutil] psutil.virtual_memory() is broken on this OS — installed vm_stat fallback (...).
 [AppleSilicon-FP8/comfy_kitchen] patched comfy_kitchen eager FP8 dequantize/quantize for MPS.
 [AppleSilicon-FP8/scaled_mm] torch._scaled_mm FP8 on MPS via LUT decode + bf16 matrix-unit matmul.
@@ -161,16 +175,27 @@ At startup you'll see (only the lines relevant to your machine):
 [AppleSilicon-FP8/tensor_to] torch.Tensor.to FP8<->float routed via LUT/CPU on MPS.
 [AppleSilicon-FP8/wan_blockswap] armed; will neutralize WanVideo block swap on MPS when it loads.
 [AppleSilicon-FP8/rmsnorm] F.rms_norm uses manual fp32 path on MPS for >2^21 rows (PiD black-image fix).
+[AppleSilicon-FP8/fused-norm] fused rmsnorm+modulation kernel active on MPS (F.rms_norm rerouted; supersedes the >2^21-row fp32 fallback).
 [AppleSilicon-FP8/flash] F.scaled_dot_product_attention -> mtlflashattn on MPS (correctness>=4096 tok, fast-tier>=1024 tok, oom>=12 GB).
 [AppleSilicon-FP8/linear_fp8] F.linear FP8 operands decoded to compute dtype on MPS.
 [AppleSilicon-FP8/te_device] text_encoder_device redirected CPU->MPS on Apple Silicon (LLM/CLIP encoders run on GPU).
 [AppleSilicon-FP8/int_mm] torch._int_mm runs on GPU (float32) on MPS instead of falling back to CPU (INT8 models).
 [AppleSilicon-FP8/int8_linear] int8-fast wide-batch matmul routed via MPS native bf16 GEMM (was fp32 _int_mm).
 [AppleSilicon-FP8/int8_kernel] INT8 convrot Linear routed through bit-exact Metal kernel on MPS (clean W8A8; weight-only fp32 dequant/un-rotation bypassed).
+[AppleSilicon-FP8/conv] conv im2col+matmul2d active on MPS (ranks=[3], tile=384MB).
+[AppleSilicon-FP8/rope-fast] fused RoPE active on MPS (eager apply_rope/apply_rope_split_half rerouted; ...; comfy-retarget OFF).
 [AppleSilicon-FP8/mlx_textgen] TextGenerate routed through MLX on Apple Silicon (qwen3vl_4b -> mlx-community/Qwen3-VL-4B-Instruct-4bit; gemma3_12b -> mlx-community/gemma-3-12b-it-qat-abliterated-lm-4bit).
 ```
 
-> **Note:** The `mlx_textgen` line appears only when `mlx-vlm` is installed (`pip install 'comfyui-applesilicon-fp8[mlx]'` or `pip install mlx-vlm`); otherwise patch #14 silently no-ops. The `int8_kernel` line appears only with `ASFP8_INT8_EXT=1` and a working Metal toolchain + `ninja`; otherwise patch #17 silently no-ops and int8 stays on comfy's weight-only path.
+> **Note:** the first line is the capability probe — `tensor_ops(M5/Metal4)` and
+> `ninja` both `yes` is what unlocks the fp8/int8 matmul kernels (#3/#17/#20). The
+> `conv` / `fused-norm` / `rope-fast` lines appear wherever their tier is
+> supported (conv needs Metal 4; fused-norm and rope-fast need only
+> `compile_shader`). The `int8_kernel` / fp8-native lines appear on an M5 with the
+> toolchain + `ninja`; elsewhere those patches silently stay inert and int8 stays
+> on comfy's weight-only path. The `mlx_textgen` line appears only when `mlx-vlm`
+> is installed (`pip install 'comfyui-applesilicon-fp8[mlx]'`); otherwise patch #14
+> no-ops.
 
 ## Notes & caveats
 
@@ -197,32 +222,38 @@ At startup you'll see (only the lines relevant to your machine):
 - **comfy_kitchen / `_scaled_mm` / `cast_bias_weight` / `Tensor.to` FP8 patches**
   only act when FP8 is genuinely involved and MPS is in play; CUDA, CPU, and all
   non-FP8 tensors take an unchanged fast path. The decode is bit-exact.
-- **The default FP8 path is compatibility, not speed.** Out of the box (no opt-in
-  kernels), MPS has no real FP8 compute, so every FP8 path decodes to bf16 before
-  the matmul — you keep FP8's *storage* savings but pay a per-use decode and run at
-  bf16-equivalent speed. If you have the RAM, a bf16 checkpoint avoids the decode
-  tax and is usually faster. **The opt-in kernels change this** for fp8 and int8
-  specifically (see `ASFP8_FP8_EXT` / `ASFP8_INT8_EXT` below): they run the
-  quantized matmul natively on the matrix units and beat the bf16 baseline.
-- **fp8-native matmul is EXPERIMENTAL and opt-in (default OFF).** With
-  `ASFP8_FP8_EXT=1` and the Xcode/Metal toolchain installed, large fp8×fp8 matmuls on
-  the **`torch._scaled_mm` seam (patch #3)** — the path FLUX / SD3.5 / Krea2 `fp8_scaled`
-  checkpoints actually take (both operands fp8 + scales) — are routed through a JIT-built
-  Metal 4.1 `matmul2d` that reads fp8 operands directly (no bf16 materialization, fp32
-  accumulate), then applies scales in fp32: **bit-exact** vs the decode path, ~1.2–2.1×
-  faster across diffusion shapes. (An earlier `F.linear` seam, patch #15, was retired —
-  ComfyUI's fp8 checkpoints route through `_scaled_mm`, not `F.linear`, so it never fired.)
+- **The default FP8 path is compatibility; the native kernels add speed where the
+  hardware allows.** With no capable GPU, MPS has no real FP8 compute, so every FP8
+  path decodes to bf16 before the matmul — you keep FP8's *storage* savings but pay
+  a per-use decode and run at bf16-equivalent speed. If you have the RAM, a bf16
+  checkpoint avoids the decode tax and is usually faster. **The native kernels
+  change this** for fp8 and int8 (see `ASFP8_FP8_EXT` / `ASFP8_FP8_NATIVE` /
+  `ASFP8_INT8_EXT` below): on an M5 + Metal 4.1 + `ninja` they run the quantized
+  matmul natively on the matrix units and beat the bf16 baseline — and they're **on
+  by default**, gated on that capability probe, so they self-enable there and stay
+  inert everywhere else.
+- **fp8-native matmul (patch #3) is ON by default, gated on M5 + Metal 4.1 +
+  `ninja`.** Large fp8×fp8 matmuls on the **`torch._scaled_mm` seam** — the path
+  FLUX / SD3.5 / Krea2 `fp8_scaled` checkpoints actually take (both operands fp8 +
+  scales) — are routed through a JIT-built Metal 4.1 `matmul2d` that reads fp8
+  operands directly (no bf16 materialization, fp32 accumulate), then applies scales
+  in fp32: **bit-exact** vs the decode path, ~1.2–2.1× faster across diffusion
+  shapes. (An earlier `F.linear` seam, patch #15, was retired — ComfyUI's fp8
+  checkpoints route through `_scaled_mm`, not `F.linear`, so it never fired.)
 
-  It builds an ObjC++ extension on first use (needs the toolchain); any build/parity
-  failure falls back automatically to the decode path, so the node still works without
-  it. Metal 4.1 is a dev-beta language version, so treat this as experimental.
+  It builds an ObjC++ extension on first use (needs the toolchain + `ninja`); the
+  capability probe skips it entirely on unsupported machines, and any build/parity
+  failure falls back automatically to the decode path — so the node works
+  everywhere. Set `ASFP8_FP8_EXT=off` to force it off on a capable machine, or `=1`
+  to force a build attempt regardless of the probe.
 
   | Env var | Behaviour |
   |---|---|
-  | `ASFP8_FP8_EXT` = `1` | Enable the fp8-native kernel at the `_scaled_mm` seam (builds the Metal 4.1 extension on first eligible matmul). Default OFF. |
+  | `ASFP8_FP8_EXT` (default on where capable) | fp8-native kernel at the `_scaled_mm` seam. Unset → on iff M5 + Metal 4.1 + `ninja`; `off`/`0` → force off; `1`/`on` → force the build attempt. |
   | `ASFP8_FP8_EXT_MIN_DIM` (8192) | Route to the fp8 kernel only if `max(K, N)` (weight dims) ≥ this. |
-- **int8 W8A8 native matmul is EXPERIMENTAL and opt-in (default OFF), patch #17.**
-  With `ASFP8_INT8_EXT=1` (needs the Metal toolchain + `ninja`), int8 convrot
+  | `ASFP8_FP8_NATIVE` (default on where capable) | Same gating, for the fp8 `mixed_precision_ops` Linear seam (patch #20, min_dim ≥ 8192). `off` to disable. |
+- **int8 W8A8 native matmul (patch #17) is ON by default, gated on M5 + Metal 4.1
+  + `ninja`.** Where supported, int8 convrot
   Linears (e.g. **Krea2 convrot int8mixed**) run the W8A8 path the format intends:
   rotate the activation online, per-row quantize it, then a **bit-exact
   INT8×INT8→INT32 Metal kernel** (Metal 4 cooperative TensorOps, **M5+ only**),
@@ -237,12 +268,32 @@ At startup you'll see (only the lines relevant to your machine):
   [Cider](https://github.com/Mininglamp-AI/cider)** (Mininglamp, MIT) — its
   CUTLASS-style register-tiled `matmul2d` is what gets int8 past the fp16-class
   throughput ceiling a naive cooperative-tensor kernel hits. Builds an ObjC++
-  extension on first use; any build/parity failure (incl. pre-M5, no toolchain,
-  no `ninja`) falls back to comfy's weight-only int8 path automatically.
+  extension on first use; the capability probe skips it on unsupported machines,
+  and any build/parity failure (incl. pre-M5, no toolchain, no `ninja`) falls back
+  to comfy's weight-only int8 path automatically.
 
   | Env var | Behaviour |
   |---|---|
-  | `ASFP8_INT8_EXT` = `1` | Enable the int8 W8A8 Metal kernel for int8 convrot Linears (builds on first model load). Default OFF. |
+  | `ASFP8_INT8_EXT` (default on where capable) | int8 W8A8 Metal kernel for int8 convrot Linears. Unset → on iff M5 + Metal 4.1 + `ninja`; `off`/`0` → force off; `1`/`on` → force the build attempt. |
+- **fused RMSNorm (#18) and fused RoPE (#21) are ON by default on any MPS with
+  `compile_shader`** — no Metal 4.1 / M5 needed. Patch #18 fuses the DiT adaLN tail
+  (rmsnorm + `(1+scale)·x+shift` + residual) into one `compile_shader` pass and
+  supersedes patch #4's >2²¹-row fallback; patch #21 fuses `comfy_kitchen`'s
+  `apply_rope` / `apply_rope_split_half` into one kernel (~6–17×/call). Both fall
+  back per-call on any unsupported shape.
+
+  | Env var | Behaviour |
+  |---|---|
+  | `ASFP8_FUSED_NORM` (default on where capable) | Fused rmsnorm+modulation+residual kernel (#18). `off`/`0` → disable; `1` → force on. |
+  | `ASFP8_ROPE_FAST` (default on where capable) | Fused standalone RoPE kernel (#21). `off`/`0` → disable; `1` → force on. |
+  | `ASFP8_ROPE_COMFY_RETARGET` (default **off**) | **Opt-in** #21b: additionally retarget the real `comfy.ldm.flux` / `llama` rope on live models (higher-risk). `1`/`on` → enable. |
+- **conv im2col (#19) is ON by default for conv3d on M5 / Metal 4.1.** VAE / SeedVR2
+  conv3d runs as im2col + `matmul2d` on the tensor units (~2.7× vs stock).
+
+  | Env var | Behaviour |
+  |---|---|
+  | `ASFP8_CONV_IM2COL` (default `3d` where capable) | `off`/`0` → disable; `3d` (default) → conv3d only; `2d` / `2d,3d` / `1` → include conv2d. Unset + non-M5 → inert. |
+  | `ASFP8_CONV_TILE_MB` (384) | Cap the im2col patch buffer (MB) so large convs tile instead of OOMing. |
 - **WanVideo block swap is neutralized on MPS (patch #9).** Block swap exists to
   fit models into scarce NVIDIA VRAM; Apple Silicon memory is unified, so it saves
   nothing and its CUDA-event-synced streaming breaks on MPS. The patch makes the
@@ -275,11 +326,19 @@ At startup you'll see (only the lines relevant to your machine):
 
 First and foremost a "make it work on Mac" compatibility layer: it targets the
 specific gaps that block FP8 / INT8 diffusion models on MPS today. On top of that
-it adds a few **opt-in, bit-exact acceleration kernels** (fp8-native and int8
-W8A8) for the hot matmul seams — off by default, enabled per env var. It is not a
-general performance library. If a model hits a *different* unsupported op (e.g.
-some `nvfp4` / `mxfp8` compute paths), it may surface a new error — open an issue
-with the traceback.
+it adds **bit-exact acceleration kernels** (fp8-native, int8 W8A8, fused RMSNorm,
+fused RoPE, conv im2col) for the hot seams — **on by default, but gated by a
+startup capability probe** so each only activates on the hardware/software that
+can run it (and any env var above forces a patch on or off). It is not a general
+performance library. If a model hits a *different* unsupported op (e.g. some
+`nvfp4` / `mxfp8` compute paths), it may surface a new error — open an issue with
+the traceback.
+
+**Global switches** (debugging / overrides): `ASFP8_DISABLE=patch1,patch2` installs
+everything *except* the named patch modules; `ASFP8_ENABLE_ONLY=patch1,patch2`
+installs *only* those (bisection). Names are the module names in the startup log
+(e.g. `fused_norm_mps`, `rope_fast_mps`). Per-patch env vars (above) are the
+preferred way to toggle a single acceleration.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ speedup is gated on a startup capability probe (see the banner in
 | 19 | **VAE / SeedVR2 conv3d decode is slow (or OOMs non-tiled) on MPS** | Stock MPS `conv3d` doesn't use the tensor units and materialises large intermediates | **On by default where supported (M5 / Metal 4.1; `ASFP8_CONV_IM2COL=off` to disable):** run conv3d as im2col + `matmul2d` on the tensor units (~2.7× vs stock conv3d, ~31% faster SeedVR2), with the patch buffer capped at `ASFP8_CONV_TILE_MB`. conv2d stays off unless opted in (`=2d`/`=2d,3d`); falls back per-conv on any unsupported shape |
 | 20 | **FP8 `mixed_precision_ops` Linear decodes fp8→bf16 every step** (Ideogram-4-style eager fp8 checkpoints) | The weight is stored fp8 but each forward LUT-decodes it to bf16 before the matmul | **On by default where supported (M5 + Metal 4.1 + `ninja`; `ASFP8_FP8_NATIVE=off` to disable):** route wide fp8 Linears (min_dim ≥ 8192) through a native fp8-e4m3 `matmul2d` — half activation × fp8 weight on the tensor units — bypassing the per-step decode. Seam confirmed via a live Flux-2 probe; falls back per-call otherwise |
 | 21 | **Rotary position embedding is a chain of small MPS ops per attention block** | `apply_rope` / `apply_rope_split_half` do the interleave/rotate as several elementwise kernels | **On by default where supported (any MPS with `compile_shader`; `ASFP8_ROPE_FAST=off` to disable):** fuse `comfy_kitchen`'s `apply_rope` / `apply_rope_split_half` into **one** `compile_shader` kernel (~6–17×/call over eager; fp32 math, no Metal 4.1/M5). **#21b** additionally retargets the *real* `comfy.ldm.flux` / `llama` rope on live models — higher-risk, so **opt-in** via `ASFP8_ROPE_COMFY_RETARGET=1` |
+| 22 | **INT4 ConvRot models run ~2× slower than INT8 on MPS** (e.g. Krea2 int4 convrot — GitHub [#3](https://github.com/pawel-mazurkiewicz/ComfyUI-AppleSilicon-FP8/issues/3)) | comfy_kitchen's eager `convrot_w4a4` quantizes + packs the *activation* to int4, then unpacks **both** operands back to bf16 for a float GEMM — the int4 activation quant only ever fed a CUDA int4 MMA, so on MPS it's pure wasted work (measured **2.24× int8**) | On MPS, reroute ConvRot W4A4 Linears to a **W4A16 fast path** (default, `compile_shader`-free, comfy_kitchen-gated): skip the wasted activation quant, dequantize the packed int4 weight and run MPS's bf16 GEMM — faster *and* more accurate (15.8% vs 22.5% rel err). Brings int4 to **parity with int8** — see the caveat below: **int4's benefit is memory, not speed**. Opt-in W4A8 fused Metal kernel via `ASFP8_INT4_EXT=1` (M5 / Metal 4.1 + `ninja`) |
 
 ### How the FP8 trick works
 
@@ -182,6 +183,7 @@ your machine), then only the patch lines relevant to it:
 [AppleSilicon-FP8/int_mm] torch._int_mm runs on GPU (float32) on MPS instead of falling back to CPU (INT8 models).
 [AppleSilicon-FP8/int8_linear] int8-fast wide-batch matmul routed via MPS native bf16 GEMM (was fp32 _int_mm).
 [AppleSilicon-FP8/int8_kernel] INT8 convrot Linear routed through bit-exact Metal kernel on MPS (clean W8A8; weight-only fp32 dequant/un-rotation bypassed).
+[AppleSilicon-FP8/int4_linear] ConvRot W4A4 (int4) Linear on MPS -> W4A16 rotated-basis fast path.
 [AppleSilicon-FP8/conv] conv im2col+matmul2d active on MPS (ranks=[3], tile=384MB).
 [AppleSilicon-FP8/rope-fast] fused RoPE active on MPS (eager apply_rope/apply_rope_split_half rerouted; ...; comfy-retarget OFF).
 [AppleSilicon-FP8/mlx_textgen] TextGenerate routed through MLX on Apple Silicon (qwen3vl_4b -> mlx-community/Qwen3-VL-4B-Instruct-4bit; gemma3_12b -> mlx-community/gemma-3-12b-it-qat-abliterated-lm-4bit).
@@ -294,6 +296,27 @@ your machine), then only the patch lines relevant to it:
   |---|---|
   | `ASFP8_CONV_IM2COL` (default `3d` where capable) | `off`/`0` → disable; `3d` (default) → conv3d only; `2d` / `2d,3d` / `1` → include conv2d. Unset + non-M5 → inert. |
   | `ASFP8_CONV_TILE_MB` (384) | Cap the im2col patch buffer (MB) so large convs tile instead of OOMing. |
+- **INT4 ConvRot (patch #22) — set expectations: parity with INT8, and the win is
+  MEMORY, not speed.** This patch *fixes* the reported "int4 is ~2× slower than int8"
+  bug (GitHub #3) by skipping comfy_kitchen's wasted activation-int4 quant, but it
+  does **not** make int4 faster than int8. On M5 the int4 tensor dtype (`int4b`) has
+  **no cooperative-input matmul intrinsics** (verified in the Metal 4.1 headers), so
+  it's structurally capped at int8's throughput — measured **parity within ±3%** at
+  diffusion shapes, int4 edging ahead only as the token count grows. int4's real
+  benefit is **resident memory** (~6.5 GB vs ~12.3 GB for int8), at int8-parity
+  speed. The default path is a `compile_shader`-free W4A16 reroute (weight-only,
+  comfy_kitchen-gated, inert off-MPS / on older comfy_kitchen); the opt-in W4A8
+  fused Metal kernel adds nothing at compute-bound shapes and is off by default.
+
+  **Experimental / honest caveats:** the kernels are bit-exact vs a torch reference
+  in headless tests, but int4 has **not yet been visually validated on a full
+  render**, and there is a known **unresolved ~1.7× gap** between live-ComfyUI int4
+  and the headless harness at matching shapes that nobody has root-caused. Treat int4
+  as experimental; prefer int8 unless you specifically need the memory saving.
+
+  | Env var | Behaviour |
+  |---|---|
+  | `ASFP8_INT4_EXT` (default **off**) | Opt-in W4A8 fused int4 Metal kernel (M5 / Metal 4.1 + `ninja`). Off → the default W4A16 reroute handles int4. The default reroute itself has no switch (it's a compatibility path, like patch #13); disable everything int4 with `ASFP8_DISABLE=int4_linear_mps`. |
 - **WanVideo block swap is neutralized on MPS (patch #9).** Block swap exists to
   fit models into scarce NVIDIA VRAM; Apple Silicon memory is unified, so it saves
   nothing and its CUDA-event-synced streaming breaks on MPS. The patch makes the
@@ -326,10 +349,11 @@ your machine), then only the patch lines relevant to it:
 
 First and foremost a "make it work on Mac" compatibility layer: it targets the
 specific gaps that block FP8 / INT8 diffusion models on MPS today. On top of that
-it adds **bit-exact acceleration kernels** (fp8-native, int8 W8A8, fused RMSNorm,
-fused RoPE, conv im2col) for the hot seams — **on by default, but gated by a
-startup capability probe** so each only activates on the hardware/software that
-can run it (and any env var above forces a patch on or off). It is not a general
+it adds **bit-exact acceleration kernels** (fp8-native, int8 W8A8, int4 W4A16/W4A8,
+fused RMSNorm, fused RoPE, conv im2col) for the hot seams — **on by default, but
+gated by a startup capability probe** so each only activates on the hardware/software
+that can run it (and any env var above forces a patch on or off). (int4's heavy W4A8
+kernel is the exception — off by default; see the int4 caveat above.) It is not a general
 performance library. If a model hits a *different* unsupported op (e.g. some
 `nvfp4` / `mxfp8` compute paths), it may surface a new error — open an issue with
 the traceback.

--- a/__init__.py
+++ b/__init__.py
@@ -45,6 +45,10 @@ Patches applied:
                                                     Metal-4.1/M5 requirement)
  21b. fused RoPE retargeted onto real comfy funcs  (OPT-IN ASFP8_ROPE_COMFY_RETARGET=1: reroutes comfy.ldm.flux /
                                                     llama apply_rope on live models; higher-risk, off by default)
+ 22. INT4 ConvRot W4A16/W4A8 Linear on MPS          (DEFAULT reroute: skip comfy_kitchen's wasted activation-int4
+                                                    quant, run W4A16 bf16 GEMM — fixes "int4 ~2x slower than int8"
+                                                    (issue #3), brings PARITY with int8; int4's win is memory not
+                                                    speed. Opt-in W4A8 fused Metal kernel via ASFP8_INT4_EXT=1)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
  (#20 reserved for fp8-native matmul on a separate branch; ROPE uses #21 to avoid collision)
 

--- a/__init__.py
+++ b/__init__.py
@@ -26,9 +26,11 @@ Patches applied:
  13. int8-fast Linear via MPS bf16 GEMM           (INT8 wide-batch matmul was 3-5x too slow in fp32 _int_mm)
  14. MLX-backed TextGenerate on MPS (Qwen3-VL + Gemma3)  (Krea2 ~50s & LTX2 ~13h eager generate -> MLX)
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
- 17. INT8 W8A8 via bit-exact Metal kernel on MPS   (opt-in ASFP8_INT8_EXT=1: int8 matmul ~1.75x over bf16,
-                                                    bypasses per-step fp32 weight dequant/un-rotation; Cider-derived kernel)
- 18. fused RMSNorm+modulation+residual on MPS  (opt-in ASFP8_FUSED_NORM=1: one compile_shader pass
+ 17. INT8 W8A8 via bit-exact Metal kernel on MPS   (DEFAULT ON, gated on M5/Metal-4.1 + ninja; ASFP8_INT8_EXT=off
+                                                    to disable: int8 matmul ~1.75x over bf16, bypasses per-step
+                                                    fp32 weight dequant/un-rotation; Cider-derived kernel)
+ 18. fused RMSNorm+modulation+residual on MPS  (DEFAULT ON, gated on compile_shader; ASFP8_FUSED_NORM=off to disable:
+                                                   one compile_shader pass
                                                    for the DiT adaLN tail; fp32+64-bit indexing also
                                                    supersedes patch #4's >2^21-row correctness fallback)
  19. conv im2col+matmul2d on MPS (ASFP8_CONV_IM2COL, conv3d DEFAULT ON / =off to disable: VAE conv via
@@ -37,9 +39,12 @@ Patches applied:
                                                     disable: half act x fp8 e4m3 weight on tensor units;
                                                     bypasses per-step fp8->bf16 decode + _scaled_mm. Only
                                                     fires on min_dim>=8192 layers, so inert on Ideogram-4)
- 21. fused standalone RoPE on MPS                  (opt-in ASFP8_ROPE_FAST=1: comfy_kitchen apply_rope /
-                                                    apply_rope_split_half via ONE compile_shader kernel; ~6-17x/call
-                                                    over eager; fp32 math, no Metal-4.1/M5 requirement)
+ 21. fused standalone RoPE on MPS                  (DEFAULT ON, gated on compile_shader; ASFP8_ROPE_FAST=off to
+                                                    disable: comfy_kitchen apply_rope / apply_rope_split_half via ONE
+                                                    compile_shader kernel; ~6-17x/call over eager; fp32 math, no
+                                                    Metal-4.1/M5 requirement)
+ 21b. fused RoPE retargeted onto real comfy funcs  (OPT-IN ASFP8_ROPE_COMFY_RETARGET=1: reroutes comfy.ldm.flux /
+                                                    llama apply_rope on live models; higher-risk, off by default)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
  (#20 reserved for fp8-native matmul on a separate branch; ROPE uses #21 to avoid collision)
 
@@ -57,7 +62,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, probe_runtime, optrace, mps_profile, fused_norm_mps
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, int4_linear_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, probe_runtime, optrace, mps_profile, fused_norm_mps
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -67,9 +72,18 @@ if __spec__ is not None and __spec__.parent:
     _only = {n.strip() for n in _os.environ.get("ASFP8_ENABLE_ONLY", "").split(",") if n.strip()}
     _disabled = {n.strip() for n in _os.environ.get("ASFP8_DISABLE", "").split(",") if n.strip()}
 
+    # Every perf patch is now DEFAULT ON but gated on the hardware/software that can run
+    # it (see _patches/_caps.py). Print the detected capabilities once so users can see
+    # exactly which acceleration tier is active on their machine.
+    try:
+        from ._patches import _caps
+        print(f"[AppleSilicon-FP8] capabilities: {_caps.summary()}", flush=True)
+    except Exception as _e:
+        print(f"[AppleSilicon-FP8] capability probe failed: {_e}", flush=True)
+
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, rope_fast_mps, probe_runtime, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, int4_linear_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, rope_fast_mps, probe_runtime, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,9 @@ Patches applied:
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
  17. INT8 W8A8 via bit-exact Metal kernel on MPS   (opt-in ASFP8_INT8_EXT=1: int8 matmul ~1.75x over bf16,
                                                     bypasses per-step fp32 weight dequant/un-rotation; Cider-derived kernel)
+ 18. fused RMSNorm+modulation+residual on MPS  (opt-in ASFP8_FUSED_NORM=1: one compile_shader pass
+                                                   for the DiT adaLN tail; fp32+64-bit indexing also
+                                                   supersedes patch #4's >2^21-row correctness fallback)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
 
 See README.md for details. MIT licensed.
@@ -44,7 +47,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile, fused_norm_mps
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -56,7 +59,7 @@ if __spec__ is not None and __spec__.parent:
 
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,11 @@ Patches applied:
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
  17. INT8 W8A8 via bit-exact Metal kernel on MPS   (opt-in ASFP8_INT8_EXT=1: int8 matmul ~1.75x over bf16,
                                                     bypasses per-step fp32 weight dequant/un-rotation; Cider-derived kernel)
+ 21. fused standalone RoPE on MPS                  (opt-in ASFP8_ROPE_FAST=1: comfy_kitchen apply_rope /
+                                                    apply_rope_split_half via ONE compile_shader kernel; ~6-17x/call
+                                                    over eager; fp32 math, no Metal-4.1/M5 requirement)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
+ (#20 reserved for fp8-native matmul on a separate branch; ROPE uses #21 to avoid collision)
 
 See README.md for details. MIT licensed.
 """
@@ -44,7 +48,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, optrace, mps_profile
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -56,7 +60,7 @@ if __spec__ is not None and __spec__.parent:
 
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, rope_fast_mps, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -57,7 +57,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, optrace, mps_profile, fused_norm_mps
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, probe_runtime, optrace, mps_profile, fused_norm_mps
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -69,7 +69,7 @@ if __spec__ is not None and __spec__.parent:
 
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, rope_fast_mps, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, rope_fast_mps, probe_runtime, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -33,10 +33,10 @@ Patches applied:
                                                    supersedes patch #4's >2^21-row correctness fallback)
  19. conv im2col+matmul2d on MPS (ASFP8_CONV_IM2COL, conv3d DEFAULT ON / =off to disable: VAE conv via
                                                    tensor units, ~2.7x vs stock conv3d, A_tile capped at ASFP8_CONV_TILE_MB)
- 20. fp8-native Linear via Metal matmul2d on MPS  (opt-in ASFP8_FP8_NATIVE=1, DEFAULT OFF until the
-                                                    real-model seam probe passes: half act x fp8 e4m3
-                                                    weight on tensor units; bypasses per-step fp8->bf16
-                                                    weight decode + _scaled_mm)
+ 20. fp8-native Linear via Metal matmul2d on MPS  (DEFAULT ON, seam confirmed; ASFP8_FP8_NATIVE=off to
+                                                    disable: half act x fp8 e4m3 weight on tensor units;
+                                                    bypasses per-step fp8->bf16 decode + _scaled_mm. Only
+                                                    fires on min_dim>=8192 layers, so inert on Ideogram-4)
  21. fused standalone RoPE on MPS                  (opt-in ASFP8_ROPE_FAST=1: comfy_kitchen apply_rope /
                                                     apply_rope_split_half via ONE compile_shader kernel; ~6-17x/call
                                                     over eager; fp32 math, no Metal-4.1/M5 requirement)

--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,10 @@ Patches applied:
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
  17. INT8 W8A8 via bit-exact Metal kernel on MPS   (opt-in ASFP8_INT8_EXT=1: int8 matmul ~1.75x over bf16,
                                                     bypasses per-step fp32 weight dequant/un-rotation; Cider-derived kernel)
+ 20. fp8-native Linear via Metal matmul2d on MPS  (opt-in ASFP8_FP8_NATIVE=1, DEFAULT OFF until the
+                                                    real-model seam probe passes: half act x fp8 e4m3
+                                                    weight on tensor units; bypasses per-step fp8->bf16
+                                                    weight decode + _scaled_mm; ~3x headroom on Flux-2 linear)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
 
 See README.md for details. MIT licensed.
@@ -44,7 +48,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -56,7 +60,7 @@ if __spec__ is not None and __spec__.parent:
 
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,7 @@ Patches applied:
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
  17. INT8 W8A8 via bit-exact Metal kernel on MPS   (opt-in ASFP8_INT8_EXT=1: int8 matmul ~1.75x over bf16,
                                                     bypasses per-step fp32 weight dequant/un-rotation; Cider-derived kernel)
+ 18. conv im2col+matmul2d on MPS (opt-in ASFP8_CONV_IM2COL=1|2d|3d: VAE conv via tensor units, A_tile capped at ASFP8_CONV_TILE_MB)
  (#15 fp8-native F.linear retired — wrong seam; the fp8-native win is patch #3's opt-in _scaled_mm fast path)
 
 See README.md for details. MIT licensed.
@@ -44,7 +45,7 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, optrace, mps_profile
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -56,7 +57,7 @@ if __spec__ is not None and __spec__.parent:
 
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
-    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, mlx_textgen, optrace, mps_profile):
+    for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, optrace, mps_profile):
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/__init__.py
+++ b/__init__.py
@@ -62,7 +62,17 @@ if __spec__ is not None and __spec__.parent:
     # string and relative imports would fail.  Checking __spec__.parent is CPython-
     # guaranteed behaviour (see importlib docs) and avoids inspecting ImportError
     # message strings that are implementation details liable to change.
-    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, int4_linear_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, probe_runtime, optrace, mps_profile, fused_norm_mps
+    from ._patches import comfykitchen_fp8, linear_fp8, ops_bias_fp8, psutil_vmstat, rmsnorm_mps_large, scaled_mm_fp8, flash_attn_mtl, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, fp8_mps_strided, rope_fast_mps, probe_runtime, optrace, mps_profile, fused_norm_mps
+
+    # int4_linear_mps is an optional / in-progress patch that is not present in every
+    # checkout; import it defensively so a missing module never breaks the whole node at
+    # startup (ImportError would otherwise abort loading before any patch installs). It
+    # stays inert when absent and installs normally when the module is present.
+    try:
+        from ._patches import int4_linear_mps
+    except Exception as _e:
+        int4_linear_mps = None
+        print(f"[AppleSilicon-FP8] int4_linear_mps not present ({_e}); skipping.", flush=True)
 
     # Bisection switches (for debugging a regression to a single patch):
     #   ASFP8_ENABLE_ONLY=psutil_vmstat,comfykitchen_fp8   install ONLY these (by module name)
@@ -84,6 +94,8 @@ if __spec__ is not None and __spec__.parent:
     # optrace installs LAST (opt-in ASFP8_TRACE_OPS=1) so it sees every matmul the
     # model dispatches, on top of all the seams the other patches wrapped.
     for _patch in (psutil_vmstat, fp8_mps_strided, comfykitchen_fp8, scaled_mm_fp8, ops_bias_fp8, stochastic_round_fp8, tensor_to_fp8, wan_blockswap_mps, rmsnorm_mps_large, fused_norm_mps, flash_attn_mtl, linear_fp8, te_device_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps, int4_linear_mps, fp8_linear_kernel_mps, conv_im2col_mps, mlx_textgen, rope_fast_mps, probe_runtime, optrace, mps_profile):
+        if _patch is None:   # optional patch (e.g. int4_linear_mps) absent from this checkout
+            continue
         _short = _patch.__name__.rsplit(".", 1)[-1]
         if (_only and _short not in _only) or _short in _disabled:
             print(f"[AppleSilicon-FP8] skipping {_short} (ASFP8_ENABLE_ONLY/ASFP8_DISABLE)")

--- a/_patches/__init__.py
+++ b/_patches/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "int_mm_mps",           # patch #12 — torch._int_mm on GPU on MPS (INT8 models, no CPU fallback)
     "int8_linear_mps",      # patch #13 — int8-fast wide-batch Linear via MPS native bf16 GEMM
     "mlx_textgen",          # patch #14 — MLX-backed Qwen3-VL TextGenerate (prompt expansion)
+    "fused_norm_mps",       # patch #18 — fused rmsnorm+modulation+residual MPS kernel (opt-in)
     # patch #15 (fp8_linear_mps, opt-in fp8-native F.linear) RETIRED — wrong seam:
     #   real ComfyUI fp8 routes through torch._scaled_mm (QuantizedTensor hides the fp8
     #   dtype so the F.linear gate never fired), and weight-only fp8 only won at tiny M.

--- a/_patches/__init__.py
+++ b/_patches/__init__.py
@@ -18,10 +18,15 @@ __all__ = [
     "int_mm_mps",           # patch #12 — torch._int_mm on GPU on MPS (INT8 models, no CPU fallback)
     "int8_linear_mps",      # patch #13 — int8-fast wide-batch Linear via MPS native bf16 GEMM
     "mlx_textgen",          # patch #14 — MLX-backed Qwen3-VL TextGenerate (prompt expansion)
-    # patch #15 (fp8_linear_mps, opt-in fp8-native F.linear) RETIRED — wrong seam:
+    "fp8_linear_kernel_mps", # patch #20 — fp8 e4m3 Linear via native Metal matmul2d (opt-in ASFP8_FP8_NATIVE=1)
+    # patch #15 (fp8_linear_mps, opt-in fp8-native *F.linear*) RETIRED — wrong seam:
     #   real ComfyUI fp8 routes through torch._scaled_mm (QuantizedTensor hides the fp8
     #   dtype so the F.linear gate never fired), and weight-only fp8 only won at tiny M.
     #   The fp8-native win lives in patch #3's _scaled_mm fast path (ASFP8_FP8_EXT=1).
+    #   NOTE: patch #20 (fp8_linear_kernel_mps) is a *different, newer* seam — it wraps
+    #   mixed_precision_ops.Linear.forward (the same factory seam patch #17 uses for int8),
+    #   intercepting BEFORE the activation is fp8-quantized, so the F.linear-gate problem
+    #   that retired #15 does not apply. Default OFF until the real-model seam probe passes.
     # Internal helpers (not patches):
     # "_common"             — decode_fp8, fp8_to_float_lut, FP8_DTYPES
     # "na_gemm"             — optional NA matmul2d backend (not wired into hot path)

--- a/_patches/__init__.py
+++ b/_patches/__init__.py
@@ -18,8 +18,8 @@ __all__ = [
     "int_mm_mps",           # patch #12 — torch._int_mm on GPU on MPS (INT8 models, no CPU fallback)
     "int8_linear_mps",      # patch #13 — int8-fast wide-batch Linear via MPS native bf16 GEMM
     "mlx_textgen",          # patch #14 — MLX-backed Qwen3-VL TextGenerate (prompt expansion)
-    "fused_norm_mps",       # patch #18 — fused rmsnorm+modulation+residual MPS kernel (opt-in)
-    "fp8_linear_kernel_mps", # patch #20 — fp8 e4m3 Linear via native Metal matmul2d (opt-in ASFP8_FP8_NATIVE=1)
+    "fused_norm_mps",       # patch #18 — fused rmsnorm+modulation+residual MPS kernel (DEFAULT ON, compile_shader-gated)
+    "fp8_linear_kernel_mps", # patch #20 — fp8 e4m3 Linear via native Metal matmul2d (DEFAULT ON, Tier-B gated; ASFP8_FP8_NATIVE=off to disable)
     # patch #15 (fp8_linear_mps, opt-in fp8-native *F.linear*) RETIRED — wrong seam:
     #   real ComfyUI fp8 routes through torch._scaled_mm (QuantizedTensor hides the fp8
     #   dtype so the F.linear gate never fired), and weight-only fp8 only won at tiny M.
@@ -27,7 +27,8 @@ __all__ = [
     #   NOTE: patch #20 (fp8_linear_kernel_mps) is a *different, newer* seam — it wraps
     #   mixed_precision_ops.Linear.forward (the same factory seam patch #17 uses for int8),
     #   intercepting BEFORE the activation is fp8-quantized, so the F.linear-gate problem
-    #   that retired #15 does not apply. Default OFF until the real-model seam probe passes.
+    #   that retired #15 does not apply. DEFAULT ON (seam confirmed via a live Flux-2 probe),
+    #   gated on Tier B (M5/Metal-4.1 + ninja); ASFP8_FP8_NATIVE=off disables.
     # Internal helpers (not patches):
     # "_common"             — decode_fp8, fp8_to_float_lut, FP8_DTYPES
     # "na_gemm"             — optional NA matmul2d backend (not wired into hot path)

--- a/_patches/_caps.py
+++ b/_patches/_caps.py
@@ -1,0 +1,129 @@
+"""Hardware/software capability probes + a three-state env gate.
+
+The one place that decides, per patch, whether an acceleration installs by DEFAULT.
+The promise this module encodes: a performance patch is on by default ONLY on
+hardware/software that can actually run it; everywhere else it stays inert. An
+explicit env var always wins over the probe (power-user override), so nothing here
+can lock a user out or force a broken kernel on.
+
+Three states per gate (see `resolve`):
+  <VAR> unset          -> default_on AND the capability probe passes
+  <VAR> in OFF tokens  -> OFF   (force disable; probe skipped)
+  <VAR> in ON tokens   -> ON    (force enable; probe skipped — the patch's own
+                                  loader still no-ops if the kernel can't build)
+
+Capability tiers:
+  A  `torch.mps.compile_shader` present            -> fp32 compile_shader kernels
+     (has_compile_shader)                              (#18 fused-norm, #21 RoPE)
+  B  Metal-4 tensor-ops `matmul2d` compiles         -> M5 / Metal-4.1 matmul kernels
+     (has_tensor_ops_matmul2d, proven via na_gemm)     (#19 conv im2col)
+     ...plus `ninja` for the ObjC++ cpp_extensions  -> #3 fp8_ext, #17 int8_ext,
+     (tier_b_ready)                                     #20 fp8-native Linear
+"""
+
+import os
+import platform
+
+import torch
+
+# Token vocabularies for the three-state gate. Anything else is treated as "unset".
+ON_TOKENS = ("1", "on", "true", "yes", "enable", "enabled")
+OFF_TOKENS = ("0", "off", "false", "no", "disable", "disabled")
+
+
+def is_mps():
+    """True iff a usable MPS backend is present."""
+    mps = getattr(torch.backends, "mps", None)
+    return bool(mps is not None and mps.is_available())
+
+
+_compile_shader = None
+
+
+def has_compile_shader():
+    """Tier A: MPS + `torch.mps.compile_shader` (the fp32 kernels need nothing more)."""
+    global _compile_shader
+    if _compile_shader is None:
+        _compile_shader = bool(is_mps() and hasattr(torch.mps, "compile_shader"))
+    return _compile_shader
+
+
+_tensor_ops = None
+
+
+def has_tensor_ops_matmul2d():
+    """Tier B runtime probe: does `mpp::tensor_ops::matmul2d` compile on this
+    OS/SDK/PyTorch/GPU? True only on M5-class / Metal-4.1 stacks. Delegates to
+    na_gemm's proven-correct kernel (memoised there) so we don't carry a second,
+    drift-prone copy of the MPP shader source."""
+    global _tensor_ops
+    if _tensor_ops is None:
+        if not has_compile_shader():
+            _tensor_ops = False
+        else:
+            try:
+                from . import na_gemm
+                _tensor_ops = bool(na_gemm.available())
+            except Exception:
+                _tensor_ops = False
+    return _tensor_ops
+
+
+_ninja = None
+
+
+def ninja_available():
+    """True iff the `ninja` build tool is reachable — required by torch's
+    cpp_extension to build the ObjC++ Metal kernels (#3/#17/#20)."""
+    global _ninja
+    if _ninja is None:
+        import shutil
+        ok = shutil.which("ninja") is not None
+        if not ok:
+            try:
+                import importlib.util
+                ok = importlib.util.find_spec("ninja") is not None
+            except Exception:
+                ok = False
+        _ninja = bool(ok)
+    return _ninja
+
+
+def tier_b_ready():
+    """Metal-4 tensor ops present AND a build toolchain for the ObjC++ extensions."""
+    return has_tensor_ops_matmul2d() and ninja_available()
+
+
+def resolve(env_name, default_on, cap):
+    """Three-state gate. Returns True iff the patch should install.
+
+    `cap` is a zero-arg predicate evaluated ONLY when the env var is unset (or set
+    to something unrecognised) — so an explicit on/off never pays for a probe and a
+    forced-on value is honoured even where the probe would say no."""
+    v = os.environ.get(env_name)
+    if v is not None:
+        t = v.strip().lower()
+        if t in OFF_TOKENS:
+            return False
+        if t in ON_TOKENS:
+            return True
+        # Unrecognised value -> fall through to default + capability probe.
+    return bool(default_on and cap())
+
+
+def reset_cache():
+    """Test hook: forget memoised probe results so a test can re-probe."""
+    global _compile_shader, _tensor_ops, _ninja
+    _compile_shader = _tensor_ops = _ninja = None
+
+
+def summary():
+    """One-line capability banner for the startup log."""
+    return ", ".join((
+        f"macOS={platform.mac_ver()[0] or '?'}",
+        f"torch={torch.__version__}",
+        f"mps={'yes' if is_mps() else 'no'}",
+        f"compile_shader={'yes' if has_compile_shader() else 'no'}",
+        f"tensor_ops(M5/Metal4)={'yes' if has_tensor_ops_matmul2d() else 'no'}",
+        f"ninja={'yes' if ninja_available() else 'no'}",
+    ))

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -102,9 +102,37 @@ kernel void gemm_nt_bias(
 }
 """
 
-# combined per-dtype source is assembled in _lib(); im2col_3d is appended in B.6.
-# Keep _ALL_SRC as the list of source fragments.
-_ALL_SRC = [_IM2COL_2D_SRC, _GEMM_SRC]
+_IM2COL_3D_SRC = r"""
+#include <metal_stdlib>
+using namespace metal;
+kernel void im2col_3d(
+    device const @T@* X     [[buffer(0)]],
+    device @T@*       Atile [[buffer(1)]],
+    device const int* PRM   [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    const int Cin=PRM[1], D=PRM[2], H=PRM[3], W=PRM[4];
+    const int kd=PRM[5], kh=PRM[6], kw=PRM[7];
+    const int sD=PRM[8], sH=PRM[9], sW=PRM[10];
+    const int pD=PRM[11], pH=PRM[12], pW=PRM[13];
+    const int Dout=PRM[14], Hout=PRM[15], Wout=PRM[16];
+    const int K=PRM[17], p0=PRM[18], rows=PRM[19];
+    const uint total = uint(rows) * uint(K);
+    if (gid >= total) return;
+    const int r=int(gid)/K, kk=int(gid)%K, pix=p0+r;
+    const int ow=pix%Wout, oh=(pix/Wout)%Hout, od=(pix/(Wout*Hout))%Dout;
+    const int n=pix/(Wout*Hout*Dout);
+    const int kj=kk%kw, ki=(kk/kw)%kh, kt=(kk/(kw*kh))%kd, c=kk/(kd*kh*kw);
+    const int id_=od*sD+kt-pD, ih=oh*sH+ki-pH, iw=ow*sW+kj-pW;
+    @T@ v=@T@(0);
+    if (id_>=0 && id_<D && ih>=0 && ih<H && iw>=0 && iw<W)
+        v = X[((((ulong(n)*Cin + c)*D + id_)*H + ih)*W + iw)];
+    Atile[gid]=v;
+}
+"""
+
+# combined per-dtype source is assembled in _lib(). Keep _ALL_SRC as source fragments.
+_ALL_SRC = [_IM2COL_2D_SRC, _IM2COL_3D_SRC, _GEMM_SRC]
 
 
 def _src(dtype_key):
@@ -141,6 +169,24 @@ def _im2col_2d_tile(x, A_tile, kh, kw, s, p, Hout, Wout, p0, rows):
     total = rows * K
     threads, group = _grid1d(total)
     _lib(x.dtype).im2col_2d(x.contiguous(), A_tile, prm, threads=threads, group_size=group)
+
+
+def _out_dhw(D, H, W, kd, kh, kw, s, p):
+    Dout = (D + 2 * p[0] - kd) // s[0] + 1
+    Hout = (H + 2 * p[1] - kh) // s[1] + 1
+    Wout = (W + 2 * p[2] - kw) // s[2] + 1
+    return Dout, Hout, Wout
+
+
+def _im2col_3d_tile(x, A_tile, kd, kh, kw, s, p, Dout, Hout, Wout, p0, rows):
+    N, Cin, D, H, W = x.shape
+    K = Cin * kd * kh * kw
+    prm = torch.tensor([N, Cin, D, H, W, kd, kh, kw, s[0], s[1], s[2],
+                        p[0], p[1], p[2], Dout, Hout, Wout, K, p0, rows],
+                       dtype=torch.int32, device=x.device)
+    total = rows * K
+    threads, group = _grid1d(total)
+    _lib(x.dtype).im2col_3d(x.contiguous(), A_tile, prm, threads=threads, group_size=group)
 
 
 def _im2col_2d_full(x, kh, kw, s, p):
@@ -229,3 +275,26 @@ def _conv2d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
         _gemm_nt_bias(view, Wmat, bias, out=out_flat[p0:p0 + rows])
     # [P,Cout] -> [N,Hout,Wout,Cout] -> [N,Cout,Hout,Wout]
     return out_flat.reshape(N, Hout, Wout, Cout).permute(0, 3, 1, 2).contiguous()
+
+
+def _conv3d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
+    assert groups == 1 and weight.dim() == 5
+    s = (stride,) * 3 if isinstance(stride, int) else tuple(stride)
+    p = (padding,) * 3 if isinstance(padding, int) else tuple(padding)
+    dil = (dilation,) * 3 if isinstance(dilation, int) else tuple(dilation)
+    assert all(d == 1 for d in dil), "dilation!=1 not supported"
+    N, Cin, D, H, W = x.shape
+    Cout, _, kd, kh, kw = weight.shape
+    Dout, Hout, Wout = _out_dhw(D, H, W, kd, kh, kw, s, p)
+    P, K = N * Dout * Hout * Wout, Cin * kd * kh * kw
+    Wmat = weight.reshape(Cout, K).contiguous()
+    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
+    tile_p = max(1, min(P, _TILE_BYTES // (K * x.element_size())))
+    A_tile = torch.empty(tile_p, K, device=x.device, dtype=x.dtype)
+    for p0 in range(0, P, tile_p):
+        rows = min(tile_p, P - p0)
+        view = A_tile[:rows]
+        _im2col_3d_tile(x, view, kd, kh, kw, s, p, Dout, Hout, Wout, p0, rows)
+        _gemm_nt_bias(view, Wmat, bias, out=out_flat[p0:p0 + rows])
+    # [P,Cout] -> [N,Dout,Hout,Wout,Cout] -> [N,Cout,Dout,Hout,Wout]
+    return out_flat.reshape(N, Dout, Hout, Wout, Cout).permute(0, 4, 1, 2, 3).contiguous()

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -100,6 +100,53 @@ kernel void gemm_nt_bias(
         Cb[ulong(r)*N + c] = @T@(y);
     }
 }
+
+// gemm_nt_bias_scatter: like gemm_nt_bias but the store epilogue writes the result
+// DIRECTLY into channel-major OUT[N,Cout,(Dout,)Hout,Wout], removing the out_flat[P,Cout]
+// staging buffer + the .permute().contiguous() copy. Unifies 2D/3D: for 2D pass Dout=1.
+// PRM: [M, N, K, has_bias, p0, Cout, Dout, Hout, Wout]
+kernel void gemm_nt_bias_scatter(
+    device @T@*       A    [[buffer(0)]],
+    device @T@*       Bw   [[buffer(1)]],
+    device float*     BIAS [[buffer(2)]],
+    device @T@*       OUT  [[buffer(3)]],
+    device const int* PRM  [[buffer(4)]],
+    uint3 tgid [[threadgroup_position_in_grid]])
+{
+    const int M=PRM[0], N=PRM[1], K=PRM[2], has_bias=PRM[3];
+    const int p0=PRM[4], Cout=PRM[5], Dout=PRM[6], Hout=PRM[7], Wout=PRM[8];
+    const int m0=int(tgid.x)*BM, n0=int(tgid.y)*BN;
+    if (m0>=M || n0>=N) return;
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+    auto mA = tensor<device @T@, dextents<int,2>, tensor_inline>(
+                  A  + ulong(m0)*K, dextents<int,2>{K, min(BM, M-m0)}, array<int,2>{1, K});
+    auto mB = tensor<device @T@, dextents<int,2>, tensor_inline>(
+                  Bw + ulong(n0)*K, dextents<int,2>{K, min(BN, N-n0)}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, float>();
+    for (uint16_t i=0;i<cC.get_capacity();++i) if (cC.is_valid_element(i)) cC[i]=0.0f;
+    op.run(mA, mB, cC);
+    const int HW = Hout*Wout, DHW = Dout*HW;
+    for (uint16_t i=0;i<cC.get_capacity();++i){
+        if(!cC.is_valid_element(i)) continue;
+        auto idx=cC.get_multidimensional_index(i);
+        const int r=int(idx[1]), col=int(idx[0]);
+        if(m0+r>=M || n0+col>=N) continue;
+        const int pix = p0 + (m0 + r);
+        const int ow = pix % Wout;
+        const int oh = (pix / Wout) % Hout;
+        const int od = (pix / HW) % Dout;
+        const int n  = pix / DHW;
+        const int c  = n0 + col;
+        float y=cC[i];
+        if(has_bias) y += BIAS[c];
+        OUT[ ((((ulong(n)*Cout + c)*Dout + od)*Hout + oh)*Wout + ow) ] = @T@(y);
+    }
+}
 """
 
 _IM2COL_3D_SRC = r"""
@@ -221,6 +268,32 @@ def _gemm_nt_bias(A, Bw, bias, out=None):
     return out
 
 
+def _scatter_on():
+    # Fused channel-major scatter epilogue (drops out_flat + permute copy). Default on.
+    return os.environ.get("ASFP8_CONV_SCATTER", "1").lower() in ("1", "on", "true")
+
+
+def _gemm_nt_bias_scatter(A, Bw, bias, out, p0, Cout, Dout, Hout, Wout):
+    """OUT[N,Cout,(Dout,)Hout,Wout] += A[rows,K] @ Bw[Cout,K]^T + bias, scattered to the
+    channel-major destination by decoding pix=p0+(m0+r) -> (n,od,oh,ow). `out` is the final
+    channel-major tensor (no out_flat staging, no permute copy). For 2D pass Dout=1."""
+    M, K = A.shape
+    N = Bw.shape[0]
+    has_bias = 1 if bias is not None else 0
+    bias_buf = bias.float().contiguous() if bias is not None else torch.zeros(1, device=A.device)
+    prm = torch.tensor([M, N, K, has_bias, p0, Cout, Dout, Hout, Wout],
+                       dtype=torch.int32, device=A.device)
+    BM = BN = 64
+    NSG = 4
+    gx = (M + BM - 1) // BM
+    gy = (N + BN - 1) // BN
+    _lib(A.dtype).gemm_nt_bias_scatter(
+        A.contiguous(), Bw.contiguous(), bias_buf, out, prm,
+        threads=(gx * NSG * 32, gy, 1), group_size=(NSG * 32, 1, 1),
+    )
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Public conv driver (tiled) + fallback contract
 # ---------------------------------------------------------------------------
@@ -264,9 +337,18 @@ def _conv2d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
     Hout, Wout = _out_hw(H, W, kh, kw, s, p)   # dilation==1 guaranteed -> formula needs no dilation
     P, K = N * Hout * Wout, Cin * kh * kw
     Wmat = weight.reshape(Cout, K).contiguous()
-    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
     tile_p = max(1, min(P, _TILE_BYTES // (K * x.element_size())))
     A_tile = torch.empty(tile_p, K, device=x.device, dtype=x.dtype)
+    if _scatter_on():
+        # Fused channel-major scatter: allocate the final output ONCE, no out_flat / copy.
+        out = torch.empty(N, Cout, Hout, Wout, device=x.device, dtype=x.dtype)
+        for p0 in range(0, P, tile_p):
+            rows = min(tile_p, P - p0)
+            view = A_tile[:rows]
+            _im2col_2d_tile(x, view, kh, kw, s, p, Hout, Wout, p0, rows)
+            _gemm_nt_bias_scatter(view, Wmat, bias, out, p0, Cout, 1, Hout, Wout)
+        return out
+    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
     for p0 in range(0, P, tile_p):
         rows = min(tile_p, P - p0)
         view = A_tile[:rows]
@@ -288,9 +370,18 @@ def _conv3d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
     Dout, Hout, Wout = _out_dhw(D, H, W, kd, kh, kw, s, p)
     P, K = N * Dout * Hout * Wout, Cin * kd * kh * kw
     Wmat = weight.reshape(Cout, K).contiguous()
-    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
     tile_p = max(1, min(P, _TILE_BYTES // (K * x.element_size())))
     A_tile = torch.empty(tile_p, K, device=x.device, dtype=x.dtype)
+    if _scatter_on():
+        # Fused channel-major scatter: allocate the final output ONCE, no out_flat / copy.
+        out = torch.empty(N, Cout, Dout, Hout, Wout, device=x.device, dtype=x.dtype)
+        for p0 in range(0, P, tile_p):
+            rows = min(tile_p, P - p0)
+            view = A_tile[:rows]
+            _im2col_3d_tile(x, view, kd, kh, kw, s, p, Dout, Hout, Wout, p0, rows)
+            _gemm_nt_bias_scatter(view, Wmat, bias, out, p0, Cout, Dout, Hout, Wout)
+        return out
+    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
     for p0 in range(0, P, tile_p):
         rows = min(tile_p, P - p0)
         view = A_tile[:rows]

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -277,9 +277,11 @@ def _scatter_on():
 
 
 def _gemm_nt_bias_scatter(A, Bw, bias, out, p0, Cout, Dout, Hout, Wout):
-    """OUT[N,Cout,(Dout,)Hout,Wout] += A[rows,K] @ Bw[Cout,K]^T + bias, scattered to the
-    channel-major destination by decoding pix=p0+(m0+r) -> (n,od,oh,ow). `out` is the final
-    channel-major tensor (no out_flat staging, no permute copy). For 2D pass Dout=1."""
+    """OUT[N,Cout,(Dout,)Hout,Wout] = A[rows,K] @ Bw[Cout,K]^T + bias, scattered to the
+    channel-major destination by decoding pix=p0+(m0+r) -> (n,od,oh,ow). Each element is
+    STORED exactly once (assign, not accumulate) and every (m<M, n<Cout) is covered across
+    tiles, so `out` needs no pre-zeroing. `out` is the final channel-major tensor (no
+    out_flat staging, no permute copy). For 2D pass Dout=1."""
     M, K = A.shape
     N = Bw.shape[0]
     has_bias = 1 if bias is not None else 0

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -56,9 +56,52 @@ kernel void im2col_2d(
 }
 """
 
-# combined per-dtype source is assembled in _lib(); im2col_3d + gemm are appended in
-# later tasks. Keep _ALL_SRC as the list of source fragments.
-_ALL_SRC = [_IM2COL_2D_SRC]
+_GEMM_SRC = r"""
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal;
+using namespace mpp::tensor_ops;
+constant constexpr int BM = 64, BN = 64, NSG = 4;
+kernel void gemm_nt_bias(
+    device @T@*       A    [[buffer(0)]],
+    device @T@*       Bw   [[buffer(1)]],
+    device float*     BIAS [[buffer(2)]],
+    device @T@*       OUT  [[buffer(3)]],
+    device const int* PRM  [[buffer(4)]],
+    uint3 tgid [[threadgroup_position_in_grid]])
+{
+    const int M=PRM[0], N=PRM[1], K=PRM[2], has_bias=PRM[3];
+    const int m0=int(tgid.x)*BM, n0=int(tgid.y)*BN;
+    if (m0>=M || n0>=N) return;
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+    auto mA = tensor<device @T@, dextents<int,2>, tensor_inline>(
+                  A  + ulong(m0)*K, dextents<int,2>{K, min(BM, M-m0)}, array<int,2>{1, K});
+    auto mB = tensor<device @T@, dextents<int,2>, tensor_inline>(
+                  Bw + ulong(n0)*K, dextents<int,2>{K, min(BN, N-n0)}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, float>();
+    for (uint16_t i=0;i<cC.get_capacity();++i) if (cC.is_valid_element(i)) cC[i]=0.0f;
+    op.run(mA, mB, cC);
+    device @T@* Cb = OUT + ulong(m0)*N + n0;
+    for (uint16_t i=0;i<cC.get_capacity();++i){
+        if(!cC.is_valid_element(i)) continue;
+        auto idx=cC.get_multidimensional_index(i);
+        const int r=int(idx[1]), c=int(idx[0]);
+        if(m0+r>=M || n0+c>=N) continue;
+        float y=cC[i];
+        if(has_bias) y += BIAS[n0+c];
+        Cb[ulong(r)*N + c] = @T@(y);
+    }
+}
+"""
+
+# combined per-dtype source is assembled in _lib(); im2col_3d is appended in B.6.
+# Keep _ALL_SRC as the list of source fragments.
+_ALL_SRC = [_IM2COL_2D_SRC, _GEMM_SRC]
 
 
 def _src(dtype_key):
@@ -106,3 +149,24 @@ def _im2col_2d_full(x, kh, kw, s, p):
     A = torch.empty(P, K, device=x.device, dtype=x.dtype)
     _im2col_2d_tile(x, A, kh, kw, s, p, Hout, Wout, 0, P)
     return A
+
+
+def _gemm_nt_bias(A, Bw, bias, out=None):
+    """OUT[M,N] = A[M,K] @ Bw[N,K]^T + bias. Writes into `out` if given (a view into
+    out_flat[p0:p0+rows]); allocates only when out is None. No per-tile alloc/copy."""
+    M, K = A.shape
+    N = Bw.shape[0]
+    if out is None:
+        out = torch.empty(M, N, device=A.device, dtype=A.dtype)
+    has_bias = 1 if bias is not None else 0
+    bias_buf = bias.float().contiguous() if bias is not None else torch.zeros(1, device=A.device)
+    prm = torch.tensor([M, N, K, has_bias], dtype=torch.int32, device=A.device)
+    BM = BN = 64
+    NSG = 4
+    gx = (M + BM - 1) // BM
+    gy = (N + BN - 1) // BN
+    _lib(A.dtype).gemm_nt_bias(
+        A.contiguous(), Bw.contiguous(), bias_buf, out, prm,
+        threads=(gx * NSG * 32, gy, 1), group_size=(NSG * 32, 1, 1),
+    )
+    return out

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -16,8 +16,11 @@ three are exposed below.
 import os
 
 import torch
+import torch.nn.functional as F
 
 TAG = "[AppleSilicon-FP8/conv]"
+
+_TILE_BYTES = int(os.environ.get("ASFP8_CONV_TILE_MB", "384")) * 1024 * 1024
 
 # B.0 (dev/probe_matmul2d_dtype_scatter.py) recorded PASS for all three operand dtypes
 # with an fp32 cooperative-tensor accumulator (matching the handed-down G2 result).
@@ -170,3 +173,59 @@ def _gemm_nt_bias(A, Bw, bias, out=None):
         threads=(gx * NSG * 32, gy, 1), group_size=(NSG * 32, 1, 1),
     )
     return out
+
+
+# ---------------------------------------------------------------------------
+# Public conv driver (tiled) + fallback contract
+# ---------------------------------------------------------------------------
+
+def _supported(x, weight, dilation, groups, dtype):
+    dil = dilation if isinstance(dilation, tuple) else (dilation,)
+    return (x.device.type == "mps" and weight.device.type == "mps"
+            and dtype in _DT and groups == 1 and all(d == 1 for d in dil))
+
+
+def _fallback_conv(x, weight, bias, stride, padding, dilation, groups):
+    """Single named seam for the stock-conv fallback (monkeypatched by the spy test)."""
+    fn = F.conv2d if weight.dim() == 4 else F.conv3d
+    return fn(x, weight, bias, stride, padding, dilation, groups)
+
+
+def conv_im2col(x, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+    # Total + never-raising: unsupported -> stock conv. Safe for direct callers (BLOCKER).
+    rank = weight.dim() - 2          # 2 -> conv2d, 3 -> conv3d
+    if rank not in (2, 3) or not _supported(x, weight, dilation, groups, x.dtype):
+        return _fallback_conv(x, weight, bias, stride, padding, dilation, groups)
+    try:
+        if rank == 2:
+            return _conv2d_im2col_checked(x, weight, bias, stride, padding, dilation, groups)
+        return _conv3d_im2col_checked(x, weight, bias, stride, padding, dilation, groups)
+    except Exception as e:      # defense in depth: never raise into the caller
+        print(f"{TAG} conv{rank}d kernel error, falling back ({e!r})")
+        return _fallback_conv(x, weight, bias, stride, padding, dilation, groups)
+
+
+def _conv2d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
+    # re-validate before any output-size math; dilation!=1 / groups!=1 already excluded by
+    # _supported, but assert defensively so direct callers of the checked fn can't get wrong math.
+    assert groups == 1 and weight.dim() == 4
+    s = (stride, stride) if isinstance(stride, int) else tuple(stride)
+    p = (padding, padding) if isinstance(padding, int) else tuple(padding)
+    dil = (dilation, dilation) if isinstance(dilation, int) else tuple(dilation)
+    assert all(d == 1 for d in dil), "dilation!=1 not supported"
+    N, Cin, H, W = x.shape
+    Cout, _, kh, kw = weight.shape
+    Hout, Wout = _out_hw(H, W, kh, kw, s, p)   # dilation==1 guaranteed -> formula needs no dilation
+    P, K = N * Hout * Wout, Cin * kh * kw
+    Wmat = weight.reshape(Cout, K).contiguous()
+    out_flat = torch.empty(P, Cout, device=x.device, dtype=x.dtype)
+    tile_p = max(1, min(P, _TILE_BYTES // (K * x.element_size())))
+    A_tile = torch.empty(tile_p, K, device=x.device, dtype=x.dtype)
+    for p0 in range(0, P, tile_p):
+        rows = min(tile_p, P - p0)
+        view = A_tile[:rows]
+        _im2col_2d_tile(x, view, kh, kw, s, p, Hout, Wout, p0, rows)
+        # write GEMM result DIRECTLY into the out_flat slice (no per-tile alloc/copy):
+        _gemm_nt_bias(view, Wmat, bias, out=out_flat[p0:p0 + rows])
+    # [P,Cout] -> [N,Hout,Wout,Cout] -> [N,Cout,Hout,Wout]
+    return out_flat.reshape(N, Hout, Wout, Cout).permute(0, 3, 1, 2).contiguous()

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -23,7 +23,16 @@ import torch.nn.functional as F
 
 TAG = "[AppleSilicon-FP8/conv]"
 
-_TILE_BYTES = int(os.environ.get("ASFP8_CONV_TILE_MB", "384")) * 1024 * 1024
+def _tile_mb():
+    # Parsed at import time; a malformed value must NOT crash the whole node before the
+    # per-patch install guards run — fall back to the 384 MB default.
+    try:
+        return max(1, int(os.environ.get("ASFP8_CONV_TILE_MB", "384")))
+    except (TypeError, ValueError):
+        return 384
+
+
+_TILE_BYTES = _tile_mb() * 1024 * 1024
 
 # B.0 (dev/probe_matmul2d_dtype_scatter.py) recorded PASS for all three operand dtypes
 # with an fp32 cooperative-tensor accumulator (matching the handed-down G2 result).

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -426,7 +426,17 @@ def _mode():
 
 
 def _gate():
-    return _mode() not in _CONV_OFF
+    mode = _mode()
+    if mode in _CONV_OFF:
+        return False
+    # When the user hasn't explicitly set ASFP8_CONV_IM2COL, only default-on where the
+    # Metal-4 tensor-ops matmul2d kernel actually compiles (M5 / Metal 4.1). An explicit
+    # 3d/2d/1 still forces it on (the wrapper falls back per-call if a conv can't run).
+    if os.environ.get("ASFP8_CONV_IM2COL") is None:
+        from . import _caps
+        if not _caps.has_tensor_ops_matmul2d():
+            return False
+    return True
 
 
 def _wanted_ranks():

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -301,12 +301,21 @@ def _gemm_nt_bias_scatter(A, Bw, bias, out, p0, Cout, Dout, Hout, Wout):
 def _supported(x, weight, dilation, groups, dtype):
     dil = dilation if isinstance(dilation, tuple) else (dilation,)
     return (x.device.type == "mps" and weight.device.type == "mps"
-            and dtype in _DT and groups == 1 and all(d == 1 for d in dil))
+            and dtype in _DT and weight.dtype == dtype
+            and groups == 1 and all(d == 1 for d in dil))
 
 
 def _fallback_conv(x, weight, bias, stride, padding, dilation, groups):
-    """Single named seam for the stock-conv fallback (monkeypatched by the spy test)."""
-    fn = F.conv2d if weight.dim() == 4 else F.conv3d
+    """Single named seam for the stock-conv fallback (monkeypatched by the spy test).
+
+    MUST call the captured true originals (_orig_conv2d/_orig_conv3d) when install() has
+    replaced F.conv2d/F.conv3d with our wrappers -- otherwise the fallback re-enters the
+    wrapper -> conv_im2col -> (kernel raises) -> _fallback_conv -> wrapper -> ... infinite
+    recursion, breaking the "never fatal" contract. Pre-install, F.conv2d IS the original."""
+    if weight.dim() == 4:
+        fn = _orig_conv2d if _orig_conv2d is not None else F.conv2d
+    else:
+        fn = _orig_conv3d if _orig_conv3d is not None else F.conv3d
     return fn(x, weight, bias, stride, padding, dilation, groups)
 
 

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -1,4 +1,4 @@
-"""Patch #18 (opt-in): VAE conv on MPS via tiled im2col + matmul2d tensor-op GEMM.
+"""Patch #18: VAE conv on MPS via tiled im2col + matmul2d tensor-op GEMM (conv3d default-ON).
 
 Routes conv2d/conv3d through `im2col_2d/3d` gather -> NT `matmul2d` GEMM (half/bf16/fp32
 operands, fp32 cooperative-tensor accumulate) + fused bias, looping over output-pixel
@@ -6,8 +6,11 @@ tiles so the lowered patch buffer (`A_tile`) is capped (default 384 MB). Targets
 Session-15 SeedVR2 non-tiled conv3d decode OOM. Authored with torch.mps.compile_shader
 (pure-Python authoring path, no .mm/xcrun/ninja build step).
 
-Gating: no-op unless ASFP8_CONV_IM2COL is set (1|on|true => both ranks; 2d / 3d => that
-rank only). Never fatal: any compile/kernel failure falls back to stock F.conv2d/conv3d.
+Gating: conv3d is ON by default (im2col is ~2.7x faster than stock MPS conv3d and ~31%
+faster end-to-end on SeedVR2 — measured on M5/Metal 4.1). conv2d stays OFF by default
+(stock conv2d is already at-roofline; im2col loses there). Kill switch: ASFP8_CONV_IM2COL=off.
+Opt conv2d in with =2d or =2d,3d (=1|on|true => both ranks). Build is M5/Metal-4.1 gated and
+never fatal: any compile/kernel/shape failure falls back to stock F.conv2d/conv3d.
 
 B.0 probe (M5 Max / macOS 27 / PyTorch 2.11 / Metal 4.1) confirmed the <T,T,float>
 cooperative-accumulate matmul2d compiles+runs+CORRECT for half, bfloat AND float, so all
@@ -411,24 +414,31 @@ _orig_conv2d = None
 _orig_conv3d = None
 
 
+_CONV_OFF = ("off", "0", "false", "none", "no")
+_CONV_BOTH = ("1", "on", "true", "all", "both", "2d,3d", "3d,2d")
+
+
 def _mode():
-    # "1"/"on"/"true" => both; "2d"/"3d" => that rank
-    return os.environ.get("ASFP8_CONV_IM2COL", "").lower()
+    # DEFAULT-ON for conv3d (measured ~2.7x vs stock MPS conv3d, ~31% faster SeedVR2).
+    # conv2d stays OFF by default (stock conv2d is at-roofline; im2col loses there).
+    # Kill switch: ASFP8_CONV_IM2COL=off. Opt conv2d in with =2d / =2d,3d (=1|on|true => both).
+    return os.environ.get("ASFP8_CONV_IM2COL", "3d").strip().lower()
 
 
 def _gate():
-    return _mode() in ("1", "on", "true", "2d", "3d")
+    return _mode() not in _CONV_OFF
 
 
 def _wanted_ranks():
     m = _mode()
-    if m in ("1", "on", "true"):
+    if m in _CONV_OFF:
+        return set()
+    if m in _CONV_BOTH:
         return {2, 3}
     if m == "2d":
         return {2}
-    if m == "3d":
-        return {3}
-    return set()
+    # "3d", the default, and any unrecognized value -> conv3d only (the proven default win)
+    return {3}
 
 
 def _make_wrap(orig, rank):

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -298,3 +298,66 @@ def _conv3d_im2col_checked(x, weight, bias, stride, padding, dilation, groups):
         _gemm_nt_bias(view, Wmat, bias, out=out_flat[p0:p0 + rows])
     # [P,Cout] -> [N,Dout,Hout,Wout,Cout] -> [N,Cout,Dout,Hout,Wout]
     return out_flat.reshape(N, Dout, Hout, Wout, Cout).permute(0, 4, 1, 2, 3).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Guarded install (never fatal). Mirrors flash_attn_mtl.py.
+# ---------------------------------------------------------------------------
+
+# Track which ranks are installed, NOT a single bool -- so a later =3d after a =2d
+# in the same process can still install conv3d (idempotence-per-mode).
+_installed_ranks = set()   # subset of {2, 3}
+_orig_conv2d = None
+_orig_conv3d = None
+
+
+def _mode():
+    # "1"/"on"/"true" => both; "2d"/"3d" => that rank
+    return os.environ.get("ASFP8_CONV_IM2COL", "").lower()
+
+
+def _gate():
+    return _mode() in ("1", "on", "true", "2d", "3d")
+
+
+def _wanted_ranks():
+    m = _mode()
+    if m in ("1", "on", "true"):
+        return {2, 3}
+    if m == "2d":
+        return {2}
+    if m == "3d":
+        return {3}
+    return set()
+
+
+def _make_wrap(orig, rank):
+    """Module-level so fallback tests can build the wrapper closure without MPS/install()."""
+    def conv(x, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        try:
+            if weight.dim() - 2 == rank and _supported(x, weight, dilation, groups, x.dtype):
+                return conv_im2col(x, weight, bias, stride, padding, dilation, groups)
+        except Exception as e:
+            print(f"{TAG} conv{rank}d fell back ({e!r})")
+        return orig(x, weight, bias, stride, padding, dilation, groups)
+    return conv
+
+
+def install():
+    global _orig_conv2d, _orig_conv3d
+    import sys
+    if sys.platform != "darwin" or not _gate():
+        return
+    if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+        return
+    if _orig_conv2d is None:
+        _orig_conv2d, _orig_conv3d = F.conv2d, F.conv3d   # capture true originals once
+    want = _wanted_ranks()
+    if 2 in want and 2 not in _installed_ranks:
+        F.conv2d = _make_wrap(_orig_conv2d, 2)
+        _installed_ranks.add(2)
+    if 3 in want and 3 not in _installed_ranks:
+        F.conv3d = _make_wrap(_orig_conv3d, 3)
+        _installed_ranks.add(3)
+    print(f"{TAG} conv im2col+matmul2d active on MPS (ranks={sorted(_installed_ranks)}, "
+          f"tile={_TILE_BYTES // 1024**2}MB).")

--- a/_patches/conv_im2col_mps.py
+++ b/_patches/conv_im2col_mps.py
@@ -1,0 +1,108 @@
+"""Patch #18 (opt-in): VAE conv on MPS via tiled im2col + matmul2d tensor-op GEMM.
+
+Routes conv2d/conv3d through `im2col_2d/3d` gather -> NT `matmul2d` GEMM (half/bf16/fp32
+operands, fp32 cooperative-tensor accumulate) + fused bias, looping over output-pixel
+tiles so the lowered patch buffer (`A_tile`) is capped (default 384 MB). Targets the
+Session-15 SeedVR2 non-tiled conv3d decode OOM. Authored with torch.mps.compile_shader
+(pure-Python authoring path, no .mm/xcrun/ninja build step).
+
+Gating: no-op unless ASFP8_CONV_IM2COL is set (1|on|true => both ranks; 2d / 3d => that
+rank only). Never fatal: any compile/kernel failure falls back to stock F.conv2d/conv3d.
+
+B.0 probe (M5 Max / macOS 27 / PyTorch 2.11 / Metal 4.1) confirmed the <T,T,float>
+cooperative-accumulate matmul2d compiles+runs+CORRECT for half, bfloat AND float, so all
+three are exposed below.
+"""
+import os
+
+import torch
+
+TAG = "[AppleSilicon-FP8/conv]"
+
+# B.0 (dev/probe_matmul2d_dtype_scatter.py) recorded PASS for all three operand dtypes
+# with an fp32 cooperative-tensor accumulator (matching the handed-down G2 result).
+_DT = {
+    torch.float16: "half",
+    torch.bfloat16: "bfloat",
+    torch.float32: "float",
+}
+
+# ---------------------------------------------------------------------------
+# Metal sources
+# ---------------------------------------------------------------------------
+
+_IM2COL_2D_SRC = r"""
+#include <metal_stdlib>
+using namespace metal;
+kernel void im2col_2d(
+    device const @T@* X     [[buffer(0)]],
+    device @T@*       Atile [[buffer(1)]],
+    device const int* PRM   [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    const int Cin=PRM[1], H=PRM[2], W=PRM[3], kh=PRM[4], kw=PRM[5];
+    const int sH=PRM[6], sW=PRM[7], pH=PRM[8], pW=PRM[9];
+    const int Hout=PRM[10], Wout=PRM[11], K=PRM[12], p0=PRM[13], rows=PRM[14];
+    const uint total = uint(rows) * uint(K);
+    if (gid >= total) return;
+    const int r=int(gid)/K, kk=int(gid)%K, pix=p0+r;
+    const int ow=pix%Wout, oh=(pix/Wout)%Hout, n=pix/(Wout*Hout);
+    const int kj=kk%kw, ki=(kk/kw)%kh, c=kk/(kh*kw);
+    const int ih=oh*sH+ki-pH, iw=ow*sW+kj-pW;
+    @T@ v=@T@(0);
+    if (ih>=0 && ih<H && iw>=0 && iw<W)
+        v = X[(((ulong(n)*Cin + c)*H + ih)*W + iw)];
+    Atile[gid]=v;
+}
+"""
+
+# combined per-dtype source is assembled in _lib(); im2col_3d + gemm are appended in
+# later tasks. Keep _ALL_SRC as the list of source fragments.
+_ALL_SRC = [_IM2COL_2D_SRC]
+
+
+def _src(dtype_key):
+    return "\n".join(_ALL_SRC).replace("@T@", dtype_key)
+
+
+_libs = {}  # dtype-key -> compiled lib
+
+
+def _lib(dtype):
+    key = _DT[dtype]
+    lib = _libs.get(key)
+    if lib is None:
+        lib = torch.mps.compile_shader(_src(key))
+        _libs[key] = lib
+    return lib
+
+
+def _grid1d(total, tg=256):
+    return (((total + tg - 1) // tg) * tg, 1, 1), (tg, 1, 1)
+
+
+def _out_hw(H, W, kh, kw, s, p):
+    Hout = (H + 2 * p[0] - kh) // s[0] + 1
+    Wout = (W + 2 * p[1] - kw) // s[1] + 1
+    return Hout, Wout
+
+
+def _im2col_2d_tile(x, A_tile, kh, kw, s, p, Hout, Wout, p0, rows):
+    N, Cin, H, W = x.shape
+    K = Cin * kh * kw
+    prm = torch.tensor([N, Cin, H, W, kh, kw, s[0], s[1], p[0], p[1],
+                        Hout, Wout, K, p0, rows], dtype=torch.int32, device=x.device)
+    total = rows * K
+    threads, group = _grid1d(total)
+    _lib(x.dtype).im2col_2d(x.contiguous(), A_tile, prm, threads=threads, group_size=group)
+
+
+def _im2col_2d_full(x, kh, kw, s, p):
+    s = (s, s) if isinstance(s, int) else tuple(s)
+    p = (p, p) if isinstance(p, int) else tuple(p)
+    N, Cin, H, W = x.shape
+    Hout, Wout = _out_hw(H, W, kh, kw, s, p)
+    P, K = N * Hout * Wout, Cin * kh * kw
+    A = torch.empty(P, K, device=x.device, dtype=x.dtype)
+    _im2col_2d_tile(x, A, kh, kw, s, p, Hout, Wout, 0, P)
+    return A

--- a/_patches/fp8_ext/loader.py
+++ b/_patches/fp8_ext/loader.py
@@ -1,7 +1,9 @@
-"""JIT loader for the fp8-native matmul2d MPS extension (patch #15 backend).
+"""JIT loader for the fp8-native matmul2d MPS extension.
 
-Builds _patches/fp8_ext/fp8_matmul2d.mm via torch.utils.cpp_extension.load (ObjC++,
-Metal 4.1). Opt-in (ASFP8_FP8_EXT=1), guarded, cached; returns None on any failure so
+Backs patch #3's _scaled_mm fast path (ASFP8_FP8_EXT=1) and patch #20's fp8-native
+Linear wrapper (ASFP8_FP8_NATIVE=1). Builds _patches/fp8_ext/fp8_matmul2d.mm via
+torch.utils.cpp_extension.load (ObjC++, Metal 4.1). Opt-in (builds when EITHER
+ASFP8_FP8_EXT=1 OR ASFP8_FP8_NATIVE=1), guarded, cached; returns None on any failure so
 the caller falls back to the decode path.
 
 Space-in-path workaround: cpp_extension emits the torch lib `-L` UNQUOTED, so a space
@@ -42,7 +44,7 @@ def module():
         return _mod
     _tried = True
 
-    if os.environ.get("ASFP8_FP8_EXT") != "1":
+    if os.environ.get("ASFP8_FP8_EXT") != "1" and os.environ.get("ASFP8_FP8_NATIVE") != "1":
         return None
     if shutil.which("xcrun") is None:
         print("[fp8_ext] no Metal toolchain (xcrun); fp8-native disabled.")

--- a/_patches/fp8_ext/loader.py
+++ b/_patches/fp8_ext/loader.py
@@ -1,10 +1,11 @@
 """JIT loader for the fp8-native matmul2d MPS extension.
 
-Backs patch #3's _scaled_mm fast path (ASFP8_FP8_EXT=1) and patch #20's fp8-native
-Linear wrapper (ASFP8_FP8_NATIVE=1). Builds _patches/fp8_ext/fp8_matmul2d.mm via
-torch.utils.cpp_extension.load (ObjC++, Metal 4.1). Opt-in (builds when EITHER
-ASFP8_FP8_EXT=1 OR ASFP8_FP8_NATIVE=1), guarded, cached; returns None on any failure so
-the caller falls back to the decode path.
+Backs patch #3's _scaled_mm fast path (ASFP8_FP8_EXT) and patch #20's fp8-native
+Linear wrapper (ASFP8_FP8_NATIVE). Builds _patches/fp8_ext/fp8_matmul2d.mm via
+torch.utils.cpp_extension.load (ObjC++, Metal 4.1). DEFAULT ON where capable —
+builds when EITHER seam resolves on via the shared three-state gate (Tier B: M5 /
+Metal 4.1 + ninja); guarded, cached; returns None on any failure so the caller
+falls back to the decode path.
 
 Space-in-path workaround: cpp_extension emits the torch lib `-L` UNQUOTED, so a space
 in torch's install path (e.g. ".../IMPERIAL SPACE/...") breaks the link. We point the
@@ -44,11 +45,37 @@ def module():
         return _mod
     _tried = True
 
-    if os.environ.get("ASFP8_FP8_EXT") != "1" and os.environ.get("ASFP8_FP8_NATIVE") != "1":
+    # DEFAULT ON where capable: build when EITHER seam wants it. Each flag resolves
+    # via the shared three-state gate (unset -> on iff Tier B; off -> off; 1 -> force).
+    # The callers (#3 _fast_eligible, #20 install) independently decide whether to USE
+    # the built module; this only decides whether to attempt the (cached) build.
+    from .. import _caps
+    if not (_caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.tier_b_ready) or
+            _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.tier_b_ready)):
         return None
     if shutil.which("xcrun") is None:
         print("[fp8_ext] no Metal toolchain (xcrun); fp8-native disabled.")
         return None
+
+    # torch's cpp_extension needs the `ninja` *binary* on PATH (not just the python
+    # module). ComfyUI-Desktop often launches with a PATH that lacks homebrew/venv
+    # bins, so add the ninja package's bundled binary dir (mirrors int8_ext/loader).
+    if shutil.which("ninja") is None:
+        try:
+            import ninja  # provides a bundled `ninja` executable
+            bin_dir = getattr(ninja, "BIN_DIR", None) or os.path.join(
+                os.path.dirname(ninja.__file__), "data", "bin"
+            )
+            if os.path.isdir(bin_dir):
+                os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+        except Exception as e:
+            print(f"[fp8_ext] ninja not importable ({e!r}); fp8-native disabled.")
+            return None
+    if shutil.which("ninja") is None:
+        print("[fp8_ext] ninja binary not found on PATH; fp8-native disabled "
+              "(pip install ninja into the ComfyUI venv).")
+        return None
+
     try:
         import torch.utils.cpp_extension as cpp
         from torch.utils.cpp_extension import load as cpp_load

--- a/_patches/fp8_linear_kernel_mps.py
+++ b/_patches/fp8_linear_kernel_mps.py
@@ -1,0 +1,225 @@
+"""Patch #20: route fp8 (e4m3) weight nn.Linear through the native fp8 Metal kernel on MPS.
+
+Flux-2 fp8 currently runs LUT-decode(weight fp8->bf16) -> torch._scaled_mm/bf16 GEMM
+(~5.5 s/step), and the activation is force-quantized bf16->fp8 upstream. This patch
+intercepts the mixed_precision_ops Linear.forward BEFORE the activation is fp8-quantized,
+feeds the RAW bf16 activation (cast to half) + the still-fp8 weight bytes into the
+existing gemm_fp8_nt kernel (fp8_matmul2d_nt: half[M,K] x W[N,K] fp8 -> f32), applies the
+weight scale (scalar OR per-channel [N]) + bias in fp32, returns bf16. Semantically this
+is `input.float() @ dequant_fp8(weight).t() * scale (+bias)` -- CLOSER to unquantized-act x
+dequantized-fp8-weight than the current lossy path (a semantic change, not equivalence).
+
+Opt-in: ASFP8_FP8_NATIVE=1, DEFAULT OFF. Never-fatal: any miss falls back to comfy's
+original forward. The real-model seam/scale/range are gated on Task -1 (see plan).
+"""
+import os
+import sys
+
+import torch
+
+TAG = "[AppleSilicon-FP8/fp8_kernel]"
+
+_installed = False
+_kernel = None
+_self_checked = False
+_self_ok = True
+_MIN_DIM_DEFAULT = 8192
+
+
+def _env_int(name, default):
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _min_dim():
+    return _env_int("ASFP8_FP8_NATIVE_MIN_DIM", _MIN_DIM_DEFAULT)
+
+
+def _range_guard_on():
+    return os.environ.get("ASFP8_FP8_NATIVE_RANGE_GUARD") == "1"
+
+
+def _load_kernel():
+    try:
+        from .fp8_ext import loader
+    except Exception as e:  # pragma: no cover
+        print(f"{TAG} loader import failed: {e!r}")
+        return None
+    mod = loader.module()
+    if mod is not None:
+        try:
+            mod.warmup()
+        except Exception as e:
+            print(f"{TAG} warmup failed; disabling: {e!r}")
+            return None
+    return mod
+
+
+def _self_check():
+    """One-time parity gate: native half x fp8 == decoded-fp32 within 5e-2, else disable.
+    MUST be called only AFTER a layer passes every eligibility/shape/scale gate."""
+    global _self_checked, _self_ok
+    if _self_checked:
+        return _self_ok
+    _self_checked = True
+    try:
+        from ._common import decode_fp8
+        d = _env_int("ASFP8_FP8_NATIVE_SELFCHECK_DIM", 8192)  # K=N; M fixed small
+        M = 32
+        g = torch.Generator().manual_seed(0)
+        a = (torch.randn(M, d, generator=g) * 0.3).to(torch.bfloat16)
+        w = (torch.randn(d, d, generator=g) * 0.3).to(torch.float8_e4m3fn)  # [N,K]
+        ref = (a.float() @ decode_fp8(w.to("mps"), torch.float32).cpu().t()).to("mps")
+        native = _kernel.fp8_matmul2d_nt(
+            a.to("mps").to(torch.float16).contiguous(),
+            w.to("mps").contiguous().view(torch.uint8), d)
+        rel = ((native - ref).abs().max() / (ref.abs().max() + 1e-9)).item()
+        _self_ok = rel < 5e-2
+        if not _self_ok:
+            print(f"{TAG} self-check failed (rel={rel:.4f}); using LUT path.")
+    except Exception as e:
+        _self_ok = False
+        print(f"{TAG} self-check raised; using LUT path: {e!r}")
+    return _self_ok
+
+
+def _fp8_linear_kernel(input, qdata, scale_weight, bias):
+    """half(input) x fp8 weight bytes -> f32, * scale (scalar or [N]), + bias, -> input.dtype.
+    Callers MUST have validated shapes/dtype/scale via _try_fp8_kernel_forward first."""
+    orig_shape = input.shape
+    N = int(qdata.shape[0])
+    x2 = input.reshape(-1, input.shape[-1])
+    a_half = x2.to(torch.float16).contiguous()
+    w_u8 = qdata.contiguous().view(torch.uint8)
+    out = _kernel.fp8_matmul2d_nt(a_half, w_u8, N)            # [M,N] f32
+    scale_f = scale_weight.to(device=out.device, dtype=torch.float32)
+    n_scale = scale_f.numel()
+    if n_scale == 1:
+        out = out * scale_f.reshape(())                       # tensorwise dequant
+    elif n_scale == N:
+        out = out * scale_f.reshape(1, N)                     # per-channel dequant
+    else:
+        raise ValueError(f"unexpected weight scale numel={n_scale} (N={N})")
+    if bias is not None:
+        out = out + bias.to(torch.float32)
+    return out.to(input.dtype).reshape(*orig_shape[:-1], N)
+
+
+def _try_fp8_kernel_forward(self, input):
+    if _kernel is None:
+        return None
+    try:
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        # --- cheap rejects first (so non-fp8 / int8 / plain layers fall through fast) ---
+        if not isinstance(input, torch.Tensor) or input.device.type != "mps":
+            return None
+        if isinstance(input, QuantizedTensor):
+            return None
+        if input.dtype not in (torch.bfloat16, torch.float16):
+            return None
+
+        w = self.weight
+        if not isinstance(w, QuantizedTensor):
+            return None
+        if not str(getattr(w, "_layout_cls", "")).startswith("TensorCoreFP8"):
+            return None
+        if getattr(self, "_full_precision_mm", False):
+            return None
+        if getattr(self, "comfy_force_cast_weights", False):
+            return None
+        if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
+            return None
+
+        params = w._params
+        if getattr(params, "transposed", False):
+            return None
+
+        qdata = w._qdata
+        # --- BLOCKER: shape/rank/dtype guards BEFORE the raw kernel call (C++ never checks W) ---
+        if qdata.dim() != 2:
+            return None
+        if not qdata.is_mps or qdata.dtype != torch.float8_e4m3fn:   # kernel decodes e4m3 only
+            return None
+        N, K = int(qdata.shape[0]), int(qdata.shape[1])
+        if input.dim() < 2 or int(input.shape[-1]) != K:
+            return None
+        bias = self.bias
+        if bias is not None and int(bias.numel()) != N:
+            return None
+
+        scale = params.scale
+        if scale.numel() not in (1, N):     # scalar OR per-channel [N] (OQ#1, resolved by Task -1)
+            return None
+
+        if max(N, K) < _min_dim():
+            return None
+
+        # --- optional real-activation fp16 range guard (off by default; see plan §3a) ---
+        if _range_guard_on() and input.dtype is torch.bfloat16:
+            if bool((input.detach().abs().amax() > 65504).item()):
+                return None
+
+        # --- BLOCKER: self-check only AFTER all gates pass, never on ineligible layers ---
+        if not _self_check():
+            return None
+
+        return _fp8_linear_kernel(input, qdata, scale, bias)
+    except Exception as e:
+        print(f"{TAG} kernel forward fell back ({e!r})")
+        return None
+
+
+def install():
+    global _installed, _kernel
+    if _installed:
+        return
+    if sys.platform != "darwin":
+        return
+    if os.environ.get("ASFP8_FP8_NATIVE") != "1":
+        return
+    if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+        return
+
+    _kernel = _load_kernel()
+    if _kernel is None:
+        return  # loader already explained why
+
+    try:
+        import comfy.ops as ops
+        orig_factory = ops.mixed_precision_ops
+        if getattr(orig_factory, "_asfp8_fp8_wrapped", False):
+            _installed = True
+            return
+
+        def wrapped_factory(*a, **k):
+            cls = orig_factory(*a, **k)
+            linear_cls = getattr(cls, "Linear", None)
+            if linear_cls is not None and not getattr(linear_cls, "_asfp8_fp8_patched", False):
+                orig_forward = linear_cls.forward
+
+                def forward(self, input, *args, **kwargs):
+                    res = _try_fp8_kernel_forward(self, input)
+                    if res is not None:
+                        return res
+                    return orig_forward(self, input, *args, **kwargs)
+
+                linear_cls.forward = forward
+                linear_cls._asfp8_fp8_patched = True
+            return cls
+
+        wrapped_factory._asfp8_fp8_wrapped = True
+        # Preserve the int8 wrapper's marker if it already wrapped the factory.
+        if getattr(orig_factory, "_asfp8_wrapped", False):
+            wrapped_factory._asfp8_wrapped = True
+        ops.mixed_precision_ops = wrapped_factory
+    except Exception as e:
+        print(f"{TAG} could not wrap mixed_precision_ops: {e!r}")
+        return
+
+    _installed = True
+    print(f"{TAG} fp8 e4m3 Linear routed through native fp8 matmul2d on MPS "
+          f"(half act x fp8 weight; LUT->bf16 weight decode bypassed; min_dim={_min_dim()}; "
+          f"range_guard={_range_guard_on()}).")

--- a/_patches/fp8_linear_kernel_mps.py
+++ b/_patches/fp8_linear_kernel_mps.py
@@ -180,8 +180,12 @@ def install():
         return
     if sys.platform != "darwin":
         return
-    if os.environ.get("ASFP8_FP8_NATIVE", "1").strip().lower() in ("0", "off", "false", "no"):
-        return  # DEFAULT ON (seam confirmed via live Flux-2 probe); ASFP8_FP8_NATIVE=off disables
+    # DEFAULT ON (seam confirmed via live Flux-2 probe), gated on Tier B (Metal-4 tensor
+    # ops + ninja for the ObjC++ fp8 extension). Unsupported HW -> default OFF (no build
+    # attempt); ASFP8_FP8_NATIVE=off force-disables, =1 forces the build attempt anyway.
+    from . import _caps
+    if not _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.tier_b_ready):
+        return
     if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         return
 

--- a/_patches/fp8_linear_kernel_mps.py
+++ b/_patches/fp8_linear_kernel_mps.py
@@ -40,7 +40,13 @@ def _min_dim():
 
 
 def _range_guard_on():
-    return os.environ.get("ASFP8_FP8_NATIVE_RANGE_GUARD") == "1"
+    # DEFAULT ON now that this kernel path is default-on: the kernel casts bf16
+    # activations to fp16 (max finite 65504), so a bf16 outlier above that would
+    # become inf and silently skew the output. The guard detects it and falls back
+    # to the bit-exact decode path. Set ASFP8_FP8_NATIVE_RANGE_GUARD=0 to skip the
+    # per-call amax check if you know your activations stay in fp16 range.
+    return os.environ.get("ASFP8_FP8_NATIVE_RANGE_GUARD", "1").strip().lower() not in (
+        "0", "off", "false", "no")
 
 
 def _load_kernel():
@@ -159,7 +165,7 @@ def _try_fp8_kernel_forward(self, input):
         if max(N, K) < _min_dim():
             return None
 
-        # --- optional real-activation fp16 range guard (off by default; see plan §3a) ---
+        # --- real-activation fp16 range guard (DEFAULT ON; =0 to skip the amax check) ---
         if _range_guard_on() and input.dtype is torch.bfloat16:
             if bool((input.detach().abs().amax() > 65504).item()):
                 return None

--- a/_patches/fp8_linear_kernel_mps.py
+++ b/_patches/fp8_linear_kernel_mps.py
@@ -9,7 +9,9 @@ weight scale (scalar OR per-channel [N]) + bias in fp32, returns bf16. Semantica
 is `input.float() @ dequant_fp8(weight).t() * scale (+bias)` -- CLOSER to unquantized-act x
 dequantized-fp8-weight than the current lossy path (a semantic change, not equivalence).
 
-Opt-in: ASFP8_FP8_NATIVE=1, DEFAULT OFF. Never-fatal: any miss falls back to comfy's
+Default ON (seam confirmed by the live Flux-2 probe); ASFP8_FP8_NATIVE=off disables.
+Note: only fires on large layers (min_dim>=8192), so it is inert on smaller DiTs (e.g. Ideogram-4
+hidden 4096). Never-fatal: any miss falls back to comfy's
 original forward. The real-model seam/scale/range are gated on Task -1 (see plan).
 """
 import os
@@ -178,8 +180,8 @@ def install():
         return
     if sys.platform != "darwin":
         return
-    if os.environ.get("ASFP8_FP8_NATIVE") != "1":
-        return
+    if os.environ.get("ASFP8_FP8_NATIVE", "1").strip().lower() in ("0", "off", "false", "no"):
+        return  # DEFAULT ON (seam confirmed via live Flux-2 probe); ASFP8_FP8_NATIVE=off disables
     if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         return
 

--- a/_patches/fused_norm_mps.py
+++ b/_patches/fused_norm_mps.py
@@ -13,13 +13,12 @@ only fixed the bare norm and reduced over all normalized dims). The 64-bit ulong
 additional defense-in-depth that prevents int32 element-offset overflow on truly enormous tensors
 (rows*D > 2^31, e.g. >2^23 rows at D=256) — valid, but not the primary fix for the 2^21-row bug.
 
-Opt-in: ASFP8_FUSED_NORM=1. Never fatal; falls back to an exact, GROUP-AWARE torch composition on
+DEFAULT ON, gated on compile_shader (ASFP8_FUSED_NORM=off disables). Never fatal; falls back to an exact, GROUP-AWARE torch composition on
 any error, off-MPS, unsupported dtype, optional-tensor shape/device/dtype mismatch, or indivisible
 modulation grouping. `_last_backend` records which path ran ("kernel" | "fallback") for tests.
 """
 from __future__ import annotations
 
-import os
 
 import torch
 import torch.nn.functional as F
@@ -271,7 +270,10 @@ def _rms_norm(input, normalized_shape, weight=None, eps=None):
 
 def install():
     global _orig_rms_norm, _installed
-    if _installed or os.environ.get("ASFP8_FUSED_NORM") != "1":
+    # DEFAULT ON, gated on compile_shader (Tier A: fp32 kernel, no Metal-4.1 needed).
+    # ASFP8_FUSED_NORM=off disables; =1 forces on. See _patches/_caps.py.
+    from . import _caps
+    if _installed or not _caps.resolve("ASFP8_FUSED_NORM", default_on=True, cap=_caps.has_compile_shader):
         return
     if not torch.backends.mps.is_available() or not hasattr(torch.mps, "compile_shader"):
         return

--- a/_patches/fused_norm_mps.py
+++ b/_patches/fused_norm_mps.py
@@ -1,0 +1,297 @@
+"""Patch #18: fused single-pass RMSNorm + affine + adaLN(scale,shift) + residual on MPS.
+
+out = residual + (rmsnorm(x) * weight) * (1 + scale) + shift   — one compile_shader kernel.
+
+Bandwidth/launch win: replaces ~4-5 separate MPS elementwise/reduction launches (each a full
+DRAM round-trip of the activation) with one kernel that reads x+residual once and writes out once,
+fp32 accumulation throughout. One threadgroup per row, 128 threads, fp32 simd_sum reduction for
+mean(x^2). The grid is z-tiled (row = z*ny + y, early-return) so dispatch is correct regardless of
+any per-dimension threadgroup cap. 64-bit element offsets + fp32 math keep it correct at every row
+count, so when installed it SUPERSEDES rmsnorm_mps_large.py's >2^21-row correctness fallback (which
+only fixed the bare norm and reduced over all normalized dims).
+
+Opt-in: ASFP8_FUSED_NORM=1. Never fatal; falls back to an exact, GROUP-AWARE torch composition on
+any error, off-MPS, unsupported dtype, optional-tensor shape/device/dtype mismatch, or indivisible
+modulation grouping. `_last_backend` records which path ran ("kernel" | "fallback") for tests.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.nn.functional as F
+
+TAG = "[AppleSilicon-FP8/fused-norm]"
+
+_MSL = r"""
+#include <metal_stdlib>
+using namespace metal;
+
+constant constexpr uint TG    = 128;
+constant constexpr uint NSIMD = TG / 32;
+
+kernel void fused_rmsnorm_modulate(
+    device const @T@*   x        [[buffer(0)]],
+    device const @T@*   weight   [[buffer(1)]],
+    device const @T@*   scale    [[buffer(2)]],
+    device const @T@*   shift    [[buffer(3)]],
+    device const @T@*   residual [[buffer(4)]],
+    device       @T@*   out      [[buffer(5)]],
+    device const int*   meta     [[buffer(6)]],
+    device const float* epsb     [[buffer(7)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  lid   [[thread_index_in_threadgroup]],
+    uint  sgid  [[simdgroup_index_in_threadgroup]],
+    uint  lane  [[thread_index_in_simdgroup]])
+{
+    const int   D     = meta[0];
+    const int   rpgS  = meta[1];
+    const int   rpgH  = meta[2];
+    const int   flags = meta[3];
+    const uint  ny    = uint(meta[4]);
+    const uint  rows  = uint(meta[5]);
+    const float eps   = epsb[0];
+
+    const uint  row  = tgpig.z * ny + tgpig.y;
+    if (row >= rows) return;
+    const ulong base = ulong(row) * ulong(D);
+
+    float local = 0.0f;
+    for (uint d = lid; d < uint(D); d += TG) {
+        float xv = float(x[base + d]);
+        local += xv * xv;
+    }
+    float warp = simd_sum(local);
+    threadgroup float part[NSIMD];
+    if (lane == 0) part[sgid] = warp;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sgid == 0) {
+        float v = (lane < NSIMD) ? part[lane] : 0.0f;
+        part[0] = simd_sum(v);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float inv = rsqrt(part[0] / float(D) + eps);
+
+    const bool  hasS  = (flags & 1) != 0;
+    const bool  hasH  = (flags & 2) != 0;
+    const bool  hasR  = (flags & 4) != 0;
+    const bool  hasW  = (flags & 8) != 0;
+    const ulong sbase = hasS ? ulong(row / uint(rpgS)) * ulong(D) : 0ul;
+    const ulong hbase = hasH ? ulong(row / uint(rpgH)) * ulong(D) : 0ul;
+
+    for (uint d = lid; d < uint(D); d += TG) {
+        float y = float(x[base + d]) * inv;
+        if (hasW) y *= float(weight[d]);
+        if (hasS) y *= (1.0f + float(scale[sbase + d]));
+        if (hasH) y += float(shift[hbase + d]);
+        if (hasR) y += float(residual[base + d]);
+        out[base + d] = @T@(y);
+    }
+}
+"""
+
+_MSL_T = {torch.float16: "half", torch.bfloat16: "bfloat", torch.float32: "float"}
+_TG = 128
+_NY = 32768                      # threadgroups along grid.y per z-slab (z-tiling)
+_libs: dict[str, object] = {}
+_meta_cache: dict[tuple, torch.Tensor] = {}
+_eps_cache: dict[tuple, torch.Tensor] = {}
+_warned = False
+_last_backend = "fallback"       # "kernel" | "fallback"; set before every return (test/bench spy)
+
+
+def _get_lib(dtype):
+    t = _MSL_T[dtype]
+    lib = _libs.get(t)
+    if lib is None:
+        lib = torch.mps.compile_shader(_MSL.replace("@T@", t))
+        _libs[t] = lib
+    return lib
+
+
+def _meta(D, rpgS, rpgH, flags, ny, rows, device):
+    key = (int(D), int(rpgS), int(rpgH), int(flags), int(ny), int(rows), str(device))
+    t = _meta_cache.get(key)
+    if t is None:
+        t = torch.tensor([D, rpgS, rpgH, flags, ny, rows], dtype=torch.int32, device=device)
+        _meta_cache[key] = t
+    return t
+
+
+def _eps(eps, device):
+    key = (float(eps), str(device))
+    t = _eps_cache.get(key)
+    if t is None:
+        t = torch.tensor([float(eps)], dtype=torch.float32, device=device)
+        _eps_cache[key] = t
+    return t
+
+
+def _expand_mod(t, D, rows):
+    """Expand a modulation tensor [..., D] -> [rows, D] using the kernel's row->group map."""
+    g = t.reshape(-1, D)
+    G = g.shape[0]
+    if G == rows:
+        return g
+    if rows % G == 0:
+        return g.repeat_interleave(rows // G, dim=0)
+    return g  # indivisible: caller's reshape raises a clear error
+
+
+def _reference(x, weight, eps, scale, shift, residual):
+    xf = x.float()
+    D = xf.shape[-1]
+    rows = xf.numel() // D
+    out = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+    if weight is not None:
+        out = out * weight.float()
+    if scale is not None:
+        out = out * (1.0 + _expand_mod(scale.float(), D, rows).reshape(out.shape))
+    if shift is not None:
+        out = out + _expand_mod(shift.float(), D, rows).reshape(out.shape)
+    if residual is not None:
+        out = out + residual.float()
+    return out.to(x.dtype)
+
+
+def _fallback(x, weight, eps, scale, shift, residual):
+    global _last_backend
+    _last_backend = "fallback"
+    return _reference(x, weight, eps, scale, shift, residual)
+
+
+def _group(t, D, rows):
+    """Reshape a modulation tensor to [G, D] and return (contig_buffer, rows_per_group) or None."""
+    g = t.contiguous().reshape(-1, D)
+    G = g.shape[0]
+    if rows % G != 0:
+        return None
+    return g, rows // G
+
+
+def _ok_optional(t, x, *, exact_shape=None, numel=None):
+    """Validate an optional tensor matches x.device/x.dtype and a shape/numel contract."""
+    if t.device != x.device or t.dtype != x.dtype:
+        return False
+    if exact_shape is not None and tuple(t.shape) != tuple(exact_shape):
+        return False
+    if numel is not None and t.numel() != numel:
+        return False
+    return True
+
+
+def fused_rmsnorm_modulate(x, weight, eps=1e-6, scale=None, shift=None, residual=None):
+    global _last_backend
+    if x.device.type != "mps" or x.dtype not in _MSL_T or x.numel() == 0:
+        return _fallback(x, weight, eps, scale, shift, residual)
+    try:
+        D = x.shape[-1]
+        xc = x.contiguous()
+        rows = xc.numel() // D
+        dummy = torch.empty(1, dtype=x.dtype, device=x.device)
+
+        flags = 0
+        wbuf = dummy
+        if weight is not None:
+            if not _ok_optional(weight, x, numel=D):
+                return _fallback(x, weight, eps, scale, shift, residual)
+            wbuf = weight.contiguous()
+            flags |= 8
+        sbuf, rpgS = dummy, 1
+        if scale is not None:
+            if scale.device != x.device or scale.dtype != x.dtype:
+                return _fallback(x, weight, eps, scale, shift, residual)
+            grp = _group(scale, D, rows)
+            if grp is None:
+                return _fallback(x, weight, eps, scale, shift, residual)
+            sbuf, rpgS = grp[0], grp[1]
+            flags |= 1
+        hbuf, rpgH = dummy, 1
+        if shift is not None:
+            if shift.device != x.device or shift.dtype != x.dtype:
+                return _fallback(x, weight, eps, scale, shift, residual)
+            grp = _group(shift, D, rows)
+            if grp is None:
+                return _fallback(x, weight, eps, scale, shift, residual)
+            hbuf, rpgH = grp[0], grp[1]
+            flags |= 2
+        rbuf = dummy
+        if residual is not None:
+            if not _ok_optional(residual, x, exact_shape=x.shape):
+                return _fallback(x, weight, eps, scale, shift, residual)
+            rbuf = residual.contiguous()
+            flags |= 4
+
+        ny = min(rows, _NY)
+        nz = (rows + ny - 1) // ny
+        out = torch.empty_like(xc)
+        meta = _meta(D, rpgS, rpgH, flags, ny, rows, x.device)
+        epsb = _eps(eps, x.device)
+        _get_lib(x.dtype).fused_rmsnorm_modulate(
+            xc, wbuf, sbuf, hbuf, rbuf, out, meta, epsb,
+            threads=(_TG, ny, nz), group_size=(_TG, 1, 1),
+        )
+        _last_backend = "kernel"
+        return out.view_as(x)
+    except Exception as e:  # never fatal
+        global _warned
+        if not _warned:
+            print(f"{TAG} kernel error ({e}); falling back to torch composition.", flush=True)
+            _warned = True
+        return _fallback(x, weight, eps, scale, shift, residual)
+
+
+# ---- optional F.rms_norm reroute (supersedes rmsnorm_mps_large.py when installed) ----
+_orig_rms_norm = None
+_installed = False
+
+
+def _rms_norm(input, normalized_shape, weight=None, eps=None):
+    if input.device.type != "mps" or input.dtype not in _MSL_T:
+        return _orig_rms_norm(input, normalized_shape, weight, eps)
+    # Codex BLOCKER #2: reduce over ALL normalized dims -> flatten last len(normalized_shape) dims.
+    D = 1
+    for d in normalized_shape:
+        D *= int(d)
+    if D <= 0 or input.numel() % D != 0:
+        return _orig_rms_norm(input, normalized_shape, weight, eps)
+    e = eps if eps is not None else torch.finfo(input.dtype).eps
+    x2d = input.contiguous().view(-1, D)
+    w1d = weight.contiguous().view(D) if weight is not None else None
+    out = fused_rmsnorm_modulate(x2d, w1d, e)
+    return out.view_as(input)
+
+
+def install():
+    global _orig_rms_norm, _installed
+    if _installed or os.environ.get("ASFP8_FUSED_NORM") != "1":
+        return
+    if not torch.backends.mps.is_available() or not hasattr(torch.mps, "compile_shader"):
+        return
+    _orig_rms_norm = F.rms_norm
+    F.rms_norm = _rms_norm
+    torch.nn.functional.rms_norm = _rms_norm
+    _installed = True
+    print(f"{TAG} fused rmsnorm+modulation kernel active on MPS "
+          f"(F.rms_norm rerouted; supersedes the >2^21-row fp32 fallback).", flush=True)
+
+
+# ---- test-only install helpers (bypass the env flag so the reroute is exercised in pytest) ----
+def install_for_test():
+    global _orig_rms_norm, _installed
+    if _installed:
+        return
+    _orig_rms_norm = F.rms_norm
+    F.rms_norm = _rms_norm
+    torch.nn.functional.rms_norm = _rms_norm
+    _installed = True
+
+
+def uninstall_for_test():
+    global _orig_rms_norm, _installed
+    if not _installed:
+        return
+    F.rms_norm = _orig_rms_norm
+    torch.nn.functional.rms_norm = _orig_rms_norm
+    _orig_rms_norm = None
+    _installed = False

--- a/_patches/fused_norm_mps.py
+++ b/_patches/fused_norm_mps.py
@@ -6,9 +6,12 @@ Bandwidth/launch win: replaces ~4-5 separate MPS elementwise/reduction launches 
 DRAM round-trip of the activation) with one kernel that reads x+residual once and writes out once,
 fp32 accumulation throughout. One threadgroup per row, 128 threads, fp32 simd_sum reduction for
 mean(x^2). The grid is z-tiled (row = z*ny + y, early-return) so dispatch is correct regardless of
-any per-dimension threadgroup cap. 64-bit element offsets + fp32 math keep it correct at every row
-count, so when installed it SUPERSEDES rmsnorm_mps_large.py's >2^21-row correctness fallback (which
-only fixed the bare norm and reduced over all normalized dims).
+any per-dimension threadgroup cap. Being a SEPARATE fp32-reduction kernel with correct Metal
+dispatch is what keeps it correct in the >2^21-row regime where stock PyTorch MPS rms_norm returns
+garbage, so when installed it SUPERSEDES rmsnorm_mps_large.py's >2^21-row correctness fallback (which
+only fixed the bare norm and reduced over all normalized dims). The 64-bit ulong element offsets are
+additional defense-in-depth that prevents int32 element-offset overflow on truly enormous tensors
+(rows*D > 2^31, e.g. >2^23 rows at D=256) — valid, but not the primary fix for the 2^21-row bug.
 
 Opt-in: ASFP8_FUSED_NORM=1. Never fatal; falls back to an exact, GROUP-AWARE torch composition on
 any error, off-MPS, unsupported dtype, optional-tensor shape/device/dtype mismatch, or indivisible
@@ -67,7 +70,8 @@ kernel void fused_rmsnorm_modulate(
     threadgroup_barrier(mem_flags::mem_threadgroup);
     if (sgid == 0) {
         float v = (lane < NSIMD) ? part[lane] : 0.0f;
-        part[0] = simd_sum(v);
+        float total = simd_sum(v);
+        if (lane == 0) part[0] = total;   // single writer: avoid concurrent-write UB
     }
     threadgroup_barrier(mem_flags::mem_threadgroup);
     const float inv = rsqrt(part[0] / float(D) + eps);
@@ -247,13 +251,16 @@ _installed = False
 
 
 def _rms_norm(input, normalized_shape, weight=None, eps=None):
+    global _last_backend
     if input.device.type != "mps" or input.dtype not in _MSL_T:
+        _last_backend = "fallback"   # outer bypass: don't let a stale "kernel" spy false-positive
         return _orig_rms_norm(input, normalized_shape, weight, eps)
     # Codex BLOCKER #2: reduce over ALL normalized dims -> flatten last len(normalized_shape) dims.
     D = 1
     for d in normalized_shape:
         D *= int(d)
     if D <= 0 or input.numel() % D != 0:
+        _last_backend = "fallback"   # outer bypass (indivisible/empty D): same spy hygiene
         return _orig_rms_norm(input, normalized_shape, weight, eps)
     e = eps if eps is not None else torch.finfo(input.dtype).eps
     x2d = input.contiguous().view(-1, D)

--- a/_patches/int4_ext/int4_matmul2d.mm
+++ b/_patches/int4_ext/int4_matmul2d.mm
@@ -321,7 +321,10 @@ torch::Tensor i8i4_linear_fused_nt(torch::Tensor a_i8, torch::Tensor w4,
                 threadsPerThreadgroup:MTLSizeMake(NSG * 32, 1, 1)];
         }
     });
-    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    // Do NOT COMMIT_AND_WAIT here (mirrors int8_gemm.mm): the kernel is encoded on
+    // torch's MPS stream, so ordering is preserved on the same command buffer and torch
+    // commits it naturally. A per-Linear commit+wait serializes the pipeline and kills
+    // async overlap (measured slowdown on int8). The result syncs when the caller reads C.
     return C;
 }
 

--- a/_patches/int4_ext/int4_matmul2d.mm
+++ b/_patches/int4_ext/int4_matmul2d.mm
@@ -1,0 +1,334 @@
+// int4b-weight matmul2d torch MPS extension (EXPERIMENTAL go/no-go probe).
+//
+// Mirrors int8_ext/int8_matmul2d.mm, but the B (weight) operand is PACKED int4
+// (`metal::int4b_format`, 2 values/byte) — the W4 tier of the M5 Neural
+// Accelerators. Two questions this answers:
+//   1. correctness: does MPP's int4b nibble order match comfy-kitchen's
+//      row-major packing (low nibble = even column)?
+//   2. speed: what do int8xint4b->int32 (W4A8) and bfloatxint4b->float (W4A16)
+//      reach at Krea2/FLUX shapes vs our int8 W8A8 kernel and MPS bf16 GEMM?
+// Weights stay packed in device memory — half the weight bandwidth of int8.
+//
+// NT layout (transpose_right=true) to match nn.Linear: A[M,K] @ Wᵀ, W=[N,K].
+
+#include <torch/extension.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSDevice.h>
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+using namespace at::mps;
+
+static const char* kSrc = R"MTL(
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal;
+using namespace mpp::tensor_ops;
+
+#if !defined(__HAVE_INT4B_FORMAT_TYPE__)
+#error "int4b_format unavailable at this Metal language version"
+#endif
+
+// Tile config from the dev/probe_int4_tune.py sweep (12 configs, all verified
+// bit-exact): BM128/BN128/NSG8 dv_i4 = 86.9 TF/s vs BM64/BN64/NSG4's 80.3 TF/s.
+// Bigger is NOT better here — BM256 collapses to 20.8 TF/s (cooperative-tensor
+// register spill), and tg_i4 threadgroup staging is 2-4x worse at every config
+// (B is already read once per m-block, so staging adds copies and barriers
+// without removing traffic).
+constant constexpr int BM = 128, BN = 128, NSG = 8;
+
+// C[M,N] int32 = A[M,K] int8 @ Wᵀ where W is [N,K] packed int4 (K/2 bytes/row).
+kernel void gemm_i8i4_nt(
+    device signed char* A [[buffer(0)]],
+    device uchar*       B [[buffer(1)]],   // [N, K/2] bytes, int4b packed
+    device int*         C [[buffer(2)]],
+    constant int& M [[buffer(3)]],
+    constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]],
+    uint3 tgid [[threadgroup_position_in_grid]])
+{
+    const int m0 = int(tgid.x) * BM;
+    const int n0 = int(tgid.y) * BN;
+    if (m0 >= M || n0 >= N) return;
+
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+
+    auto mA = tensor<device signed char, dextents<int,2>, tensor_inline>(
+                  A + ulong(m0)*K, dextents<int,2>{K, min(BM, M - m0)}, array<int,2>{1, K});
+    auto mB = tensor<device int4b_format, dextents<int,2>, tensor_inline>(
+                  B + ulong(n0)*(K/2), dextents<int,2>{K, min(BN, N - n0)}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, int>();
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i)
+        if (cC.is_valid_element(i)) cC[i] = 0;
+
+    op.run(mA, mB, cC);
+
+    device int* Cb = C + ulong(m0)*N + n0;
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i) {
+        if (!cC.is_valid_element(i)) continue;
+        auto idx = cC.get_multidimensional_index(i);
+        const int r = int(idx[1]), c = int(idx[0]);
+        if (m0 + r >= M || n0 + c >= N) continue;
+        Cb[ulong(r)*N + c] = cC[i];
+    }
+}
+
+// C[M,N] float = A[M,K] bfloat @ Wᵀ where W is [N,K] packed int4.
+kernel void gemm_bf16i4_nt(
+    device bfloat* A [[buffer(0)]],
+    device uchar*  B [[buffer(1)]],
+    device float*  C [[buffer(2)]],
+    constant int& M [[buffer(3)]],
+    constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]],
+    uint3 tgid [[threadgroup_position_in_grid]])
+{
+    const int m0 = int(tgid.x) * BM;
+    const int n0 = int(tgid.y) * BN;
+    if (m0 >= M || n0 >= N) return;
+
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+
+    auto mA = tensor<device bfloat, dextents<int,2>, tensor_inline>(
+                  A + ulong(m0)*K, dextents<int,2>{K, min(BM, M - m0)}, array<int,2>{1, K});
+    auto mB = tensor<device int4b_format, dextents<int,2>, tensor_inline>(
+                  B + ulong(n0)*(K/2), dextents<int,2>{K, min(BN, N - n0)}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, float>();
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i)
+        if (cC.is_valid_element(i)) cC[i] = 0.0f;
+
+    op.run(mA, mB, cC);
+
+    device float* Cb = C + ulong(m0)*N + n0;
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i) {
+        if (!cC.is_valid_element(i)) continue;
+        auto idx = cC.get_multidimensional_index(i);
+        const int r = int(idx[1]), c = int(idx[0]);
+        if (m0 + r >= M || n0 + c >= N) continue;
+        Cb[ulong(r)*N + c] = cC[i];
+    }
+}
+// C[M,N] bf16 = dequant(A_int8[M,K] @ Wᵀ_int4b[N,K]) fused epilogue:
+//   C[m,n] = bf16(float(acc) * x_scale[m] * w_scale[n]) (+ bias[n] in bf16)
+// Mirrors int8_gemm.mm's store-epilogue contract: int32→fp32, fp32 rescale,
+// round to bf16, then a separate bf16-precision bias add.
+kernel void gemm_i8i4_fused_nt(
+    device signed char* A [[buffer(0)]],
+    device uchar*       B [[buffer(1)]],
+    device bfloat*      C [[buffer(2)]],
+    constant int& M [[buffer(3)]],
+    constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]],
+    device float* x_scale [[buffer(6)]],   // [M] per-row activation scale
+    device float* w_scale [[buffer(7)]],   // [N] per-row weight scale
+    device bfloat* bias [[buffer(8)]],     // [N] or unused
+    constant int& has_bias [[buffer(9)]],
+    uint3 tgid [[threadgroup_position_in_grid]])
+{
+    const int m0 = int(tgid.x) * BM;
+    const int n0 = int(tgid.y) * BN;
+    if (m0 >= M || n0 >= N) return;
+
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+
+    auto mA = tensor<device signed char, dextents<int,2>, tensor_inline>(
+                  A + ulong(m0)*K, dextents<int,2>{K, min(BM, M - m0)}, array<int,2>{1, K});
+    auto mB = tensor<device int4b_format, dextents<int,2>, tensor_inline>(
+                  B + ulong(n0)*(K/2), dextents<int,2>{K, min(BN, N - n0)}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, int>();
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i)
+        if (cC.is_valid_element(i)) cC[i] = 0;
+
+    op.run(mA, mB, cC);
+
+    device bfloat* Cb = C + ulong(m0)*N + n0;
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i) {
+        if (!cC.is_valid_element(i)) continue;
+        auto idx = cC.get_multidimensional_index(i);
+        const int r = int(idx[1]), c = int(idx[0]);
+        if (m0 + r >= M || n0 + c >= N) continue;
+        float acc = float(cC[i]) * x_scale[m0 + r] * w_scale[n0 + c];
+        bfloat v = bfloat(acc);
+        if (has_bias) v = v + bias[n0 + c];
+        Cb[ulong(r)*N + c] = v;
+    }
+}
+)MTL";
+
+static id<MTLLibrary> g_lib = nil;
+static id<MTLComputePipelineState> g_pso_i8i4 = nil;
+static id<MTLComputePipelineState> g_pso_bf16i4 = nil;
+static id<MTLComputePipelineState> g_pso_i8i4_fused = nil;
+
+static id<MTLLibrary> get_lib() {
+    if (g_lib) return g_lib;
+    id<MTLDevice> dev = MPSDevice::getInstance()->device();
+    MTLCompileOptions* opts = [MTLCompileOptions new];
+    opts.languageVersion = MTLLanguageVersion4_1;
+    NSError* err = nil;
+    g_lib = [dev newLibraryWithSource:[NSString stringWithUTF8String:kSrc]
+                              options:opts error:&err];
+    TORCH_CHECK(g_lib, "int4 Metal library compile failed: ",
+                err ? err.localizedDescription.UTF8String : "unknown");
+    return g_lib;
+}
+
+static id<MTLComputePipelineState> get_pso(const char* name,
+                                           id<MTLComputePipelineState>* slot) {
+    if (*slot) return *slot;
+    id<MTLDevice> dev = MPSDevice::getInstance()->device();
+    NSError* err = nil;
+    id<MTLFunction> fn = [get_lib() newFunctionWithName:[NSString stringWithUTF8String:name]];
+    TORCH_CHECK(fn, name, " not found in compiled library");
+    *slot = [dev newComputePipelineStateWithFunction:fn error:&err];
+    TORCH_CHECK(*slot, name, " pipeline state creation failed: ",
+                err ? err.localizedDescription.UTF8String : "unknown");
+    return *slot;
+}
+
+static void dispatch_nt(id<MTLComputePipelineState> pso,
+                        torch::Tensor a, torch::Tensor w4, torch::Tensor C,
+                        int M, int N, int K) {
+    MPSStream* stream = getCurrentMPSStream();
+    id<MTLBuffer> aBuf = __builtin_bit_cast(id<MTLBuffer>, a.storage().data());
+    id<MTLBuffer> bBuf = __builtin_bit_cast(id<MTLBuffer>, w4.storage().data());
+    id<MTLBuffer> cBuf = __builtin_bit_cast(id<MTLBuffer>, C.storage().data());
+    const NSUInteger aOff = a.storage_offset() * a.element_size();
+    const NSUInteger bOff = w4.storage_offset() * w4.element_size();
+    const NSUInteger cOff = C.storage_offset() * C.element_size();
+    const int BM = 128, BN = 128, NSG = 8;  // must match kSrc
+    const NSUInteger gx = (M + BM - 1) / BM, gy = (N + BN - 1) / BN;
+    dispatch_sync(stream->queue(), ^(){
+        @autoreleasepool {
+            id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+            [enc setComputePipelineState:pso];
+            [enc setBuffer:aBuf offset:aOff atIndex:0];
+            [enc setBuffer:bBuf offset:bOff atIndex:1];
+            [enc setBuffer:cBuf offset:cOff atIndex:2];
+            [enc setBytes:&M length:sizeof(int) atIndex:3];
+            [enc setBytes:&N length:sizeof(int) atIndex:4];
+            [enc setBytes:&K length:sizeof(int) atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake(gx, gy, 1)
+                threadsPerThreadgroup:MTLSizeMake(NSG * 32, 1, 1)];
+        }
+    });
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+}
+
+// C[M,N] int32 = A[M,K] int8 @ Wᵀ, W packed int4 [N, K/2] uint8.
+torch::Tensor i8i4_matmul2d_nt(torch::Tensor a_i8, torch::Tensor w4, int64_t K, int64_t N) {
+    TORCH_CHECK(a_i8.is_mps() && w4.is_mps(), "inputs must be on mps");
+    TORCH_CHECK(a_i8.scalar_type() == torch::kChar, "A must be int8");
+    TORCH_CHECK(w4.scalar_type() == torch::kByte || w4.scalar_type() == torch::kChar,
+                "W must be packed int4 bytes");
+    TORCH_CHECK(a_i8.is_contiguous() && w4.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(K % 2 == 0, "K must be even");
+    const int M = (int)a_i8.size(0);
+    auto C = torch::zeros({(long)M, (long)N}, a_i8.options().dtype(torch::kInt32));
+    dispatch_nt(get_pso("gemm_i8i4_nt", &g_pso_i8i4), a_i8, w4, C, M, (int)N, (int)K);
+    return C;
+}
+
+// C[M,N] float = A[M,K] bfloat @ Wᵀ, W packed int4 [N, K/2] uint8.
+torch::Tensor bf16i4_matmul2d_nt(torch::Tensor a_bf, torch::Tensor w4, int64_t K, int64_t N) {
+    TORCH_CHECK(a_bf.is_mps() && w4.is_mps(), "inputs must be on mps");
+    TORCH_CHECK(a_bf.scalar_type() == torch::kBFloat16, "A must be bfloat16");
+    TORCH_CHECK(w4.scalar_type() == torch::kByte || w4.scalar_type() == torch::kChar,
+                "W must be packed int4 bytes");
+    TORCH_CHECK(a_bf.is_contiguous() && w4.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(K % 2 == 0, "K must be even");
+    const int M = (int)a_bf.size(0);
+    auto C = torch::zeros({(long)M, (long)N}, a_bf.options().dtype(torch::kFloat32));
+    dispatch_nt(get_pso("gemm_bf16i4_nt", &g_pso_bf16i4), a_bf, w4, C, M, (int)N, (int)K);
+    return C;
+}
+
+// C[M,N] bf16 = (A_int8 @ Wᵀ_int4b) * x_scale[m] * w_scale[n] (+ bias), fused.
+torch::Tensor i8i4_linear_fused_nt(torch::Tensor a_i8, torch::Tensor w4,
+                                   torch::Tensor x_scale, torch::Tensor w_scale,
+                                   c10::optional<torch::Tensor> bias,
+                                   int64_t K, int64_t N) {
+    TORCH_CHECK(a_i8.is_mps() && w4.is_mps(), "inputs must be on mps");
+    TORCH_CHECK(a_i8.scalar_type() == torch::kChar, "A must be int8");
+    TORCH_CHECK(w4.scalar_type() == torch::kByte || w4.scalar_type() == torch::kChar,
+                "W must be packed int4 bytes");
+    TORCH_CHECK(x_scale.scalar_type() == torch::kFloat && w_scale.scalar_type() == torch::kFloat,
+                "scales must be float32");
+    TORCH_CHECK(a_i8.is_contiguous() && w4.is_contiguous() &&
+                x_scale.is_contiguous() && w_scale.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(K % 2 == 0, "K must be even");
+    const int M = (int)a_i8.size(0);
+    TORCH_CHECK(x_scale.numel() == M && w_scale.numel() == N, "scale shapes");
+    torch::Tensor b;
+    const int has_bias = bias.has_value() ? 1 : 0;
+    if (has_bias) {
+        b = bias.value();
+        TORCH_CHECK(b.is_mps() && b.scalar_type() == torch::kBFloat16 && b.is_contiguous(),
+                    "bias must be contiguous bf16 on mps");
+        TORCH_CHECK(b.numel() == N, "bias shape");
+    } else {
+        b = w_scale;  // placeholder binding, never read (has_bias=0)
+    }
+    auto C = torch::empty({(long)M, (long)N}, a_i8.options().dtype(torch::kBFloat16));
+
+    id<MTLComputePipelineState> pso = get_pso("gemm_i8i4_fused_nt", &g_pso_i8i4_fused);
+    MPSStream* stream = getCurrentMPSStream();
+    id<MTLBuffer> aBuf = __builtin_bit_cast(id<MTLBuffer>, a_i8.storage().data());
+    id<MTLBuffer> bBuf = __builtin_bit_cast(id<MTLBuffer>, w4.storage().data());
+    id<MTLBuffer> cBuf = __builtin_bit_cast(id<MTLBuffer>, C.storage().data());
+    id<MTLBuffer> xsBuf = __builtin_bit_cast(id<MTLBuffer>, x_scale.storage().data());
+    id<MTLBuffer> wsBuf = __builtin_bit_cast(id<MTLBuffer>, w_scale.storage().data());
+    id<MTLBuffer> biBuf = __builtin_bit_cast(id<MTLBuffer>, b.storage().data());
+    const NSUInteger aOff = a_i8.storage_offset() * a_i8.element_size();
+    const NSUInteger bOff = w4.storage_offset() * w4.element_size();
+    const NSUInteger cOff = C.storage_offset() * C.element_size();
+    const NSUInteger xsOff = x_scale.storage_offset() * x_scale.element_size();
+    const NSUInteger wsOff = w_scale.storage_offset() * w_scale.element_size();
+    const NSUInteger biOff = b.storage_offset() * b.element_size();
+    int Mi = M, Ni = (int)N, Ki = (int)K, hb = has_bias;
+    const int BM = 128, BN = 128, NSG = 8;  // must match kSrc
+    const NSUInteger gx = (M + BM - 1) / BM, gy = (N + BN - 1) / BN;
+    dispatch_sync(stream->queue(), ^(){
+        @autoreleasepool {
+            id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+            [enc setComputePipelineState:pso];
+            [enc setBuffer:aBuf offset:aOff atIndex:0];
+            [enc setBuffer:bBuf offset:bOff atIndex:1];
+            [enc setBuffer:cBuf offset:cOff atIndex:2];
+            [enc setBytes:&Mi length:sizeof(int) atIndex:3];
+            [enc setBytes:&Ni length:sizeof(int) atIndex:4];
+            [enc setBytes:&Ki length:sizeof(int) atIndex:5];
+            [enc setBuffer:xsBuf offset:xsOff atIndex:6];
+            [enc setBuffer:wsBuf offset:wsOff atIndex:7];
+            [enc setBuffer:biBuf offset:biOff atIndex:8];
+            [enc setBytes:&hb length:sizeof(int) atIndex:9];
+            [enc dispatchThreadgroups:MTLSizeMake(gx, gy, 1)
+                threadsPerThreadgroup:MTLSizeMake(NSG * 32, 1, 1)];
+        }
+    });
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    return C;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("i8i4_linear_fused_nt", &i8i4_linear_fused_nt,
+          "NT W4A8 linear with fused per-row dequant + bias (int8 x packed-int4 -> bf16) on MPS");
+    m.def("i8i4_matmul2d_nt", &i8i4_matmul2d_nt, "NT W4A8 matmul (int8 x packed-int4 -> int32) on MPS");
+    m.def("bf16i4_matmul2d_nt", &bf16i4_matmul2d_nt, "NT W4A16 matmul (bf16 x packed-int4 -> float) on MPS");
+    m.def("warmup", []() { get_lib(); return true; }, "compile library");
+}

--- a/_patches/int4_ext/int4_tune.mm
+++ b/_patches/int4_ext/int4_tune.mm
@@ -1,0 +1,221 @@
+// int4b matmul2d TUNING harness — sweep BM/BN/NSG/BK and dv_i4 vs tg_i4.
+//
+// Why: int4_matmul2d.mm was written as a go/no-go correctness probe (BM=64,
+// BN=64, NSG=4, one op.run over the whole K straight from device memory). It was
+// never tuned, so benchmarking it against the register-tiled int8_gemm.mm and
+// concluding "M5 doesn't accelerate int4" was invalid.
+//
+// Header fact (MPPTensorOpsMatMul2dImpl.h): int4b_format has NO cooperative-input
+// intrinsics — every variant is dv_i4 (device) or tg_i4 (threadgroup). So the
+// register-tiling int8 uses is unavailable for int4; the only levers are tile
+// shape and staging the packed weight through threadgroup memory (tg_i4).
+//
+// Builds one pipeline per config, cached. Correctness is checked in Python
+// against the int32 reference for every config before it is timed.
+
+#include <torch/extension.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSDevice.h>
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+#include <map>
+#include <string>
+
+using namespace at::mps;
+
+static const char* kSrcTemplate = R"MTL(
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal;
+using namespace mpp::tensor_ops;
+
+#if !defined(__HAVE_INT4B_FORMAT_TYPE__)
+#error "int4b_format unavailable at this Metal language version"
+#endif
+
+constant constexpr int BM = @BM@, BN = @BN@, NSG = @NSG@, BK = @BK@;
+#define USE_TG @USE_TG@
+
+kernel void gemm_tuned(
+    device signed char* A [[buffer(0)]],
+    device uchar*       B [[buffer(1)]],
+    device int*         C [[buffer(2)]],
+    constant int& M [[buffer(3)]],
+    constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint  tid  [[thread_index_in_threadgroup]])
+{
+    const int m0 = int(tgid.x) * BM;
+    const int n0 = int(tgid.y) * BN;
+    if (m0 >= M || n0 >= N) return;
+    const int rows = min(BM, M - m0);
+    const int cols = min(BN, N - n0);
+    device int* Cb = C + ulong(m0)*N + n0;
+
+#if USE_TG
+    // Stage the packed weight tile [BN, BK/2] bytes into threadgroup memory and
+    // accumulate over K. B is read from device once per (m-block, k-block).
+    threadgroup uchar sB[BN * BK / 2];
+
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, BK, false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+
+    auto mA0 = tensor<device signed char, dextents<int,2>, tensor_inline>(
+                   A + ulong(m0)*K, dextents<int,2>{BK, rows}, array<int,2>{1, K});
+    auto tB0 = tensor<threadgroup int4b_format, dextents<int,2>, tensor_inline>(
+                   sB, dextents<int,2>{BK, BN}, array<int,2>{1, BK});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA0)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(tB0)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, int>();
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i)
+        if (cC.is_valid_element(i)) cC[i] = 0;
+
+    const uint nthreads = NSG * 32u;
+    const int halfBK = BK / 2, halfK = K / 2;
+    for (int k0 = 0; k0 < K; k0 += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint i = tid; i < uint(BN * halfBK); i += nthreads) {
+            const int n  = int(i) / halfBK;
+            const int kb = int(i) % halfBK;
+            const int ko = k0 / 2 + kb;
+            uchar v = 0;
+            if (n < cols && ko < halfK) v = B[ulong(n0 + n)*halfK + ko];
+            sB[i] = v;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        auto mA = tensor<device signed char, dextents<int,2>, tensor_inline>(
+                      A + ulong(m0)*K + k0, dextents<int,2>{BK, rows}, array<int,2>{1, K});
+        auto tB = tensor<threadgroup int4b_format, dextents<int,2>, tensor_inline>(
+                      sB, dextents<int,2>{BK, BN}, array<int,2>{1, BK});
+        op.run(mA, tB, cC);
+    }
+
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i) {
+        if (!cC.is_valid_element(i)) continue;
+        auto idx = cC.get_multidimensional_index(i);
+        const int r = int(idx[1]), c = int(idx[0]);
+        if (r >= rows || c >= cols) continue;
+        Cb[ulong(r)*N + c] = cC[i];
+    }
+#else
+    // Baseline: one op.run over the whole K, weight read straight from device.
+    constexpr auto desc = matmul2d_descriptor(
+        BM, BN, static_cast<int>(dynamic_extent), false, true, false,
+        matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc, execution_simdgroups<NSG>> op;
+
+    auto mA = tensor<device signed char, dextents<int,2>, tensor_inline>(
+                  A + ulong(m0)*K, dextents<int,2>{K, rows}, array<int,2>{1, K});
+    auto mB = tensor<device int4b_format, dextents<int,2>, tensor_inline>(
+                  B + ulong(n0)*(K/2), dextents<int,2>{K, cols}, array<int,2>{1, K});
+    using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC = op.get_destination_cooperative_tensor<AT, BT, int>();
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i)
+        if (cC.is_valid_element(i)) cC[i] = 0;
+
+    op.run(mA, mB, cC);
+
+    for (uint16_t i = 0; i < cC.get_capacity(); ++i) {
+        if (!cC.is_valid_element(i)) continue;
+        auto idx = cC.get_multidimensional_index(i);
+        const int r = int(idx[1]), c = int(idx[0]);
+        if (r >= rows || c >= cols) continue;
+        Cb[ulong(r)*N + c] = cC[i];
+    }
+#endif
+}
+)MTL";
+
+static std::string substitute(int BM, int BN, int NSG, int BK, int use_tg) {
+    std::string s(kSrcTemplate);
+    auto rep = [&s](const std::string& k, int v) {
+        std::string val = std::to_string(v);
+        size_t p;
+        while ((p = s.find(k)) != std::string::npos) s.replace(p, k.size(), val);
+    };
+    rep("@BM@", BM); rep("@BN@", BN); rep("@NSG@", NSG);
+    rep("@BK@", BK); rep("@USE_TG@", use_tg);
+    return s;
+}
+
+static std::map<std::string, id<MTLComputePipelineState>> g_cache;
+
+static id<MTLComputePipelineState> get_pso(int BM, int BN, int NSG, int BK, int use_tg) {
+    char key[128];
+    snprintf(key, sizeof(key), "%d_%d_%d_%d_%d", BM, BN, NSG, BK, use_tg);
+    auto it = g_cache.find(key);
+    if (it != g_cache.end()) return it->second;
+
+    id<MTLDevice> dev = MPSDevice::getInstance()->device();
+    MTLCompileOptions* opts = [MTLCompileOptions new];
+    opts.languageVersion = MTLLanguageVersion4_1;
+    NSError* err = nil;
+    std::string src = substitute(BM, BN, NSG, BK, use_tg);
+    id<MTLLibrary> lib = [dev newLibraryWithSource:[NSString stringWithUTF8String:src.c_str()]
+                                           options:opts error:&err];
+    TORCH_CHECK(lib, "int4 tune compile failed (", key, "): ",
+                err ? err.localizedDescription.UTF8String : "unknown");
+    id<MTLFunction> fn = [lib newFunctionWithName:@"gemm_tuned"];
+    TORCH_CHECK(fn, "gemm_tuned not found (", key, ")");
+    id<MTLComputePipelineState> pso = [dev newComputePipelineStateWithFunction:fn error:&err];
+    TORCH_CHECK(pso, "int4 tune pipeline failed (", key, "): ",
+                err ? err.localizedDescription.UTF8String : "unknown");
+    g_cache[key] = pso;
+    return pso;
+}
+
+torch::Tensor i8i4_tuned(torch::Tensor a_i8, torch::Tensor w4, int64_t K, int64_t N,
+                         int64_t BM, int64_t BN, int64_t NSG, int64_t BK, int64_t use_tg) {
+    TORCH_CHECK(a_i8.is_mps() && w4.is_mps(), "inputs must be on mps");
+    TORCH_CHECK(a_i8.scalar_type() == torch::kChar, "A must be int8");
+    TORCH_CHECK(a_i8.is_contiguous() && w4.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(K % 2 == 0, "K must be even");
+    if (use_tg) TORCH_CHECK(K % BK == 0, "K must be divisible by BK for tg staging");
+
+    const int M = (int)a_i8.size(0);
+    auto C = torch::zeros({(long)M, (long)N}, a_i8.options().dtype(torch::kInt32));
+
+    id<MTLComputePipelineState> pso = get_pso((int)BM, (int)BN, (int)NSG, (int)BK, (int)use_tg);
+
+    MPSStream* stream = getCurrentMPSStream();
+    id<MTLBuffer> aBuf = __builtin_bit_cast(id<MTLBuffer>, a_i8.storage().data());
+    id<MTLBuffer> bBuf = __builtin_bit_cast(id<MTLBuffer>, w4.storage().data());
+    id<MTLBuffer> cBuf = __builtin_bit_cast(id<MTLBuffer>, C.storage().data());
+    const NSUInteger aOff = a_i8.storage_offset() * a_i8.element_size();
+    const NSUInteger bOff = w4.storage_offset() * w4.element_size();
+    const NSUInteger cOff = C.storage_offset() * C.element_size();
+    const int Mi = M, Ni = (int)N, Ki = (int)K;
+    const NSUInteger gx = (M + BM - 1) / BM, gy = (N + BN - 1) / BN;
+    const NSUInteger tpg = NSG * 32;
+
+    dispatch_sync(stream->queue(), ^(){
+        @autoreleasepool {
+            id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+            [enc setComputePipelineState:pso];
+            [enc setBuffer:aBuf offset:aOff atIndex:0];
+            [enc setBuffer:bBuf offset:bOff atIndex:1];
+            [enc setBuffer:cBuf offset:cOff atIndex:2];
+            [enc setBytes:&Mi length:sizeof(int) atIndex:3];
+            [enc setBytes:&Ni length:sizeof(int) atIndex:4];
+            [enc setBytes:&Ki length:sizeof(int) atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake(gx, gy, 1)
+                threadsPerThreadgroup:MTLSizeMake(tpg, 1, 1)];
+        }
+    });
+    stream->synchronize(SyncType::COMMIT_AND_WAIT);
+    return C;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("i8i4_tuned", &i8i4_tuned,
+        "Tunable NT int8 x packed-int4 matmul: C[M,N] int32 = A[M,K] @ B[N,K]^T",
+        pybind11::arg("a_i8"), pybind11::arg("w4"), pybind11::arg("K"), pybind11::arg("N"),
+        pybind11::arg("BM"), pybind11::arg("BN"), pybind11::arg("NSG"),
+        pybind11::arg("BK"), pybind11::arg("use_tg"));
+}

--- a/_patches/int4_ext/loader.py
+++ b/_patches/int4_ext/loader.py
@@ -1,0 +1,92 @@
+"""JIT loader for the packed-int4 matmul2d MPS probe extension.
+
+Builds _patches/int4_ext/int4_matmul2d.mm via torch.utils.cpp_extension.load
+(ObjC++, Metal 4.1). Opt-in (ASFP8_INT4_EXT=1), guarded, cached; returns None on
+any failure. Same space-in-path workaround as int8_ext/fp8_ext.
+"""
+
+import os
+import shutil
+
+_mod = None
+_tried = False
+
+_NOSPACE_ROOT = "/tmp/asfp8_build"
+
+
+def _nospace_torch_lib():
+    import torch.utils.cpp_extension as cpp
+    real = cpp.TORCH_LIB_PATH
+    if " " not in real:
+        return real
+    os.makedirs(_NOSPACE_ROOT, exist_ok=True)
+    link = os.path.join(_NOSPACE_ROOT, "torchlib")
+    try:
+        if os.path.islink(link):
+            os.unlink(link)
+        os.symlink(real, link)
+    except OSError:
+        return real
+    return link
+
+
+def module():
+    global _mod, _tried
+    if _tried:
+        return _mod
+    _tried = True
+
+    if os.environ.get("ASFP8_INT4_EXT") != "1":
+        return None
+    if shutil.which("xcrun") is None:
+        print("[int4_ext] no Metal toolchain (xcrun); int4-native disabled.")
+        return None
+
+    if shutil.which("ninja") is None:
+        try:
+            import ninja
+            bin_dir = getattr(ninja, "BIN_DIR", None) or os.path.join(
+                os.path.dirname(ninja.__file__), "data", "bin"
+            )
+            if os.path.isdir(bin_dir):
+                os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+        except Exception as e:
+            print(f"[int4_ext] ninja not importable ({e!r}); int4-native disabled.")
+            return None
+    if shutil.which("ninja") is None:
+        print("[int4_ext] ninja binary not found on PATH; int4-native disabled.")
+        return None
+
+    try:
+        import torch.utils.cpp_extension as cpp
+        from torch.utils.cpp_extension import load as cpp_load
+    except Exception as e:
+        print(f"[int4_ext] cpp_extension unavailable: {e!r}")
+        return None
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    src = os.path.join(here, "int4_matmul2d.mm")
+    build_dir = os.path.join(_NOSPACE_ROOT, "int4_ext")
+    os.makedirs(build_dir, exist_ok=True)
+
+    saved = cpp.TORCH_LIB_PATH
+    try:
+        cpp.TORCH_LIB_PATH = _nospace_torch_lib()
+        _mod = cpp_load(
+            name="asfp8_int4_matmul2d",
+            sources=[src],
+            extra_cflags=["-std=c++17", "-ObjC++"],
+            extra_ldflags=["-framework", "Metal", "-framework", "Foundation"],
+            build_directory=build_dir,
+            verbose=False,
+        )
+    except Exception as e:
+        print(f"[int4_ext] build failed; int4-native disabled: {e!r}")
+        _mod = None
+    finally:
+        cpp.TORCH_LIB_PATH = saved
+    return _mod
+
+
+def available():
+    return module() is not None

--- a/_patches/int4_linear_mps.py
+++ b/_patches/int4_linear_mps.py
@@ -1,0 +1,137 @@
+"""Fix: ConvRot W4A4 (int4) models crawl on MPS — ~3.7x slower per Linear than int8.
+
+comfy-kitchen (>=0.2.13) has no Metal backend, so its registry (cuda -> triton ->
+eager) routes every ConvRot W4A4 Linear on MPS to the *eager emulation*
+(`backends/eager/convrot_w4a4.py:convrot_w4a4_linear`), which per layer per step:
+
+  1. Hadamard-rotates the activation (fine — cheap grouped GEMM),
+  2. quantizes + packs the activation to int4 (absmax/div/round/clamp/pack),
+  3. then immediately UNPACKS BOTH operands back to the float compute dtype and
+     runs a plain float GEMM — materializing the full [N, K] bf16 weight and
+     paying the activation quantization error for nothing.
+
+Step 2 only exists to feed a real int4 MMA, which never happens off-CUDA. Skipping
+it is faster AND more accurate (weight-only W4A16 instead of fake W4A4).
+
+The rotation trick: the stored weight is rotated (W_rot = W @ H per 256-group,
+H orthogonal), so `x_rot @ W_rot^T = x H H^T W^T = x @ W^T`. We therefore keep the
+weight in its rotated basis (no per-call un-rotation) and rotate only the
+activation — a small grouped GEMM — then run MPS's native bf16 GEMM.
+
+The nibble unpack also avoids eager's int32/where round-trip: int8 arithmetic
+shifts sign-extend, so lo = (p << 4) >> 4 and hi = p >> 4 decode signed nibbles
+in two kernels instead of four (measured ~35% faster unpack on M5).
+
+Hook point: `comfy_kitchen.tensor.convrot_w4a4.convrot_w4a4_linear` (the public
+dispatcher). Its layout-op handlers resolve it as a module global at call time,
+so replacing the module attribute covers both plain comfy checkpoints and the
+ComfyUI-INT4-Fast custom node. Non-MPS inputs fall through to the original.
+No-op when comfy-kitchen is too old to have the ConvRot W4A4 layout.
+"""
+
+import sys
+
+import torch
+
+TAG = "[AppleSilicon-FP8/int4_linear]"
+
+_installed = False
+_patched = False
+_orig = None
+_kernel = None
+_kernel_tried = False
+
+
+def _load_kernel():
+    """W4A8 Metal kernel (opt-in ASFP8_INT4_EXT=1): int8 act x packed-int4 weight
+    -> int32 MMA on the M5 tensor units, per-row dequant + bias fused into the
+    store epilogue. Weights stay packed in device memory (half of int8's traffic).
+    Probe-verified: MPP int4b nibble order == kitchen packing (bit-exact)."""
+    global _kernel, _kernel_tried
+    if _kernel_tried:
+        return _kernel
+    _kernel_tried = True
+    try:
+        from .int4_ext import loader
+        _kernel = loader.module()
+    except Exception as e:
+        print(f"{TAG} int4 kernel unavailable ({e!r}); using W4A16 fast path.")
+        _kernel = None
+    if _kernel is not None:
+        print(f"{TAG} W4A8 fused Metal kernel active for ConvRot int4 layers.")
+    return _kernel
+
+
+def _w4a8_kernel_linear(x_rot_2d, qweight, wscales, bias, kernel):
+    absmax = x_rot_2d.float().abs().amax(dim=-1).clamp(min=1e-10)
+    x_scale = absmax / 127.0
+    qx = torch.round(x_rot_2d.float() / x_scale.unsqueeze(-1)).clamp(-127, 127).to(torch.int8)
+    b = bias.to(torch.bfloat16).contiguous() if bias is not None else None
+    y = kernel.i8i4_linear_fused_nt(
+        qx.contiguous(), qweight.contiguous(),
+        x_scale.contiguous(), wscales.float().contiguous(), b,
+        x_rot_2d.shape[-1], qweight.shape[0])
+    return y if x_rot_2d.dtype == torch.bfloat16 else y.to(x_rot_2d.dtype)
+
+
+def _unpack_int4_signed_fast(packed: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Decode row-major packed signed nibbles (low = even column) via arithmetic shifts."""
+    lo = (packed << 4) >> 4
+    hi = packed >> 4
+    out = torch.stack((lo, hi), dim=-1).to(dtype)
+    return out.reshape(*packed.shape[:-1], packed.shape[-1] * 2)
+
+
+def _w4a16_linear_mps(x, qweight, wscales, bias, convrot_groupsize, mod):
+    orig_shape = x.shape
+    x2d = x.reshape(-1, orig_shape[-1])
+    h = mod._build_hadamard(convrot_groupsize, device=x2d.device, dtype=x2d.dtype)
+    x_rot = mod._rotate_activation(x2d, h, convrot_groupsize)
+
+    kernel = _load_kernel()
+    if kernel is not None:
+        y = _w4a8_kernel_linear(x_rot, qweight, wscales, bias, kernel)
+        return y.reshape(*orig_shape[:-1], qweight.shape[0])
+
+    w = _unpack_int4_signed_fast(qweight, x2d.dtype)
+    w = w * wscales.to(device=w.device, dtype=x2d.dtype).reshape(-1, 1)
+    b = bias.to(dtype=x2d.dtype) if bias is not None else None
+    y = torch.nn.functional.linear(x_rot, w, b)
+    return y.reshape(*orig_shape[:-1], qweight.shape[0])
+
+
+def install():
+    global _installed, _patched, _orig
+    if _installed:
+        return
+    _installed = True
+
+    if not (hasattr(torch, "mps") and torch.backends.mps.is_available()):
+        return
+
+    try:
+        import comfy_kitchen.tensor.convrot_w4a4 as ck_convrot
+        import comfy_kitchen.backends.eager.convrot_w4a4 as ck_eager
+    except ImportError:
+        print(f"{TAG} comfy-kitchen has no ConvRot W4A4 layout (too old) — skipping.")
+        return
+
+    _orig = ck_convrot.convrot_w4a4_linear
+
+    def convrot_w4a4_linear_mps(x, qweight, wscales, bias=None, convrot_groupsize=256,
+                                quant_group_size=64, linear_dtype="int4"):
+        if x.device.type != "mps":
+            return _orig(x, qweight, wscales, bias=bias, convrot_groupsize=convrot_groupsize,
+                         quant_group_size=quant_group_size, linear_dtype=linear_dtype)
+        return _w4a16_linear_mps(x, qweight, wscales, bias, convrot_groupsize, ck_eager)
+
+    ck_convrot.convrot_w4a4_linear = convrot_w4a4_linear_mps
+    _patched = True
+    print(f"{TAG} ConvRot W4A4 (int4) Linear on MPS -> W4A16 rotated-basis fast path.")
+
+
+def uninstall():
+    global _patched
+    if _patched and _orig is not None:
+        sys.modules["comfy_kitchen.tensor.convrot_w4a4"].convrot_w4a4_linear = _orig
+        _patched = False

--- a/_patches/int4_linear_mps.py
+++ b/_patches/int4_linear_mps.py
@@ -54,6 +54,11 @@ def _load_kernel():
     try:
         from .int4_ext import loader
         _kernel = loader.module()
+        if _kernel is not None:
+            # Force the Metal 4.1 / int4b shader to compile NOW so an unsupported
+            # GPU/SDK raises here (caught -> W4A16 fallback) instead of aborting a
+            # render at the first kernel dispatch.
+            _kernel.warmup()
     except Exception as e:
         print(f"{TAG} int4 kernel unavailable ({e!r}); using W4A16 fast path.")
         _kernel = None
@@ -66,7 +71,7 @@ def _w4a8_kernel_linear(x_rot_2d, qweight, wscales, bias, kernel):
     absmax = x_rot_2d.float().abs().amax(dim=-1).clamp(min=1e-10)
     x_scale = absmax / 127.0
     qx = torch.round(x_rot_2d.float() / x_scale.unsqueeze(-1)).clamp(-127, 127).to(torch.int8)
-    b = bias.to(torch.bfloat16).contiguous() if bias is not None else None
+    b = bias.to(device=x_rot_2d.device, dtype=torch.bfloat16).contiguous() if bias is not None else None
     y = kernel.i8i4_linear_fused_nt(
         qx.contiguous(), qweight.contiguous(),
         x_scale.contiguous(), wscales.float().contiguous(), b,
@@ -90,12 +95,16 @@ def _w4a16_linear_mps(x, qweight, wscales, bias, convrot_groupsize, mod):
 
     kernel = _load_kernel()
     if kernel is not None:
-        y = _w4a8_kernel_linear(x_rot, qweight, wscales, bias, kernel)
-        return y.reshape(*orig_shape[:-1], qweight.shape[0])
+        try:
+            y = _w4a8_kernel_linear(x_rot, qweight, wscales, bias, kernel)
+            return y.reshape(*orig_shape[:-1], qweight.shape[0])
+        except Exception as e:
+            # Never abort a render on a kernel hiccup — drop to the W4A16 unpack path.
+            print(f"{TAG} W4A8 kernel call failed ({e!r}); falling back to W4A16.")
 
     w = _unpack_int4_signed_fast(qweight, x2d.dtype)
     w = w * wscales.to(device=w.device, dtype=x2d.dtype).reshape(-1, 1)
-    b = bias.to(dtype=x2d.dtype) if bias is not None else None
+    b = bias.to(device=x2d.device, dtype=x2d.dtype) if bias is not None else None
     y = torch.nn.functional.linear(x_rot, w, b)
     return y.reshape(*orig_shape[:-1], qweight.shape[0])
 

--- a/_patches/int8_ext/int8_gemm.mm
+++ b/_patches/int8_ext/int8_gemm.mm
@@ -145,6 +145,39 @@ inline void nax_frag_store_dequant_act(const thread int32_t *src, device OutT *d
   }
 }
 
+// ── Fragment store: fused SwiGLU/GEGLU gate ─────────────────────
+// H[m,n] = act(gate[m,n]*rs_g[m] + bias_g[n]) * (up[m,n]*rs_u[m] + bias_u[n]),
+// gate/up being two int32 register accumulators for the SAME (m,n) tile from two
+// GEMMs (B=Wg, B=Wu). act: 1=silu (SwiGLU), 2=gelu-tanh (GEGLU). GELU via the exp
+// identity (precise::tanh is low-accuracy; see nax_frag_store_dequant_act).
+template <typename OutT>
+inline void nax_frag_store_swiglu(const thread int32_t *gate, const thread int32_t *up,
+                                  device OutT *dst, int ld, short2 sc, short off_m, short off_n,
+                                  uint M, uint N, uint m_base, uint n_base,
+                                  const device float *rs_g, const device float *rs_u,
+                                  const device OutT *bias_g, const device OutT *bias_u,
+                                  bool hb_g, bool hb_u, uint act) {
+  for (short i = 0; i < 2; i++) {
+    for (short j = 0; j < kElemCols; j++) {
+      uint mi = m_base + sc.y + off_m + i * kElemRowsJump;
+      uint ni = n_base + sc.x + off_n + j;
+      if (mi < M && ni < N) {
+        short e = i * kElemCols + j;
+        OutT g = OutT(float(gate[e]) * rs_g[mi]); if (hb_g) g = g + bias_g[ni];
+        OutT u = OutT(float(up[e])   * rs_u[mi]); if (hb_u) u = u + bias_u[ni];
+        float gf = float(g);
+        if (act == 1u) {                              // SwiGLU
+          gf = gf / (1.0f + precise::exp(-gf));
+        } else if (act == 2u) {                       // GEGLU-tanh (via exp identity)
+          float c2 = 1.5957691216057308f;             // 2*sqrt(2/pi)
+          gf = gf / (1.0f + precise::exp(-c2 * (gf + 0.044715f * gf * gf * gf)));
+        }
+        dst[(sc.y + off_m + i * kElemRowsJump) * ld + (sc.x + off_n + j)] = OutT(gf * float(u));
+      }
+    }
+  }
+}
+
 // ── Raw INT32 GEMM compute (B is [N, K], transpose_b=true) ──────
 // Fills c_frags (int32 register accumulators) for this simdgroup's tile
 // of C[M,N] = A[M,K] × B[N,K]^T, and reports the tile origin (m_base,
@@ -422,6 +455,68 @@ kernel void int8_matmul_fused_small(
                                            m_base, n_base, row_scale, bias,
                                            has_bias != 0u, act);
 }
+
+// ── Fused SwiGLU/GEGLU gate entry points, bf16 output ───────────
+// Runs the templated GEMM body twice for the SAME output tile (B=Bg, then
+// B=Bu) into two int32 register accumulators, then one combined gated store:
+// D = act(A@Bg^T*rs_g + bias_g) * (A@Bu^T*rs_u + bias_u).
+kernel void int8_matmul_swiglu(
+    const device int8_t *A [[buffer(0)]], const device int8_t *Bg [[buffer(1)]],
+    const device int8_t *Bu [[buffer(2)]], device bfloat *D [[buffer(3)]],
+    constant uint &M [[buffer(4)]], constant uint &N [[buffer(5)]], constant uint &K [[buffer(6)]],
+    constant uint &swizzle_log [[buffer(7)]], constant uint &tiles_m [[buffer(8)]],
+    constant uint &tiles_n [[buffer(9)]], const device float *rs_g [[buffer(10)]],
+    const device float *rs_u [[buffer(11)]], const device bfloat *bias_g [[buffer(12)]],
+    const device bfloat *bias_u [[buffer(13)]], constant uint &hb_g [[buffer(14)]],
+    constant uint &hb_u [[buffer(15)]], constant uint &act [[buffer(16)]],
+    uint2 tgid [[threadgroup_position_in_grid]], uint sgid [[simdgroup_index_in_threadgroup]],
+    uint lid [[thread_index_in_simdgroup]]) {
+  constexpr short TM = ((128 / 4) / 16), TN = ((128 / 4) / 16);
+  int32_t cg[TM * TN][kElemsPerFrag];
+  short2 sc; uint m_base, n_base;
+  if (!w8a8_gemm_compute<128, 128, 512, 32, 4, 4>(A, Bg, cg, sc, m_base, n_base, M, N, K,
+        swizzle_log, tiles_m, tiles_n, tgid, sgid, lid)) return;
+  int32_t cu[TM * TN][kElemsPerFrag];
+  short2 sc2; uint mb2, nb2;
+  bool ok2 = w8a8_gemm_compute<128, 128, 512, 32, 4, 4>(A, Bu, cu, sc2, mb2, nb2, M, N, K,
+        swizzle_log, tiles_m, tiles_n, tgid, sgid, lid);
+  if (!ok2 || sc2.x != sc.x || sc2.y != sc.y || mb2 != m_base || nb2 != n_base) return;
+  device bfloat *Dp = D + m_base * N + n_base;
+  for (short mm = 0; mm < TM; mm++)
+    for (short nn = 0; nn < TN; nn++)
+      nax_frag_store_swiglu<bfloat>(cg[mm * TN + nn], cu[mm * TN + nn], Dp, int(N), sc,
+        short(mm * 16), short(nn * 16), M, N, m_base, n_base, rs_g, rs_u, bias_g, bias_u,
+        hb_g != 0u, hb_u != 0u, act);
+}
+
+kernel void int8_matmul_swiglu_small(
+    const device int8_t *A [[buffer(0)]], const device int8_t *Bg [[buffer(1)]],
+    const device int8_t *Bu [[buffer(2)]], device bfloat *D [[buffer(3)]],
+    constant uint &M [[buffer(4)]], constant uint &N [[buffer(5)]], constant uint &K [[buffer(6)]],
+    constant uint &swizzle_log [[buffer(7)]], constant uint &tiles_m [[buffer(8)]],
+    constant uint &tiles_n [[buffer(9)]], const device float *rs_g [[buffer(10)]],
+    const device float *rs_u [[buffer(11)]], const device bfloat *bias_g [[buffer(12)]],
+    const device bfloat *bias_u [[buffer(13)]], constant uint &hb_g [[buffer(14)]],
+    constant uint &hb_u [[buffer(15)]], constant uint &act [[buffer(16)]],
+    uint2 tgid [[threadgroup_position_in_grid]], uint sgid [[simdgroup_index_in_threadgroup]],
+    uint lid [[thread_index_in_simdgroup]]) {
+  constexpr short TM = ((32 / 1) / 16), TN = ((128 / 4) / 16);
+  int32_t cg[TM * TN][kElemsPerFrag];
+  short2 sc; uint m_base, n_base;
+  if (!w8a8_gemm_compute<32, 128, 512, 32, 1, 4>(A, Bg, cg, sc, m_base, n_base, M, N, K,
+        swizzle_log, tiles_m, tiles_n, tgid, sgid, lid)) return;
+  int32_t cu[TM * TN][kElemsPerFrag];
+  short2 sc2; uint mb2, nb2;
+  bool ok2 = w8a8_gemm_compute<32, 128, 512, 32, 1, 4>(A, Bu, cu, sc2, mb2, nb2, M, N, K,
+        swizzle_log, tiles_m, tiles_n, tgid, sgid, lid);
+  if (!ok2 || sc2.x != sc.x || sc2.y != sc.y || mb2 != m_base || nb2 != n_base) return;
+  device bfloat *Dp = D + m_base * N + n_base;
+  for (short mm = 0; mm < TM; mm++)
+    for (short nn = 0; nn < TN; nn++)
+      nax_frag_store_swiglu<bfloat>(cg[mm * TN + nn], cu[mm * TN + nn], Dp, int(N), sc,
+        short(mm * 16), short(nn * 16), M, N, m_base, n_base, rs_g, rs_u, bias_g, bias_u,
+        hb_g != 0u, hb_u != 0u, act);
+}
 )MTL";
 
 // ── Host: pipeline cache ─────────────────────────────────────────
@@ -429,6 +524,8 @@ static id<MTLComputePipelineState> g_pso_large = nil;
 static id<MTLComputePipelineState> g_pso_small = nil;
 static id<MTLComputePipelineState> g_pso_fused = nil;
 static id<MTLComputePipelineState> g_pso_fused_small = nil;
+static id<MTLComputePipelineState> g_pso_swiglu = nil;
+static id<MTLComputePipelineState> g_pso_swiglu_small = nil;
 static id<MTLLibrary> g_lib = nil;
 static std::string g_compile_error;
 
@@ -476,6 +573,15 @@ static id<MTLComputePipelineState> pso_for_fused(bool small) {
   id<MTLComputePipelineState> pso =
       pso_for_name(small ? @"int8_matmul_fused_small" : @"int8_matmul_fused");
   if (small) g_pso_fused_small = pso; else g_pso_fused = pso;
+  return pso;
+}
+
+static id<MTLComputePipelineState> pso_for_swiglu(bool small) {
+  if (small && g_pso_swiglu_small) return g_pso_swiglu_small;
+  if (!small && g_pso_swiglu) return g_pso_swiglu;
+  id<MTLComputePipelineState> pso =
+      pso_for_name(small ? @"int8_matmul_swiglu_small" : @"int8_matmul_swiglu");
+  if (small) g_pso_swiglu_small = pso; else g_pso_swiglu = pso;
   return pso;
 }
 
@@ -628,6 +734,95 @@ torch::Tensor i8_matmul2d_nt_fused(torch::Tensor a_i8, torch::Tensor b_i8,
   return D;
 }
 
+// Fused gated: D[M,N] bf16 = act(A@Bg^T*rs_g[M] + bias_g[N]) * (A@Bu^T*rs_u[M] +
+// bias_u[N]). One launch, two register accumulators, two bf16 intermediates that
+// never leave registers. act: 1=silu (SwiGLU), 2=gelu-tanh (GEGLU).
+torch::Tensor i8_matmul2d_nt_swiglu(torch::Tensor a_i8, torch::Tensor bg_i8,
+                                    torch::Tensor bu_i8, torch::Tensor row_scale_gate,
+                                    torch::Tensor row_scale_up,
+                                    c10::optional<torch::Tensor> bias_gate,
+                                    c10::optional<torch::Tensor> bias_up,
+                                    int64_t act) {
+  TORCH_CHECK(a_i8.is_mps() && bg_i8.is_mps() && bu_i8.is_mps(), "swiglu: inputs must be MPS");
+  TORCH_CHECK(a_i8.scalar_type() == torch::kChar && bg_i8.scalar_type() == torch::kChar
+              && bu_i8.scalar_type() == torch::kChar, "swiglu: A/Bg/Bu must be int8");
+  TORCH_CHECK(a_i8.dim() == 2 && bg_i8.dim() == 2 && bu_i8.dim() == 2, "swiglu: A/Bg/Bu must be 2D");
+  TORCH_CHECK(bg_i8.sizes() == bu_i8.sizes(), "swiglu: Bg and Bu must have identical [N,K]");
+  TORCH_CHECK(a_i8.size(1) == bg_i8.size(1), "swiglu: K mismatch A vs Bg/Bu");
+  TORCH_CHECK(a_i8.is_contiguous() && bg_i8.is_contiguous() && bu_i8.is_contiguous(),
+              "swiglu: A/Bg/Bu must be contiguous");
+  const int64_t Mll = a_i8.size(0), Nll = bg_i8.size(0);
+  TORCH_CHECK(row_scale_gate.is_contiguous() && row_scale_up.is_contiguous()
+              && row_scale_gate.scalar_type() == torch::kFloat
+              && row_scale_up.scalar_type() == torch::kFloat
+              && row_scale_gate.numel() == Mll && row_scale_up.numel() == Mll,
+              "swiglu: row scales must be contiguous fp32 of length M");
+
+  const int M = (int)Mll;
+  const int K = (int)a_i8.size(1);
+  const int N = (int)Nll;
+  auto D = torch::empty({(long)M, (long)N}, a_i8.options().dtype(torch::kBFloat16));
+
+  const bool hb_g = bias_gate.has_value();
+  const bool hb_u = bias_up.has_value();
+  torch::Tensor bg = hb_g ? bias_gate.value().to(torch::kBFloat16).contiguous()
+                          : torch::zeros({1}, a_i8.options().dtype(torch::kBFloat16));
+  torch::Tensor bu = hb_u ? bias_up.value().to(torch::kBFloat16).contiguous()
+                          : torch::zeros({1}, a_i8.options().dtype(torch::kBFloat16));
+  if (hb_g) TORCH_CHECK(bg.is_mps() && bg.numel() == N, "swiglu: bias_gate must be N MPS elements");
+  if (hb_u) TORCH_CHECK(bu.is_mps() && bu.numel() == N, "swiglu: bias_up must be N MPS elements");
+
+  Geom g = geom_for(M, N);
+  id<MTLComputePipelineState> pso = pso_for_swiglu(g.small);
+  MPSStream* stream = getCurrentMPSStream();
+  id<MTLBuffer> aBuf = __builtin_bit_cast(id<MTLBuffer>, a_i8.storage().data());
+  id<MTLBuffer> bgBuf = __builtin_bit_cast(id<MTLBuffer>, bg_i8.storage().data());
+  id<MTLBuffer> buBuf = __builtin_bit_cast(id<MTLBuffer>, bu_i8.storage().data());
+  id<MTLBuffer> dBuf = __builtin_bit_cast(id<MTLBuffer>, D.storage().data());
+  id<MTLBuffer> sgBuf = __builtin_bit_cast(id<MTLBuffer>, row_scale_gate.storage().data());
+  id<MTLBuffer> suBuf = __builtin_bit_cast(id<MTLBuffer>, row_scale_up.storage().data());
+  id<MTLBuffer> bgBiasBuf = __builtin_bit_cast(id<MTLBuffer>, bg.storage().data());
+  id<MTLBuffer> buBiasBuf = __builtin_bit_cast(id<MTLBuffer>, bu.storage().data());
+  const NSUInteger aOff = a_i8.storage_offset() * a_i8.element_size();
+  const NSUInteger bgOff = bg_i8.storage_offset() * bg_i8.element_size();
+  const NSUInteger buOff = bu_i8.storage_offset() * bu_i8.element_size();
+  const NSUInteger dOff = D.storage_offset() * D.element_size();
+  const NSUInteger sgOff = row_scale_gate.storage_offset() * row_scale_gate.element_size();
+  const NSUInteger suOff = row_scale_up.storage_offset() * row_scale_up.element_size();
+  const NSUInteger bgBiasOff = bg.storage_offset() * bg.element_size();
+  const NSUInteger buBiasOff = bu.storage_offset() * bu.element_size();
+  uint Mu = (uint)M, Nu = (uint)N, Ku = (uint)K;
+  uint swizzle_log = g.swizzle_log, tiles_m = g.tiles_m, tiles_n = g.tiles_n;
+  uint hb_g_u = hb_g ? 1u : 0u, hb_u_u = hb_u ? 1u : 0u, act_u = (uint)act;
+
+  dispatch_sync(stream->queue(), ^(){
+    @autoreleasepool {
+      id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+      [enc setComputePipelineState:pso];
+      [enc setBuffer:aBuf offset:aOff atIndex:0];
+      [enc setBuffer:bgBuf offset:bgOff atIndex:1];
+      [enc setBuffer:buBuf offset:buOff atIndex:2];
+      [enc setBuffer:dBuf offset:dOff atIndex:3];
+      [enc setBytes:&Mu length:sizeof(uint) atIndex:4];
+      [enc setBytes:&Nu length:sizeof(uint) atIndex:5];
+      [enc setBytes:&Ku length:sizeof(uint) atIndex:6];
+      [enc setBytes:&swizzle_log length:sizeof(uint) atIndex:7];
+      [enc setBytes:&tiles_m length:sizeof(uint) atIndex:8];
+      [enc setBytes:&tiles_n length:sizeof(uint) atIndex:9];
+      [enc setBuffer:sgBuf offset:sgOff atIndex:10];
+      [enc setBuffer:suBuf offset:suOff atIndex:11];
+      [enc setBuffer:bgBiasBuf offset:bgBiasOff atIndex:12];
+      [enc setBuffer:buBiasBuf offset:buBiasOff atIndex:13];
+      [enc setBytes:&hb_g_u length:sizeof(uint) atIndex:14];
+      [enc setBytes:&hb_u_u length:sizeof(uint) atIndex:15];
+      [enc setBytes:&act_u length:sizeof(uint) atIndex:16];
+      [enc dispatchThreadgroups:MTLSizeMake(g.grid_x, g.grid_y, 1)
+          threadsPerThreadgroup:MTLSizeMake(g.THREADS, 1, 1)];
+    }
+  });
+  return D;
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("i8_matmul2d_nt", &i8_matmul2d_nt,
         "Bit-exact NT int8 matmul: C[M,N] int32 = A[M,K] @ B[N,K]^T on MPS");
@@ -637,9 +832,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         pybind11::arg("a_i8"), pybind11::arg("b_i8"), pybind11::arg("row_scale"),
         pybind11::arg("bias") = c10::optional<torch::Tensor>(),
         pybind11::arg("act") = 0);
+  m.def("i8_matmul2d_nt_swiglu", &i8_matmul2d_nt_swiglu,
+        "Fused gated int8 matmul: D[M,N] bf16 = act(A@Bg^T*rsg+bg) * (A@Bu^T*rsu+bu); "
+        "act 1=silu (SwiGLU), 2=gelu-tanh (GEGLU)",
+        pybind11::arg("a_i8"), pybind11::arg("bg_i8"), pybind11::arg("bu_i8"),
+        pybind11::arg("row_scale_gate"), pybind11::arg("row_scale_up"),
+        pybind11::arg("bias_gate") = c10::optional<torch::Tensor>(),
+        pybind11::arg("bias_up") = c10::optional<torch::Tensor>(),
+        pybind11::arg("act") = 1);
   m.def("warmup", []() {
         pso_for(false); pso_for(true);
         pso_for_fused(false); pso_for_fused(true);
+        pso_for_swiglu(false); pso_for_swiglu(true);
         return true;
       },
       "compile + build pipelines");

--- a/_patches/int8_ext/int8_gemm.mm
+++ b/_patches/int8_ext/int8_gemm.mm
@@ -678,6 +678,10 @@ torch::Tensor i8_matmul2d_nt_fused(torch::Tensor a_i8, torch::Tensor b_i8,
   TORCH_CHECK(row_scale.scalar_type() == torch::kFloat && row_scale.is_contiguous(),
               "row_scale must be contiguous float32");
   TORCH_CHECK(row_scale.numel() == a_i8.size(0), "row_scale must have M elements");
+  // Defense-in-depth: the store epilogue only branches on act 1 (silu) / 2 (gelu-tanh);
+  // act 0 means "none". Any other value would silently emit un-activated output, so reject
+  // it here (act=3 gelu-erf was dropped — Metal `erf` does not compile under 4.1).
+  TORCH_CHECK(act >= 0 && act <= 2, "fused: act must be 0(none)/1(silu)/2(gelu-tanh)");
 
   const int M = (int)a_i8.size(0);
   const int K = (int)a_i8.size(1);
@@ -771,6 +775,9 @@ torch::Tensor i8_matmul2d_nt_swiglu(torch::Tensor a_i8, torch::Tensor bg_i8,
                           : torch::zeros({1}, a_i8.options().dtype(torch::kBFloat16));
   if (hb_g) TORCH_CHECK(bg.is_mps() && bg.numel() == N, "swiglu: bias_gate must be N MPS elements");
   if (hb_u) TORCH_CHECK(bu.is_mps() && bu.numel() == N, "swiglu: bias_up must be N MPS elements");
+  // Defense-in-depth: the gated store only branches on act 1 (SwiGLU) / 2 (GEGLU-tanh);
+  // act 0 / anything else would gate by the raw linear value (un-activated), so reject it.
+  TORCH_CHECK(act == 1 || act == 2, "swiglu: act must be 1(silu) or 2(gelu-tanh)");
 
   Geom g = geom_for(M, N);
   id<MTLComputePipelineState> pso = pso_for_swiglu(g.small);

--- a/_patches/int8_ext/int8_gemm.mm
+++ b/_patches/int8_ext/int8_gemm.mm
@@ -108,6 +108,43 @@ inline void nax_frag_store_dequant(const thread int32_t *src, device OutT *dst,
   }
 }
 
+// ── Fragment store: fused dequant + optional bias + activation ──
+// P0 verdict (M5 Max / macOS 27 / Metal 4.1): precise::exp/precise::tanh compile;
+// `erf`/`metal::erf` do NOT -> act=3 (gelu-erf) is removed. Supported act enum:
+//   0=none, 1=silu (x*sigmoid(x)), 2=gelu-tanh (F.gelu approximate='tanh').
+// Activation is applied AFTER rescale+bias (FFN convention), in fp32 on the
+// bf16-rounded post-bias value, then rounded back to OutT.
+template <typename OutT>
+inline void nax_frag_store_dequant_act(const thread int32_t *src, device OutT *dst,
+                                       int ld, short2 sc, short off_m, short off_n,
+                                       uint M, uint N, uint m_base, uint n_base,
+                                       const device float *row_scale,
+                                       const device OutT *bias, bool has_bias, uint act) {
+  for (short i = 0; i < 2; i++) {
+    for (short j = 0; j < kElemCols; j++) {
+      uint mi = m_base + sc.y + off_m + i * kElemRowsJump;
+      uint ni = n_base + sc.x + off_n + j;
+      if (mi < M && ni < N) {
+        float acc = float(src[i * kElemCols + j]) * row_scale[mi];
+        OutT r = OutT(acc);
+        if (has_bias) { r = r + bias[ni]; }
+        float y = float(r);                 // promote the bf16 linear output to fp32
+        if (act == 1u) {                    // SiLU: x * sigmoid(x)
+          y = y / (1.0f + precise::exp(-y));
+        } else if (act == 2u) {             // GELU tanh-approx (F.gelu approximate='tanh')
+          // tanh(z)=2*sigmoid(2z)-1 => 0.5*x*(1+tanh(z)) == x*sigmoid(2z)
+          //  = x / (1 + exp(-2z)).  Metal precise::tanh is low-accuracy (~160 ulp
+          // off torch), but precise::exp matches torch (silu is bit-exact to 1 ulp),
+          // so route GELU-tanh through exp.  z = sqrt(2/pi)*(x + 0.044715 x^3).
+          float c2 = 1.5957691216057308f;   // 2*sqrt(2/pi)
+          y = y / (1.0f + precise::exp(-c2 * (y + 0.044715f * y * y * y)));
+        }
+        dst[(sc.y + off_m + i * kElemRowsJump) * ld + (sc.x + off_n + j)] = OutT(y);
+      }
+    }
+  }
+}
+
 // ── Raw INT32 GEMM compute (B is [N, K], transpose_b=true) ──────
 // Fills c_frags (int32 register accumulators) for this simdgroup's tile
 // of C[M,N] = A[M,K] × B[N,K]^T, and reports the tile origin (m_base,
@@ -323,6 +360,7 @@ kernel void int8_matmul_fused(
     const device float *row_scale [[buffer(9)]],
     const device bfloat *bias [[buffer(10)]],
     constant uint &has_bias [[buffer(11)]],
+    constant uint &act [[buffer(12)]],
     uint2 tgid [[threadgroup_position_in_grid]],
     uint sgid [[simdgroup_index_in_threadgroup]],
     uint lid [[thread_index_in_simdgroup]]) {
@@ -337,10 +375,16 @@ kernel void int8_matmul_fused(
   device bfloat *Dp = D + m_base * N + n_base;
   for (short mm = 0; mm < TM; mm++)
     for (short nn = 0; nn < TN; nn++)
-      nax_frag_store_dequant<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
-                                     short(mm * 16), short(nn * 16), M, N,
-                                     m_base, n_base, row_scale, bias,
-                                     has_bias != 0u);
+      if (act == 0u)
+        nax_frag_store_dequant<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
+                                       short(mm * 16), short(nn * 16), M, N,
+                                       m_base, n_base, row_scale, bias,
+                                       has_bias != 0u);
+      else
+        nax_frag_store_dequant_act<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
+                                           short(mm * 16), short(nn * 16), M, N,
+                                           m_base, n_base, row_scale, bias,
+                                           has_bias != 0u, act);
 }
 
 kernel void int8_matmul_fused_small(
@@ -352,6 +396,7 @@ kernel void int8_matmul_fused_small(
     const device float *row_scale [[buffer(9)]],
     const device bfloat *bias [[buffer(10)]],
     constant uint &has_bias [[buffer(11)]],
+    constant uint &act [[buffer(12)]],
     uint2 tgid [[threadgroup_position_in_grid]],
     uint sgid [[simdgroup_index_in_threadgroup]],
     uint lid [[thread_index_in_simdgroup]]) {
@@ -366,10 +411,16 @@ kernel void int8_matmul_fused_small(
   device bfloat *Dp = D + m_base * N + n_base;
   for (short mm = 0; mm < TM; mm++)
     for (short nn = 0; nn < TN; nn++)
-      nax_frag_store_dequant<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
-                                     short(mm * 16), short(nn * 16), M, N,
-                                     m_base, n_base, row_scale, bias,
-                                     has_bias != 0u);
+      if (act == 0u)
+        nax_frag_store_dequant<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
+                                       short(mm * 16), short(nn * 16), M, N,
+                                       m_base, n_base, row_scale, bias,
+                                       has_bias != 0u);
+      else
+        nax_frag_store_dequant_act<bfloat>(c_frags[mm * TN + nn], Dp, int(N), sc,
+                                           short(mm * 16), short(nn * 16), M, N,
+                                           m_base, n_base, row_scale, bias,
+                                           has_bias != 0u, act);
 }
 )MTL";
 
@@ -509,7 +560,8 @@ torch::Tensor i8_matmul2d_nt(torch::Tensor a_i8, torch::Tensor b_i8) {
 // written to global memory — this is the per-call epilogue we skip.
 torch::Tensor i8_matmul2d_nt_fused(torch::Tensor a_i8, torch::Tensor b_i8,
                                    torch::Tensor row_scale,
-                                   c10::optional<torch::Tensor> bias_opt) {
+                                   c10::optional<torch::Tensor> bias_opt,
+                                   int64_t act) {
   TORCH_CHECK(a_i8.is_mps() && b_i8.is_mps() && row_scale.is_mps(),
               "inputs must be on mps");
   TORCH_CHECK(a_i8.scalar_type() == torch::kChar && b_i8.scalar_type() == torch::kChar,
@@ -550,6 +602,7 @@ torch::Tensor i8_matmul2d_nt_fused(torch::Tensor a_i8, torch::Tensor b_i8,
   uint Mu = (uint)M, Nu = (uint)N, Ku = (uint)K;
   uint swizzle_log = g.swizzle_log, tiles_m = g.tiles_m, tiles_n = g.tiles_n;
   uint has_bias_u = has_bias ? 1u : 0u;
+  uint act_u = (uint)act;
 
   dispatch_sync(stream->queue(), ^(){
     @autoreleasepool {
@@ -567,6 +620,7 @@ torch::Tensor i8_matmul2d_nt_fused(torch::Tensor a_i8, torch::Tensor b_i8,
       [enc setBuffer:sBuf offset:sOff atIndex:9];
       [enc setBuffer:biasBuf offset:biasOff atIndex:10];
       [enc setBytes:&has_bias_u length:sizeof(uint) atIndex:11];
+      [enc setBytes:&act_u length:sizeof(uint) atIndex:12];
       [enc dispatchThreadgroups:MTLSizeMake(g.grid_x, g.grid_y, 1)
           threadsPerThreadgroup:MTLSizeMake(g.THREADS, 1, 1)];
     }
@@ -578,9 +632,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("i8_matmul2d_nt", &i8_matmul2d_nt,
         "Bit-exact NT int8 matmul: C[M,N] int32 = A[M,K] @ B[N,K]^T on MPS");
   m.def("i8_matmul2d_nt_fused", &i8_matmul2d_nt_fused,
-        "Fused NT int8 matmul: D[M,N] bf16 = (A@B^T)*row_scale[M] + bias[N]",
+        "Fused NT int8 matmul: D[M,N] bf16 = act((A@B^T)*row_scale[M] + bias[N]); "
+        "act 0=none,1=silu,2=gelu-tanh",
         pybind11::arg("a_i8"), pybind11::arg("b_i8"), pybind11::arg("row_scale"),
-        pybind11::arg("bias") = c10::optional<torch::Tensor>());
+        pybind11::arg("bias") = c10::optional<torch::Tensor>(),
+        pybind11::arg("act") = 0);
   m.def("warmup", []() {
         pso_for(false); pso_for(true);
         pso_for_fused(false); pso_for_fused(true);

--- a/_patches/int8_ext/loader.py
+++ b/_patches/int8_ext/loader.py
@@ -1,8 +1,9 @@
 """JIT loader for the bit-exact int8 matmul2d MPS extension.
 
 Builds _patches/int8_ext/int8_gemm.mm via torch.utils.cpp_extension.load (ObjC++,
-Metal 4.1). Opt-in (ASFP8_INT8_EXT=1), guarded, cached; returns None on any failure
-so callers fall back to the fp32/bf16 _int_mm path.
+Metal 4.1). DEFAULT ON where capable (Tier B: M5 / Metal 4.1 + ninja, via the shared
+three-state gate); guarded, cached; returns None on any failure so callers fall back
+to the fp32/bf16 _int_mm path.
 
 Space-in-path workaround (same as fp8_ext): cpp_extension emits torch's lib `-L`
 UNQUOTED, so a space in torch's install path (".../IMPERIAL SPACE/...") breaks the
@@ -42,7 +43,10 @@ def module():
         return _mod
     _tried = True
 
-    if os.environ.get("ASFP8_INT8_EXT") != "1":
+    # DEFAULT ON where capable (Tier B: M5/Metal-4.1 + ninja). Three-state gate:
+    # unset -> on iff tier_b_ready; ASFP8_INT8_EXT=off -> off; =1 -> force the build.
+    from .. import _caps
+    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.tier_b_ready):
         return None
     if shutil.which("xcrun") is None:
         print("[int8_ext] no Metal toolchain (xcrun); int8-native disabled.")

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -104,6 +104,12 @@ def _int8_linear_kernel(
         or weight.device.type != "mps"
         or weight.dtype != torch.int8
     ):
+        if _orig_int8_linear is None:
+            raise RuntimeError(
+                f"{TAG} _int8_linear_kernel fallback needs the original int8_linear, "
+                "but it is None (install() never ran / kernel not built). Call install() "
+                "first or route through the comfy forward, which catches this."
+            )
         return _apply_act(
             _orig_int8_linear(
                 x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize
@@ -173,9 +179,9 @@ def _int8_swiglu_kernel(x, w_gate, w_up, ws_gate, ws_up, bias_gate=None, bias_up
     through the per-branch _int8_linear_kernel path (which handles per-channel scales
     and applies the activation itself). act in {"silu","gelu_tanh"} (no "none").
     """
-    _act_code(act)  # validate (raises on typo)
     if act == "none":
         raise ValueError("_int8_swiglu_kernel requires a real gate activation, not 'none'")
+    _act_code(act)  # validate (raises on typo)
     if w_gate.shape != w_up.shape:
         raise ValueError(
             f"gate/up weights must match: {tuple(w_gate.shape)} vs {tuple(w_up.shape)}"

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -32,10 +32,9 @@ global memory -- bit-identical to the chunked path, ~1.2-1.65x faster per call.
 Everything else (other quant formats, transposed weights, LoRA weight/bias
 functions, non-MPS) falls back to comfy's original forward unchanged.
 
-Opt-in: only active when ``ASFP8_INT8_EXT=1`` (the kernel build flag).
+DEFAULT ON, gated on M5/Metal-4.1 + ninja; ``ASFP8_INT8_EXT=off`` force-disables, ``=1`` forces the build attempt.
 """
 
-import os
 import sys
 
 import torch
@@ -268,7 +267,11 @@ def install():
         return
     if sys.platform != "darwin":
         return
-    if os.environ.get("ASFP8_INT8_EXT") != "1":
+    # DEFAULT ON, gated on Tier B (Metal-4 tensor ops + ninja to build the ObjC++
+    # extension). On unsupported HW the default resolves to OFF so we never attempt a
+    # build; ASFP8_INT8_EXT=off force-disables, =1 forces the build attempt anyway.
+    from . import _caps
+    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.tier_b_ready):
         return
     if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         return

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -164,6 +164,54 @@ def _int8_linear_kernel(
     return result.reshape(*orig_shape[:-1], weight.shape[0])
 
 
+def _int8_swiglu_kernel(x, w_gate, w_up, ws_gate, ws_up, bias_gate=None, bias_up=None,
+                        convrot=False, convrot_groupsize=256, act="silu"):
+    """Fused gated linear: H = act(x@w_gate^T + bias_gate) * (x@w_up^T + bias_up).
+
+    Uses the single-pass fused gate kernel only when both weight scales are scalar
+    (the row-scale precombine ws*x_scale[m] is only valid then); otherwise routes
+    through the per-branch _int8_linear_kernel path (which handles per-channel scales
+    and applies the activation itself). act in {"silu","gelu_tanh"} (no "none").
+    """
+    _act_code(act)  # validate (raises on typo)
+    if act == "none":
+        raise ValueError("_int8_swiglu_kernel requires a real gate activation, not 'none'")
+    if w_gate.shape != w_up.shape:
+        raise ValueError(
+            f"gate/up weights must match: {tuple(w_gate.shape)} vs {tuple(w_up.shape)}"
+        )
+
+    scalar_scales = (ws_gate.numel() == 1 and ws_up.numel() == 1)
+    fused_ok = (_kernel is not None and x.device.type == "mps" and w_gate.dtype == torch.int8
+                and w_up.dtype == torch.int8 and scalar_scales
+                and hasattr(_kernel, "i8_matmul2d_nt_swiglu"))
+    if not fused_ok:
+        # Per-branch fallback (kernel missing, off-MPS, non-int8, or per-channel scales —
+        # the row-scale precombine below is only valid for scalar weight scales).
+        g = _int8_linear_kernel(x, w_gate, ws_gate, bias_gate, torch.bfloat16,
+                                convrot, convrot_groupsize, act=act)  # activation applied here
+        u = _int8_linear_kernel(x, w_up, ws_up, bias_up, torch.bfloat16,
+                                convrot, convrot_groupsize, act="none")
+        return g * u
+
+    from comfy_kitchen.backends.eager.quantization import quantize_int8_rowwise
+    from comfy_kitchen.tensor.int8_utils import _build_hadamard, _rotate_activation
+    if convrot:
+        h = _build_hadamard(convrot_groupsize, device=x.device, dtype=x.dtype)
+        x = _rotate_activation(x, h, convrot_groupsize)
+    shp = x.shape
+    x2 = x.reshape(-1, x.shape[-1])
+    x8, xs = quantize_int8_rowwise(x2)
+    xs = xs.reshape(-1).float()
+    rsg = (ws_gate.view(-1).float() * xs).contiguous()  # scalar * [M] -> [M] (valid: scalar_scales)
+    rsu = (ws_up.view(-1).float() * xs).contiguous()
+    bg = bias_gate.to(torch.bfloat16) if bias_gate is not None else None
+    bu = bias_up.to(torch.bfloat16) if bias_up is not None else None
+    out = _kernel.i8_matmul2d_nt_swiglu(x8.contiguous(), w_gate.contiguous(),
+            w_up.contiguous(), rsg, rsu, bg, bu, _act_code(act))
+    return out.reshape(*shp[:-1], w_gate.shape[0])
+
+
 def _try_int8_kernel_forward(self, input):
     """Return the layer output via the kernel W8A8 path, or None to fall back.
 

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -46,6 +46,29 @@ _installed = False
 _orig_int8_linear = None
 _kernel = None
 
+# Supported fused activations. P0 verdict (M5 Max / macOS 27 / Metal 4.1):
+# Metal `erf` is unavailable, so act=3 (gelu-erf) is dropped entirely; only
+# {none, silu, gelu_tanh} are kept everywhere (kernel store, pybind, this map).
+_ACT = {"none": 0, "silu": 1, "gelu_tanh": 2}
+
+
+def _act_code(act):
+    if act not in _ACT:
+        raise ValueError(f"unknown act {act!r}; expected one of {sorted(_ACT)}")
+    return _ACT[act]
+
+
+def _apply_act(result, act):
+    """Apply the named activation to an already-computed linear output. Single source
+    of truth so no return path can silently drop the activation."""
+    if act == "none":
+        return result
+    if act == "silu":
+        return torch.nn.functional.silu(result)
+    if act == "gelu_tanh":
+        return torch.nn.functional.gelu(result, approximate="tanh")
+    raise ValueError(f"unknown act {act!r}; expected one of {sorted(_ACT)}")
+
 
 def _load_kernel():
     try:
@@ -64,6 +87,7 @@ def _int8_linear_kernel(
     out_dtype=torch.bfloat16,
     convrot=False,
     convrot_groupsize=256,
+    act="none",
 ):
     """Kernel-backed drop-in for comfy_kitchen eager int8_linear.
 
@@ -72,14 +96,19 @@ def _int8_linear_kernel(
     weight_scale*row_scale, optional bias). Only the matmul backend differs (our
     NT kernel vs torch._int_mm) and the weight is used in its stored [N,K] layout.
     """
+    code = _act_code(act)  # validate up front (raises on typo) before any dispatch
+
     if (
         _kernel is None
         or x.device.type != "mps"
         or weight.device.type != "mps"
         or weight.dtype != torch.int8
     ):
-        return _orig_int8_linear(
-            x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize
+        return _apply_act(
+            _orig_int8_linear(
+                x, weight, weight_scale, bias, out_dtype, convrot, convrot_groupsize
+            ),
+            act,
         )
 
     from comfy_kitchen.backends.eager.quantization import quantize_int8_rowwise
@@ -107,8 +136,9 @@ def _int8_linear_kernel(
     ):
         row_scale = (weight_scale.float() * x_scale.reshape(-1).float()).contiguous()
         bias_arg = bias.to(torch.bfloat16) if bias is not None else None
+        # Activation is fused IN-KERNEL here; do NOT also call _apply_act.
         result = _kernel.i8_matmul2d_nt_fused(
-            x_8.contiguous(), weight.contiguous(), row_scale, bias_arg
+            x_8.contiguous(), weight.contiguous(), row_scale, bias_arg, code
         )
         return result.reshape(*orig_shape[:-1], weight.shape[0])
 
@@ -127,6 +157,9 @@ def _int8_linear_kernel(
 
     if bias is not None:
         result = result + bias.to(device=result.device, dtype=result.dtype)
+
+    # Chunked fallback path: activation is applied here (never fused in-kernel).
+    result = _apply_act(result, act)
 
     return result.reshape(*orig_shape[:-1], weight.shape[0])
 

--- a/_patches/mps_profile.py
+++ b/_patches/mps_profile.py
@@ -37,6 +37,50 @@ _t_start = None
 _t_last_dump = None
 _interval = 20.0
 _gguf_wrapped = False
+_rope_wrapped_ids: set = set()
+# id() of every original RoPE function object that has been replaced in
+# all its occurrences (including aliases). Unlike _gguf_wrapped (boolean,
+# single-target), RoPE is multi-target across many model families and alias
+# imports; we never set a global "all done" flag. Each id is added when the
+# corresponding original function is first found and wrapped; subsequent scans
+# skip ids already present, making repeat calls cheap.
+
+# Canonical module-level function names that perform rotary embedding, plus
+# known alias names used by Wan 2.2, EchoShot, Mocha, and KJNodes.
+# Derived from:
+#   grep -rn "def apply_rope\|def rope_apply\|def apply_rotary\|def _ideogram4" \
+#     $COMFYUI --include="*.py"
+# and cross-referenced against Codex review of actual import patterns.
+#
+# NOTE: alias names (apply_rope_comfy, rope_apply_z, etc.) are included so
+# Pass 1 can discover them if they appear as standalone functions. Aliases
+# bound by 'from X import Y as Z' at import time are also caught by Pass 2
+# (object-identity scan) even if their name is not listed here.
+_ROPE_FN_NAMES = frozenset({
+    # Wan 2.2 canonical
+    "rope_apply",
+    "rope_apply_3d",
+    "rope_apply_1d",
+    "apply_rotary_emb_split",
+    # Wan 2.2 aliases (wanvideo/modules/model.py lines 27-29, called at 441-451, 677-680)
+    "apply_rope_comfy",
+    "apply_rope_comfy1",
+    # Flux / Chroma / Ideogram canonical
+    "apply_rope",
+    # HunyuanVideo / LTX
+    "apply_rotary_emb",
+    # ChatGLM-derived
+    "apply_rotary_pos_emb",
+    # KJNodes Ideogram4 int8/convrot path
+    # (comfyui-kjnodes/nodes/model_optimization_nodes.py lines 1967-1992)
+    "_ideogram4_apply_rope_lowp",
+    # EchoShot (echoshot/echoshot.py, referenced by wanvideo/modules/model.py line 24)
+    "rope_apply_z",
+    "rope_apply_c",
+    "rope_apply_echoshot",
+    # Mocha (mocha/nodes.py, referenced by nodes_sampler.py line 968)
+    "rope_apply_mocha",
+})
 
 
 def _is_mps(args):
@@ -73,7 +117,8 @@ def _dump():
               f"({calls} calls, {avg_ms:.3f} ms/call)")
     print(f"{TAG}   {'<unwrapped>':<14} {other:8.2f}s  "
           f"{(100.0 * other / elapsed) if elapsed else 0.0:5.1f}%  "
-          f"(elementwise / copies / gguf math not in a wrapped seam)")
+          f"(elementwise / modulation / rotary-if-not-found / "
+          f"gguf-if-not-found / copies / misc not in a wrapped seam)")
 
 
 def _maybe_dump():
@@ -94,6 +139,7 @@ def _timed(name, orig):
         torch.mps.synchronize()
         _record(name, time.perf_counter() - t0)
         _try_wrap_gguf()
+        _try_wrap_rope()
         _maybe_dump()
         return out
     wrapper._asfp8_timed = True
@@ -129,6 +175,88 @@ def _try_wrap_gguf():
         _gguf_wrapped = True
 
 
+def _try_wrap_rope():
+    """Lazily wrap module-level rotary-embedding functions using two-pass identity scanning.
+
+    Called inside every _timed wrapper closure (like _try_wrap_gguf), but unlike
+    _try_wrap_gguf (single-target, stops permanently once found), _try_wrap_rope
+    never short-circuits globally because:
+      1. RoPE spans many model families; new model modules may load late.
+      2. Alias imports (from wanvideo.modules.model import rope_apply as apply_rope_comfy1)
+         bind the original function object under a different name in the caller's namespace.
+         Patching only the source module leaves caller-module aliases stale.
+
+    Algorithm:
+      Pass 1 — collect unpatched original function objects by canonical name:
+        For each module in sys.modules, look for names in _ROPE_FN_NAMES.
+        Skip: _asfp8_timed (already wrapped), no __code__ (builtin/partial),
+        id already in _rope_wrapped_ids (wrapped in a prior scan).
+        Collect into originals: dict[id(fn) -> fn].
+
+      Pass 2 — patch every occurrence in every module by object identity:
+        For every callable value in every module dict whose id() is in originals
+        and is not _asfp8_timed, replace it with _timed('rotary', val) and
+        record id(val) in _rope_wrapped_ids.
+        This catches aliases regardless of their local attribute name.
+
+    If Pass 1 finds no new originals (all known ids already in _rope_wrapped_ids),
+    returns immediately — cost is one dict-intersection check per call.
+    """
+    global _rope_wrapped_ids
+
+    # Pass 1: discover unpatched rope function objects by name
+    originals: dict = {}  # id(fn) -> fn
+    for _mod_name, mod in list(sys.modules.items()):
+        if (mod is None
+                or _mod_name.startswith("torch._classes")
+                or _mod_name.startswith("torch.classes")):
+            continue
+        try:
+            mod_dict = mod.__dict__
+            for fn_name in _ROPE_FN_NAMES:
+                fn = mod_dict.get(fn_name)
+                if fn is None or not callable(fn):
+                    continue
+                if getattr(fn, "_asfp8_timed", False):
+                    continue
+                # Skip C-extension callables and builtins — they have no __code__.
+                # Note: do NOT check co_argcount; *args-only functions have
+                # co_argcount == 0 but are valid RoPE implementations.
+                if getattr(fn, "__code__", None) is None:
+                    continue
+                fn_id = id(fn)
+                if fn_id not in _rope_wrapped_ids:
+                    originals[fn_id] = fn
+        except Exception:
+            continue
+
+    if not originals:
+        return  # nothing new; cheap exit
+
+    # Pass 2: patch every occurrence in every module (catches alias imports)
+    for _mod_name, mod in list(sys.modules.items()):
+        if (mod is None
+                or _mod_name.startswith("torch._classes")
+                or _mod_name.startswith("torch.classes")):
+            continue
+        try:
+            for attr_name, val in list(mod.__dict__.items()):
+                if not callable(val):
+                    continue
+                if getattr(val, "_asfp8_timed", False):
+                    continue
+                fn_id = id(val)
+                if fn_id not in originals:
+                    continue
+                # Replace with a fresh wrapper pointing at the original fn.
+                # Do not check _rope_wrapped_ids here — the same id may appear
+                # in multiple modules (aliases); we want to patch all of them.
+                _rope_wrapped_ids.add(fn_id)
+                mod.__dict__[attr_name] = _timed("rotary", originals[fn_id])
+        except Exception:
+            continue
+
+
 def install():
     global _installed, _t_start, _t_last_dump, _interval
     if _installed:
@@ -156,8 +284,23 @@ def install():
     torch.matmul = _timed("matmul", torch.matmul)
     torch.bmm = _timed("bmm", torch.bmm)
 
+    # Activation ops. All three share the 'activation' bucket.
+    # PREREQUISITE: run Task 0 probe first to confirm nn.SiLU/nn.GELU dispatch
+    # through F.silu/F.gelu in this PyTorch version. If they bypass F.*, also
+    # wrap nn.SiLU.forward and nn.GELU.forward (see Task 0 probe output).
+    F.silu = _timed("activation", F.silu)
+    F.gelu = _timed("activation", F.gelu)
+    F.glu  = _timed("activation", F.glu)
+
+    # Attempt an early lazy scan for RoPE functions — the model may already be
+    # partially imported by the time mps_profile.install() runs. The wrapper also
+    # calls _try_wrap_rope() on every timed invocation for the late-import case.
+    _try_wrap_rope()
+
     _t_start = time.perf_counter()
     _t_last_dump = _t_start
     _installed = True
     print(f"{TAG} GPU-time profiler active (synchronized; run is slower). "
-          f"Cumulative breakdown every {_interval:.0f}s. GGUF dequant wrapped lazily.")
+          f"Seams: attn / linear / conv2d / conv3d / layernorm / rmsnorm / "
+          f"matmul / bmm / activation (silu+gelu+glu) / rotary (lazy, identity-scan) / "
+          f"gguf_dequant (lazy). Breakdown every {_interval:.0f}s.")

--- a/_patches/probe_runtime.py
+++ b/_patches/probe_runtime.py
@@ -1,0 +1,129 @@
+"""DIAGNOSTIC (opt-in ASFP8_PROBE=1): auto-fire the issue-F (fp8 seam/scale/range) and
+issue-ROPE (rotary origin) HUMAN-gate probes during a NORMAL ComfyUI render — no manual
+`probe(model)` call, no console paste, no workflow edit. Read-only: each finding logs once,
+then stays quiet. Never fatal. Inert unless ASFP8_PROBE=1.
+
+HOW TO USE
+  Launch ComfyUI with the optimizations OFF (so the probe sees the UNMODIFIED model):
+      ASFP8_PROBE=1 <comfyui launch>     # leave ASFP8_FP8_NATIVE / ASFP8_ROPE_FAST UNSET
+  Queue ONE Flux-2-Klein-9B (fp8) render and ONE Ideogram-4 (int8) render, then read the
+  [F-PROBE ...] and [ROPE-ORIGIN ...] lines in the log. They answer:
+    - fp8 SEAM  : the class that owns the fp8 Linear.forward (MRO) + does it wrap torch._scaled_mm
+    - fp8 SCALE : scalar vs per-output-channel [N]
+    - fp8 RANGE : per-layer |x|.max() vs fp16's 65504 (the native wrapper casts bf16->half)
+    - ROPE ORIGIN: is the fired rotary the comfy_kitchen path, or model-specific (e.g. KJNodes
+                   _ideogram4_apply_rope_lowp)? Only comfy_kitchen + x.rank==4 is in scope for #21.
+
+Decision matrices live in dev/probe_F_flux_seam.py and docs/superpowers/results/{F,ROPE}-results.md.
+"""
+
+import os
+
+TAG = "[F-PROBE]"
+
+_installed = False
+_seam_logged = set()          # class keys already dumped (+ the sentinel "ORDER")
+_smm = {"fired": False, "inside_fp8_fwd": False}
+_fp8_depth = 0
+
+
+def _is_fp8_weight(w):
+    return hasattr(w, "_layout_cls") and str(getattr(w, "_layout_cls", "")).startswith("TensorCoreFP8")
+
+
+def _install_rope_origin():
+    """Load dev/probe_rope_runtime.py by path; it self-installs the [ROPE-ORIGIN] loggers on import."""
+    import os.path as p
+    import importlib.util as u
+    repo_root = p.dirname(p.dirname(p.abspath(__file__)))
+    script = p.join(repo_root, "dev", "probe_rope_runtime.py")
+    if not p.exists(script):
+        print(f"{TAG} rope-origin probe not found at {script}")
+        return
+    spec = u.spec_from_file_location("_asfp8_rope_origin_probe", script)
+    mod = u.module_from_spec(spec)
+    spec.loader.exec_module(mod)   # prints "[ROPE-ORIGIN] installed; ..."
+
+
+def _install_fp8_seam(torch):
+    """Global forward hooks that dump the fp8 Linear seam/scale/range on the first fp8 layer,
+    and whether torch._scaled_mm fires INSIDE that forward (proving the forward is the
+    interceptable seam, before the activation is fp8-quantized)."""
+    from torch.nn.modules.module import register_module_forward_hook, register_module_forward_pre_hook
+
+    _orig_smm = torch._scaled_mm
+
+    def _smm_wrap(*a, **k):
+        _smm["fired"] = True
+        if _fp8_depth > 0:
+            _smm["inside_fp8_fwd"] = True
+        return _orig_smm(*a, **k)
+
+    torch._scaled_mm = _smm_wrap
+
+    def _pre(module, inp):
+        global _fp8_depth
+        w = getattr(module, "weight", None)
+        if not _is_fp8_weight(w):
+            return
+        _fp8_depth += 1
+        cls = type(module)
+        key = f"{cls.__module__}.{cls.__qualname__}"
+        if key in _seam_logged:
+            return
+        _seam_logged.add(key)
+        try:
+            sc = w._params.scale
+            sc_shape = tuple(sc.shape) if hasattr(sc, "shape") else "scalar"
+            x = inp[0] if inp else None
+            amax = float(x.detach().float().abs().amax().cpu()) if x is not None else -1.0
+            print(f"{TAG} SEAM  class={key}")
+            print(f"{TAG}   MRO   ={[c.__name__ for c in cls.__mro__]}")
+            print(f"{TAG}   layout={w._layout_cls}  qdata={tuple(w._qdata.shape)},{w._qdata.dtype}  "
+                  f"scale={sc_shape},numel={sc.numel()},{sc.dtype}  "
+                  f"-> {'PER-CHANNEL [N]' if sc.numel() > 1 else 'SCALAR'}")
+            print(f"{TAG}   ACT|max|={amax:.2f} (fp16 max 65504) -> "
+                  f"{'RANGE OK (guard off)' if 0 <= amax < 65504 else 'RANGE GUARD NEEDED'}")
+        except Exception as e:
+            print(f"{TAG}   seam dump error {e!r}")
+
+    def _post(module, inp, out):
+        global _fp8_depth
+        w = getattr(module, "weight", None)
+        if not _is_fp8_weight(w) or _fp8_depth <= 0:
+            return
+        _fp8_depth -= 1
+        if _smm["fired"] and "ORDER" not in _seam_logged:
+            _seam_logged.add("ORDER")
+            verdict = "BEFORE (forward wraps _scaled_mm -> seam interceptable)" \
+                if _smm["inside_fp8_fwd"] else "NOT before (activation quantized elsewhere -> seam SUSPECT)"
+            print(f"{TAG} ORDER fp8 Linear.forward ran {verdict}")
+
+    register_module_forward_pre_hook(_pre)
+    register_module_forward_hook(_post)
+
+
+def install():
+    global _installed
+    if _installed:
+        return
+    if os.environ.get("ASFP8_PROBE", "").strip().lower() not in ("1", "on", "true"):
+        return
+    import sys
+    if sys.platform != "darwin":
+        return
+    try:
+        import torch
+    except Exception:
+        return
+    _installed = True
+    try:
+        _install_rope_origin()
+    except Exception as e:
+        print(f"{TAG} rope-origin probe skipped ({e!r})")
+    try:
+        _install_fp8_seam(torch)
+        print(f"{TAG} fp8 seam/scale/range auto-probe armed. Run ONE Flux-2 render with the "
+              f"optimizations OFF; read the [F-PROBE ...] lines.")
+    except Exception as e:
+        print(f"{TAG} fp8 seam probe skipped ({e!r})")

--- a/_patches/rope_fast_mps.py
+++ b/_patches/rope_fast_mps.py
@@ -68,6 +68,8 @@ _warned = False
 # Per-call backend trace (MAJOR 5). Each kernel/fallback decision appends one event.
 # Tests inspect the tail to assert BOTH calls of a pair wrapper took the intended path.
 _backend_events: list[tuple] = []   # (fn_name, "kernel"|"fallback", tuple(shape))
+_MAX_EVENTS = 4096                   # bound the spy trace: default-on RoPE fires every block,
+                                     # so an unbounded list would leak across a long session
 
 # captured originals (set in install()/install_for_test()); fallback uses these.
 _orig: dict = {}                    # name -> original eager fn
@@ -75,6 +77,8 @@ _orig: dict = {}                    # name -> original eager fn
 
 def _record(name, backend, shape):
     _backend_events.append((name, backend, tuple(shape)))
+    if len(_backend_events) > _MAX_EVENTS:
+        del _backend_events[:-_MAX_EVENTS // 2]   # keep the most-recent half (tests read the tail)
 
 
 def _last_backend():

--- a/_patches/rope_fast_mps.py
+++ b/_patches/rope_fast_mps.py
@@ -8,14 +8,14 @@ out once, fp32 math in registers, store in the input dtype. freqs_cis is the pre
 matrix per (position, pair) -- NO complex multiply, NO cos/sin computed in-kernel.
 
 Pure elementwise compile_shader -> works on Apple Silicon M1+ (torch>=2.5); NOT gated on Metal
-4.1 / M5. Opt-in ASFP8_ROPE_FAST=1 (default OFF). Never fatal: any compile/shape/dtype/convention
+4.1 / M5. DEFAULT ON, gated on compile_shader (ASFP8_ROPE_FAST=off disables); the #21b comfy-func
+retarget is opt-in via ASFP8_ROPE_COMFY_RETARGET=1. Never fatal: any compile/shape/dtype/convention
 mismatch falls back to the captured original eager apply_rope*. Per-call backend trace in
 _backend_events records (fn_name, "kernel"|"fallback", shape) for the spy tests. Patches the four
 comfy_kitchen.backends.eager attributes the registry reads via getattr() on every dispatch, and --
 as defence-in-depth -- the same four names on comfy_kitchen.backends.eager.rope.
 Scope: 4-D [B,H,L,D], fp32 freqs_cis table, batch/head-broadcast table. Anything else -> fallback."""
 from __future__ import annotations
-import os
 import torch
 
 TAG = "[AppleSilicon-FP8/rope-fast]"
@@ -436,7 +436,10 @@ def _do_install():
 
 
 def install():
-    if os.environ.get("ASFP8_ROPE_FAST") != "1":   # default OFF
+    # Patch #21 (standalone fused RoPE kernel) is DEFAULT ON, gated on compile_shader
+    # (Tier A: fp32 math, no Metal-4.1/M5 needed). ASFP8_ROPE_FAST=off disables; =1 forces on.
+    from . import _caps
+    if not _caps.resolve("ASFP8_ROPE_FAST", default_on=True, cap=_caps.has_compile_shader):
         return
     mps = getattr(torch.backends, "mps", None)
     if mps is None or not mps.is_available() or not hasattr(torch.mps, "compile_shader"):
@@ -452,16 +455,20 @@ def install():
             _do_install()
         except Exception as e:                 # never fatal
             print(f"{TAG} eager install failed ({e}); leaving eager rope untouched.", flush=True)
-    # Retarget the REAL comfy rope functions the live models call (patch #21b). Independent of
-    # comfy_kitchen; never fatal.
-    try:
-        _install_comfy()
-    except Exception as e:
-        print(f"{TAG} comfy retarget failed ({e}); leaving comfy rope untouched.", flush=True)
+    # Patch #21b: retarget the REAL comfy rope functions the live models call
+    # (comfy.ldm.flux / llama apply_rope). Higher-risk — it patches live model code — so it
+    # stays OPT-IN behind its own flag (default OFF) until it has broader cross-model
+    # validation. ASFP8_ROPE_COMFY_RETARGET=1 turns it on. Independent of comfy_kitchen; never fatal.
+    if _caps.resolve("ASFP8_ROPE_COMFY_RETARGET", default_on=False, cap=_caps.has_compile_shader):
+        try:
+            _install_comfy()
+        except Exception as e:
+            print(f"{TAG} comfy retarget failed ({e}); leaving comfy rope untouched.", flush=True)
     targeted = sorted(_orig_comfy.keys())
-    print(f"{TAG} fused RoPE active on MPS (eager apply_rope/apply_rope_split_half + comfy "
-          f"{targeted or 'none'} rerouted; interleaved + split-half; fp32 math, "
-          f"no Metal-4.1/M5 requirement).", flush=True)
+    print(f"{TAG} fused RoPE active on MPS (eager apply_rope/apply_rope_split_half"
+          f"{' + comfy ' + str(targeted) if targeted else ''} rerouted; interleaved + split-half; "
+          f"fp32 math, no Metal-4.1/M5 requirement; comfy-retarget "
+          f"{'ON' if targeted else 'OFF (ASFP8_ROPE_COMFY_RETARGET=1 to enable)'}).", flush=True)
 
 
 def install_for_test():

--- a/_patches/rope_fast_mps.py
+++ b/_patches/rope_fast_mps.py
@@ -1,0 +1,269 @@
+"""Patch #21: fused standalone RoPE (apply_rope / apply_rope_split_half) on MPS.
+
+comfy_kitchen's eager apply_rope is bandwidth-bound but spends several ms/call because it runs the
+rotation as ~3-7 separate PyTorch launches with fp32 intermediates and (split-half) two
+non-contiguous movedim views (see dev/probe_rope_source.py / probe_rope_cost.py). This replaces
+it with ONE compile_shader pass: read x once, read the precomputed 2x2 rotation table once, write
+out once, fp32 math in registers, store in the input dtype. freqs_cis is the precomputed rotation
+matrix per (position, pair) -- NO complex multiply, NO cos/sin computed in-kernel.
+
+Pure elementwise compile_shader -> works on Apple Silicon M1+ (torch>=2.5); NOT gated on Metal
+4.1 / M5. Opt-in ASFP8_ROPE_FAST=1 (default OFF). Never fatal: any compile/shape/dtype/convention
+mismatch falls back to the captured original eager apply_rope*. Per-call backend trace in
+_backend_events records (fn_name, "kernel"|"fallback", shape) for the spy tests. Patches the four
+comfy_kitchen.backends.eager attributes the registry reads via getattr() on every dispatch, and --
+as defence-in-depth -- the same four names on comfy_kitchen.backends.eager.rope.
+Scope: 4-D [B,H,L,D], fp32 freqs_cis table, batch/head-broadcast table. Anything else -> fallback."""
+from __future__ import annotations
+import os
+import torch
+
+TAG = "[AppleSilicon-FP8/rope-fast]"
+
+_MSL = r"""
+#include <metal_stdlib>
+using namespace metal;
+constant constexpr uint TG = 256;
+kernel void apply_rope_fused(
+    device const @T@*   x    [[buffer(0)]],
+    device const float* fr   [[buffer(1)]],
+    device       @T@*   out  [[buffer(2)]],
+    device const int*   meta [[buffer(3)]],
+    uint3 tgpig [[threadgroup_position_in_grid]],
+    uint  lid   [[thread_index_in_threadgroup]])
+{
+    const int  D     = meta[0];
+    const int  halfD = meta[1];
+    const int  L     = meta[2];
+    const uint ny    = uint(meta[3]);
+    const uint rows  = uint(meta[4]);
+    const int  split = meta[5];
+    const uint row = tgpig.z * ny + tgpig.y;
+    if (row >= rows) return;
+    const ulong xbase = ulong(row) * ulong(D);
+    const uint  l     = row % uint(L);
+    const ulong fbase = ulong(l) * ulong(halfD) * 4ul;
+    for (uint p = lid; p < uint(halfD); p += TG) {
+        const ulong fo  = fbase + ulong(p) * 4ul;
+        const float f00 = fr[fo + 0], f01 = fr[fo + 1];
+        const float f10 = fr[fo + 2], f11 = fr[fo + 3];
+        uint ia, ib;
+        if (split == 0) { ia = 2u*p; ib = 2u*p + 1u; }
+        else            { ia = p;    ib = p + uint(halfD); }
+        const float a = float(x[xbase + ia]);
+        const float b = float(x[xbase + ib]);
+        out[xbase + ia] = @T@(f00 * a + f01 * b);
+        out[xbase + ib] = @T@(f10 * a + f11 * b);
+    }
+}
+"""
+
+_MSL_T = {torch.float16: "half", torch.bfloat16: "bfloat", torch.float32: "float"}
+_TG = 256
+_NY = 32768
+_libs: dict[str, object] = {}
+_meta_cache: dict[tuple, torch.Tensor] = {}
+_warned = False
+
+# Per-call backend trace (MAJOR 5). Each kernel/fallback decision appends one event.
+# Tests inspect the tail to assert BOTH calls of a pair wrapper took the intended path.
+_backend_events: list[tuple] = []   # (fn_name, "kernel"|"fallback", tuple(shape))
+
+# captured originals (set in install()/install_for_test()); fallback uses these.
+_orig: dict = {}                    # name -> original eager fn
+
+
+def _record(name, backend, shape):
+    _backend_events.append((name, backend, tuple(shape)))
+
+
+def _last_backend():
+    """Convenience for single-call tests: backend of the most recent event."""
+    return _backend_events[-1][1] if _backend_events else "fallback"
+
+
+def _get_lib(dtype):
+    t = _MSL_T[dtype]
+    lib = _libs.get(t)
+    if lib is None:
+        lib = torch.mps.compile_shader(_MSL.replace("@T@", t))
+        _libs[t] = lib
+    return lib
+
+
+def _meta(D, halfD, L, ny, rows, split, device):
+    key = (D, halfD, L, ny, rows, split, str(device))
+    t = _meta_cache.get(key)
+    if t is None:
+        t = torch.tensor([D, halfD, L, ny, rows, split], dtype=torch.int32, device=device)
+        _meta_cache[key] = t
+    return t
+
+
+def _reference_interleaved(x, freqs_cis):
+    """Eager-FORMULA reference for apply_rope1 (interleaved). DIAGNOSTIC ONLY -- not the
+    primary oracle. The primary oracle in tests is the captured REAL eager op (see Task 2)."""
+    x_ = x.to(dtype=freqs_cis.dtype).reshape(*x.shape[:-1], -1, 1, 2)
+    f = freqs_cis
+    if x_.shape[2] != 1 and f.shape[2] != 1 and x_.shape[2] != f.shape[2]:
+        f = f[:, :, :x_.shape[2]]
+    out = f[..., 0] * x_[..., 0]
+    out = out + f[..., 1] * x_[..., 1]
+    return out.reshape(*x.shape).type_as(x)
+
+
+def _reference_split_half(x, freqs_cis):
+    """Eager-FORMULA reference for apply_rope_split_half1. DIAGNOSTIC ONLY."""
+    t_ = x.reshape(*x.shape[:-1], 2, -1).movedim(-2, -1).unsqueeze(-2).to(freqs_cis.dtype)
+    t_out = freqs_cis[..., 0] * t_[..., 0] + freqs_cis[..., 1] * t_[..., 1]
+    return t_out.movedim(-1, -2).reshape(*x.shape).type_as(x)
+
+
+def _fallback1(name, x, freqs_cis):
+    _record(name, "fallback", x.shape)
+    return _orig[name](x, freqs_cis)
+
+
+def _prep_table(freqs_cis, halfD, L):
+    """Return contiguous fp32 [Lf,halfD,4] table or None (-> fallback).
+
+    No cache (MAJOR 9 contingency): a ``weakref.WeakKeyDictionary`` keyed by a tensor crashes on
+    this torch build because ``weakref.ref.__eq__`` delegates to the tensor's elementwise ``__eq__``
+    ("Boolean value of Tensor with more than one value is ambiguous"). The plan's sanctioned
+    fallback is to recompute ``fr`` every call -- which is free for the common case: an
+    already-contiguous fp32 table makes ``reshape`` a metadata-only view and ``contiguous`` a no-op
+    (returns the same storage, no copy). Recomputing also means the table can never go stale, so
+    in-place table mutation is reflected automatically."""
+    if freqs_cis.dtype != torch.float32:                # MAJOR 8: hard-fallback on non-fp32
+        return None
+    fs = freqs_cis.shape
+    if len(fs) < 4 or fs[-1] != 2 or fs[-2] != 2 or fs[-3] != halfD:
+        return None
+    Lf = fs[-4]
+    if Lf < L:
+        return None
+    if any(int(d) != 1 for d in fs[:-4]):               # require batch/head broadcast (Open Q #2)
+        return None
+    return freqs_cis.reshape(Lf, halfD, 4).contiguous()  # already fp32; view + no-op for contiguous
+
+
+def _rope_fused(name, x, freqs_cis, split):
+    global _warned
+    if (x.device.type != "mps" or x.dtype not in _MSL_T
+            or freqs_cis.device != x.device or x.numel() == 0 or x.dim() != 4):  # MAJOR 6: rank-4 only
+        return _fallback1(name, x, freqs_cis)
+    try:
+        D = x.shape[-1]
+        if D % 2 != 0:
+            return _fallback1(name, x, freqs_cis)
+        halfD = D // 2
+        L = x.shape[-2]
+        fr = _prep_table(freqs_cis, halfD, L)
+        if fr is None:
+            return _fallback1(name, x, freqs_cis)
+        xc = x.contiguous()
+        rows = xc.numel() // D
+        ny = min(rows, _NY)
+        nz = (rows + ny - 1) // ny
+        out = torch.empty_like(xc)
+        meta = _meta(D, halfD, L, ny, rows, split, x.device)
+        _get_lib(x.dtype).apply_rope_fused(
+            xc, fr, out, meta, threads=(_TG, ny, nz), group_size=(_TG, 1, 1))
+        _record(name, "kernel", x.shape)
+        return out.view_as(x)
+    except Exception as e:
+        if not _warned:
+            print(f"{TAG} kernel error ({e}); falling back to eager rope.", flush=True)
+            _warned = True
+        return _fallback1(name, x, freqs_cis)
+
+
+def apply_rope1_fused(x, freqs_cis):
+    return _rope_fused("apply_rope1", x, freqs_cis, split=0)
+
+
+def apply_rope_split_half1_fused(x, freqs_cis):
+    return _rope_fused("apply_rope_split_half1", x, freqs_cis, split=1)
+
+
+def apply_rope_fused_pair(xq, xk, freqs_cis):
+    return apply_rope1_fused(xq, freqs_cis), apply_rope1_fused(xk, freqs_cis)
+
+
+def apply_rope_split_half_fused_pair(xq, xk, freqs_cis):
+    return (apply_rope_split_half1_fused(xq, freqs_cis),
+            apply_rope_split_half1_fused(xk, freqs_cis))
+
+
+_PATCH_MAP = {
+    "apply_rope1": "apply_rope1_fused",
+    "apply_rope": "apply_rope_fused_pair",
+    "apply_rope_split_half1": "apply_rope_split_half1_fused",
+    "apply_rope_split_half": "apply_rope_split_half_fused_pair",
+}
+_installed = False
+
+
+def _targets():
+    """The module objects whose attrs we patch: the eager PACKAGE (read by the registry) and the
+    eager.rope SOURCE module (defence-in-depth for direct importers / pair-wrapper internals)."""
+    import comfy_kitchen.backends.eager as e
+    import comfy_kitchen.backends.eager.rope as r
+    return (e, r)
+
+
+def _do_install():
+    global _installed
+    if _installed:
+        return True
+    e, r = _targets()
+    for name in _PATCH_MAP:
+        _orig[name] = getattr(e, name)        # capture original (used by fallback + as oracle)
+    g = globals()
+    for name, repl in _PATCH_MAP.items():
+        setattr(e, name, g[repl])             # the attr the registry reads via getattr
+        try:
+            setattr(r, name, g[repl])         # source-module global (MAJOR 4)
+        except Exception:
+            pass
+    _installed = True
+    return True
+
+
+def install():
+    if os.environ.get("ASFP8_ROPE_FAST") != "1":   # default OFF
+        return
+    mps = getattr(torch.backends, "mps", None)
+    if mps is None or not mps.is_available() or not hasattr(torch.mps, "compile_shader"):
+        return
+    try:
+        import comfy_kitchen.backends.eager  # noqa: F401
+    except Exception:
+        print(f"{TAG} comfy_kitchen not installed; rope-fast off.", flush=True)
+        return
+    try:
+        _do_install()
+    except Exception as e:                     # never fatal
+        print(f"{TAG} install failed ({e}); leaving eager rope untouched.", flush=True)
+        return
+    print(f"{TAG} fused RoPE active on MPS (eager apply_rope/apply_rope_split_half rerouted; "
+          f"interleaved + split-half; fp32 math, no Metal-4.1/M5 requirement).", flush=True)
+
+
+def install_for_test():
+    _do_install()
+
+
+def uninstall_for_test():
+    global _installed
+    if not _installed:
+        return
+    e, r = _targets()
+    for name, fn in _orig.items():
+        setattr(e, name, fn)
+        try:
+            setattr(r, name, fn)
+        except Exception:
+            pass
+    _orig.clear()
+    _installed = False

--- a/_patches/rope_fast_mps.py
+++ b/_patches/rope_fast_mps.py
@@ -147,6 +147,22 @@ def _prep_table(freqs_cis, halfD, L):
     return freqs_cis.reshape(Lf, halfD, 4).contiguous()  # already fp32; view + no-op for contiguous
 
 
+def _launch(x, fr, D, halfD, L, split):
+    """Low-level kernel launch. ``x`` must be rank-4 MPS with a supported dtype; ``fr`` a contiguous
+    fp32 rotation table whose rows are indexed by ``row % L`` (table layout [Lf, halfD, 4], flattened
+    f00,f01,f10,f11 per pair). Returns ``out`` shaped like ``x``. Raises on any kernel failure (the
+    caller turns that into a fallback)."""
+    xc = x.contiguous()
+    rows = xc.numel() // D
+    ny = min(rows, _NY)
+    nz = (rows + ny - 1) // ny
+    out = torch.empty_like(xc)
+    meta = _meta(D, halfD, L, ny, rows, split, x.device)
+    _get_lib(x.dtype).apply_rope_fused(
+        xc, fr, out, meta, threads=(_TG, ny, nz), group_size=(_TG, 1, 1))
+    return out.view_as(x)
+
+
 def _rope_fused(name, x, freqs_cis, split):
     global _warned
     if (x.device.type != "mps" or x.dtype not in _MSL_T
@@ -161,16 +177,9 @@ def _rope_fused(name, x, freqs_cis, split):
         fr = _prep_table(freqs_cis, halfD, L)
         if fr is None:
             return _fallback1(name, x, freqs_cis)
-        xc = x.contiguous()
-        rows = xc.numel() // D
-        ny = min(rows, _NY)
-        nz = (rows + ny - 1) // ny
-        out = torch.empty_like(xc)
-        meta = _meta(D, halfD, L, ny, rows, split, x.device)
-        _get_lib(x.dtype).apply_rope_fused(
-            xc, fr, out, meta, threads=(_TG, ny, nz), group_size=(_TG, 1, 1))
+        out = _launch(x, fr, D, halfD, L, split)
         _record(name, "kernel", x.shape)
-        return out.view_as(x)
+        return out
     except Exception as e:
         if not _warned:
             print(f"{TAG} kernel error ({e}); falling back to eager rope.", flush=True)
@@ -193,6 +202,202 @@ def apply_rope_fused_pair(xq, xk, freqs_cis):
 def apply_rope_split_half_fused_pair(xq, xk, freqs_cis):
     return (apply_rope_split_half1_fused(xq, freqs_cis),
             apply_rope_split_half1_fused(xk, freqs_cis))
+
+
+# ===========================================================================
+# Patch #21b: retarget the REAL comfy RoPE functions the live models call.
+#
+# A live probe (2026-07-01) showed comfy_kitchen.backends.eager fires at most ONCE per model --
+# the DiT / TE actually call comfy's OWN rope functions, which we must intercept directly:
+#
+#   comfy.ldm.flux.math.apply_rope / .apply_rope1      INTERLEAVED 2x2 form (single fp32 freqs
+#       tensor, shape (...,halfD,2,2)); identical convention to comfy_kitchen's apply_rope, so it
+#       maps onto the existing split=0 kernel with NO new math.  (flux.math.apply_rope itself only
+#       delegates to comfy.quant_ops.ck.apply_rope when not training; we intercept ABOVE that.)
+#
+#   comfy.text_encoders.llama.apply_rope               HALF-SPLIT rotate_half form. freqs_cis is a
+#   (== comfy.ldm.ideogram4.model.apply_rope,           3-TUPLE (cos, sin, nsin), cos full-dim D,
+#       same object, imported by alias)                 sin/nsin half-dim. Expressed on the split=1
+#       kernel by building a per-pair 2x2 table:
+#           out[p]        = cos[p]*x[p]      + nsin[p]*x[p+halfD]   (= f00*a + f01*b)
+#           out[p+halfD]  = sin[p]*x[p]      + cos[p+halfD]*x[p+halfD] (= f10*a + f11*b)
+#       i.e. table row = [cos[:halfD], nsin, sin, cos[halfD:]]. Bit-faithful to the real fn (it does
+#       q*cos then addcmul_ with nsin/sin in fp32, then casts back).
+#
+# Both retargets are guarded, never fatal, and gated on the SAME opt-in ASFP8_ROPE_FAST=1.
+# Fallback for each comfy target is the captured REAL comfy function (NOT eager) -- so a fallback is
+# always bit-identical to stock comfy. Anything the kernel cannot match -> fall back, never wrong.
+# ===========================================================================
+
+# captured REAL comfy originals (oracle + fallback). Keys: 'flux.apply_rope', 'flux.apply_rope1',
+# 'llama.apply_rope'. Kept separate from _orig (which holds comfy_kitchen eager originals).
+_orig_comfy: dict = {}
+_comfy_replacements: list = []   # (module_dict, attr_name, original_fn) for clean uninstall
+
+
+def _interleaved_single(x, freqs_cis):
+    """Run the split=0 (interleaved 2x2) kernel for one tensor. Returns out or None (-> fallback).
+    Shared validity gate with _rope_fused, but never touches _orig / never records."""
+    if (x.device.type != "mps" or x.dtype not in _MSL_T
+            or not torch.is_tensor(freqs_cis) or freqs_cis.device != x.device
+            or x.numel() == 0 or x.dim() != 4):
+        return None
+    D = x.shape[-1]
+    if D % 2 != 0:
+        return None
+    halfD = D // 2
+    L = x.shape[-2]
+    fr = _prep_table(freqs_cis, halfD, L)
+    if fr is None:
+        return None
+    return _launch(x, fr, D, halfD, L, split=0)
+
+
+def _flux_apply_rope1_fused(x, freqs_cis):
+    global _warned
+    try:
+        out = _interleaved_single(x, freqs_cis)
+    except Exception as e:
+        if not _warned:
+            print(f"{TAG} flux apply_rope1 kernel error ({e}); falling back.", flush=True)
+            _warned = True
+        out = None
+    if out is None:
+        _record("flux.apply_rope1", "fallback", getattr(x, "shape", ()))
+        return _orig_comfy["flux.apply_rope1"](x, freqs_cis)
+    _record("flux.apply_rope1", "kernel", x.shape)
+    return out
+
+
+def _flux_apply_rope_fused(xq, xk, freqs_cis):
+    """flux pair wrapper. Run the kernel for BOTH q and k; if either cannot, fall back the whole
+    pair to the real comfy original (never mix kernel + fallback within one pair)."""
+    global _warned
+    try:
+        oq = _interleaved_single(xq, freqs_cis)
+        ok = _interleaved_single(xk, freqs_cis) if oq is not None else None
+    except Exception as e:
+        if not _warned:
+            print(f"{TAG} flux apply_rope kernel error ({e}); falling back.", flush=True)
+            _warned = True
+        oq = ok = None
+    if oq is None or ok is None:
+        _record("flux.apply_rope", "fallback", getattr(xq, "shape", ()))
+        return _orig_comfy["flux.apply_rope"](xq, xk, freqs_cis)
+    _record("flux.apply_rope", "kernel", xq.shape)
+    _record("flux.apply_rope", "kernel", xk.shape)
+    return oq, ok
+
+
+def _prep_table_llama(freqs_cis, halfD):
+    """Build a contiguous fp32 [L, halfD, 4] split=1 rotation table from llama's (cos, sin, nsin)
+    3-tuple, or return (None, 0) -> fallback. cos has last-dim 2*halfD; sin/nsin have last-dim halfD.
+    Leading dims must collapse to exactly L rows (i.e. batch/head broadcast == 1) so the kernel's
+    row%L indexing is valid; a true batch (>1) table is rejected (-> fallback)."""
+    if not (isinstance(freqs_cis, (tuple, list)) and len(freqs_cis) == 3):
+        return None, 0
+    cos, sin, nsin = freqs_cis
+    if not all(torch.is_tensor(t) for t in (cos, sin, nsin)):
+        return None, 0
+    if cos.shape[-1] != 2 * halfD or sin.shape[-1] != halfD or nsin.shape[-1] != halfD:
+        return None, 0
+
+    def _flatten(t, last):
+        flat = t.reshape(-1, last)   # collapse all leading dims
+        return flat                  # rows must equal L (checked against the cos rows below)
+
+    cflat = _flatten(cos, 2 * halfD)
+    sflat = _flatten(sin, halfD)
+    nflat = _flatten(nsin, halfD)
+    L = cflat.shape[0]
+    if sflat.shape[0] != L or nflat.shape[0] != L:   # batch/head broadcast mismatch -> fallback
+        return None, 0
+    cos_lo = cflat[:, :halfD]
+    cos_hi = cflat[:, halfD:]
+    table = torch.stack([cos_lo, nflat, sflat, cos_hi], dim=-1)   # (L, halfD, 4)
+    return table.reshape(L, halfD, 4).to(torch.float32).contiguous(), L
+
+
+def _llama_apply_rope_fused(xq, xk, freqs_cis):
+    """llama/ideogram pair wrapper (half-split rotate_half). Build the 2x2 table once from
+    (cos,sin,nsin), then run the split=1 kernel for both q and k. Fall back the whole pair to the
+    real comfy original on any mismatch."""
+    global _warned
+    fb = _orig_comfy["llama.apply_rope"]
+    try:
+        if (xq.device.type != "mps" or xq.dtype not in _MSL_T or xk.dtype not in _MSL_T
+                or xq.dim() != 4 or xk.dim() != 4
+                or xq.shape[-1] % 2 or xk.shape[-1] != xq.shape[-1]
+                or xq.numel() == 0 or xk.numel() == 0):
+            raise ValueError("unsupported shape/dtype")
+        D = xq.shape[-1]
+        halfD = D // 2
+        table, L = _prep_table_llama(freqs_cis, halfD)
+        if table is None or table.device != xq.device:
+            raise ValueError("table not buildable on device")
+        # The table has exactly L position rows; require both tensors' sequence length == L so the
+        # kernel's row%L indexing lands on the right position (self-attention: Lq == Lk == L).
+        if xq.shape[-2] != L or xk.shape[-2] != L:
+            raise ValueError("seq length != table rows")
+        oq = _launch(xq, table, D, halfD, L, split=1)
+        ok = _launch(xk, table, D, halfD, L, split=1)
+    except Exception as e:
+        if not isinstance(e, ValueError) and not _warned:
+            print(f"{TAG} llama apply_rope kernel error ({e}); falling back.", flush=True)
+            _warned = True
+        _record("llama.apply_rope", "fallback", getattr(xq, "shape", ()))
+        return fb(xq, xk, freqs_cis)
+    _record("llama.apply_rope", "kernel", xq.shape)
+    _record("llama.apply_rope", "kernel", xk.shape)
+    return oq, ok
+
+
+def _install_comfy():
+    """Capture the REAL comfy rope functions and replace every reference to them (by object
+    identity, mirroring mps_profile._try_wrap_rope) so aliased re-imports -- e.g.
+    comfy.ldm.ideogram4.model.apply_rope, which IS llama.apply_rope -- are all rerouted. Best-effort:
+    a missing module just skips that target."""
+    import sys
+    id_map = {}   # id(original_fn) -> wrapper
+    try:
+        import comfy.ldm.flux.math as _fm
+        _orig_comfy["flux.apply_rope"] = _fm.apply_rope
+        _orig_comfy["flux.apply_rope1"] = _fm.apply_rope1
+        id_map[id(_fm.apply_rope)] = _flux_apply_rope_fused
+        id_map[id(_fm.apply_rope1)] = _flux_apply_rope1_fused
+    except Exception:
+        pass
+    try:
+        import comfy.text_encoders.llama as _ll
+        _orig_comfy["llama.apply_rope"] = _ll.apply_rope
+        id_map[id(_ll.apply_rope)] = _llama_apply_rope_fused
+    except Exception:
+        pass
+    if not id_map:
+        return
+    for _mod_name, mod in list(sys.modules.items()):
+        if (mod is None or _mod_name.startswith("torch._classes")
+                or _mod_name.startswith("torch.classes")):
+            continue
+        try:
+            d = mod.__dict__
+            for attr, val in list(d.items()):
+                wrap = id_map.get(id(val))
+                if wrap is not None and val is not wrap:
+                    _comfy_replacements.append((d, attr, val))
+                    d[attr] = wrap
+        except Exception:
+            continue
+
+
+def _uninstall_comfy():
+    for d, attr, orig in _comfy_replacements:
+        try:
+            d[attr] = orig
+        except Exception:
+            pass
+    _comfy_replacements.clear()
+    _orig_comfy.clear()
 
 
 _PATCH_MAP = {
@@ -236,22 +441,40 @@ def install():
     mps = getattr(torch.backends, "mps", None)
     if mps is None or not mps.is_available() or not hasattr(torch.mps, "compile_shader"):
         return
+    have_ck = True
     try:
         import comfy_kitchen.backends.eager  # noqa: F401
     except Exception:
-        print(f"{TAG} comfy_kitchen not installed; rope-fast off.", flush=True)
-        return
+        have_ck = False
+        print(f"{TAG} comfy_kitchen not installed; eager-rope retarget off.", flush=True)
+    if have_ck:
+        try:
+            _do_install()
+        except Exception as e:                 # never fatal
+            print(f"{TAG} eager install failed ({e}); leaving eager rope untouched.", flush=True)
+    # Retarget the REAL comfy rope functions the live models call (patch #21b). Independent of
+    # comfy_kitchen; never fatal.
     try:
-        _do_install()
-    except Exception as e:                     # never fatal
-        print(f"{TAG} install failed ({e}); leaving eager rope untouched.", flush=True)
-        return
-    print(f"{TAG} fused RoPE active on MPS (eager apply_rope/apply_rope_split_half rerouted; "
-          f"interleaved + split-half; fp32 math, no Metal-4.1/M5 requirement).", flush=True)
+        _install_comfy()
+    except Exception as e:
+        print(f"{TAG} comfy retarget failed ({e}); leaving comfy rope untouched.", flush=True)
+    targeted = sorted(_orig_comfy.keys())
+    print(f"{TAG} fused RoPE active on MPS (eager apply_rope/apply_rope_split_half + comfy "
+          f"{targeted or 'none'} rerouted; interleaved + split-half; fp32 math, "
+          f"no Metal-4.1/M5 requirement).", flush=True)
 
 
 def install_for_test():
     _do_install()
+
+
+def install_comfy_for_test():
+    """Test-only: capture + patch the comfy targets (requires comfy importable)."""
+    _install_comfy()
+
+
+def uninstall_comfy_for_test():
+    _uninstall_comfy()
 
 
 def uninstall_for_test():

--- a/_patches/rope_fast_mps.py
+++ b/_patches/rope_fast_mps.py
@@ -233,6 +233,7 @@ def apply_rope_split_half_fused_pair(xq, xk, freqs_cis):
 # 'llama.apply_rope'. Kept separate from _orig (which holds comfy_kitchen eager originals).
 _orig_comfy: dict = {}
 _comfy_replacements: list = []   # (module_dict, attr_name, original_fn) for clean uninstall
+_comfy_installed = False         # idempotency: a 2nd call would capture wrappers as "originals"
 
 
 def _interleaved_single(x, freqs_cis):
@@ -357,6 +358,9 @@ def _install_comfy():
     identity, mirroring mps_profile._try_wrap_rope) so aliased re-imports -- e.g.
     comfy.ldm.ideogram4.model.apply_rope, which IS llama.apply_rope -- are all rerouted. Best-effort:
     a missing module just skips that target."""
+    global _comfy_installed
+    if _comfy_installed:
+        return
     import sys
     id_map = {}   # id(original_fn) -> wrapper
     try:
@@ -388,9 +392,12 @@ def _install_comfy():
                     d[attr] = wrap
         except Exception:
             continue
+    _comfy_installed = True
 
 
 def _uninstall_comfy():
+    global _comfy_installed
+    _comfy_installed = False
     for d, attr, orig in _comfy_replacements:
         try:
             d[attr] = orig

--- a/_patches/scaled_mm_fp8.py
+++ b/_patches/scaled_mm_fp8.py
@@ -16,7 +16,7 @@ We monkey-patch torch._scaled_mm so that, for MPS + FP8 operands, it:
 
 Non-MPS or non-FP8 calls fall through to the original implementation untouched.
 
-EXPERIMENTAL (opt-in, ASFP8_FP8_EXT=1): for large fp8(e4m3) x fp8(e4m3) matmuls
+DEFAULT ON, gated on M5/Metal-4.1 + ninja (ASFP8_FP8_EXT=off disables): for large fp8(e4m3) x fp8(e4m3) matmuls
 this seam routes both operands through a Metal 4.1 fp8-native kernel (no bf16
 decode), then applies scales/bias in fp32 — bit-exact vs the decode path, faster.
 When the flag is unset/0 the fast path is inert and numerics are unchanged.
@@ -33,7 +33,7 @@ TAG = "[AppleSilicon-FP8/scaled_mm]"
 _original = None
 _installed = False
 
-# fp8-native fast path (EXPERIMENTAL, opt-in via ASFP8_FP8_EXT=1). When the flag is
+# fp8-native fast path (DEFAULT ON where capable; ASFP8_FP8_EXT=off disables). When the gate is
 # unset/0 this whole path is inert and torch._scaled_mm behaves exactly as the decode
 # implementation below — same numerics, zero extra work, no extension build.
 _backend = None          # the cpp module, or False once known-unavailable
@@ -64,9 +64,12 @@ def _min_dim():
 
 
 def _fast_eligible(input, other):
-    """Pure shape/dtype/env predicate (no device work, no import). Returns False
-    instantly when ASFP8_FP8_EXT is unset/0 so the default decode path is untouched."""
-    if os.environ.get("ASFP8_FP8_EXT") != "1":
+    """Shape/dtype/capability predicate (no per-call device work). The fp8_ext fast
+    path is DEFAULT ON, gated on Tier B (Metal-4 tensor ops + ninja for the ObjC++
+    extension). ASFP8_FP8_EXT=off force-disables; =1 forces it on. The capability
+    probes are memoised, so this stays cheap on the hot matmul path."""
+    from . import _caps
+    if not _caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.tier_b_ready):
         return False
     # The kernel decodes both operands as e4m3; only route when that's exact.
     if input.dtype != torch.float8_e4m3fn or other.dtype != torch.float8_e4m3fn:
@@ -162,7 +165,7 @@ def _mps_scaled_mm(
             bias=bias, scale_result=scale_result, use_fast_accum=use_fast_accum,
         )
 
-    # EXPERIMENTAL opt-in fast path: fp8xfp8 -> f32 via the Metal 4.1 kernel. Any
+    # fp8-native fast path: fp8xfp8 -> f32 via the Metal 4.1 kernel. Any
     # failure (build/parity/runtime) falls through to the decode path below, so a
     # render never breaks. Inert unless ASFP8_FP8_EXT=1.
     if _fast_eligible(input, other):

--- a/dev/bench_conv_im2col.py
+++ b/dev/bench_conv_im2col.py
@@ -1,0 +1,58 @@
+# dev/bench_conv_im2col.py
+import time
+
+import torch
+
+from _patches.conv_im2col_mps import conv_im2col
+
+
+def bench(fn, it=20, warmup=3):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t = time.perf_counter()
+    for _ in range(it):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t) / it * 1e3
+
+
+def verify(ours, x, w, **kw):
+    """Correctness gate BEFORE timing: compare to fp32 reference; report max-diff."""
+    ref = torch.nn.functional.conv2d(x.float(), w.float(), **kw) if w.dim() == 4 \
+        else torch.nn.functional.conv3d(x.float(), w.float(), **kw)
+    got = ours().float()
+    maxdiff = (got - ref).abs().max().item()
+    ok = maxdiff < 2e-1
+    print(f"  correctness: max|diff|={maxdiff:.4g} -> {'OK' if ok else 'FAIL'}")
+    return ok
+
+
+def main():
+    x = torch.randn(1, 256, 512, 512, device="mps", dtype=torch.float16)
+    w = torch.randn(256, 256, 3, 3, device="mps", dtype=torch.float16)
+    if not verify(lambda: conv_im2col(x, w, None, 1, 1), x, w, padding=1):
+        print("DECISION: correctness FAIL -> do not ship regardless of speed")
+        return
+    torch.mps.empty_cache()
+    ours = bench(lambda: conv_im2col(x, w, None, 1, 1))
+    stock = bench(lambda: torch.nn.functional.conv2d(x, w, padding=1))
+    print(f"conv2d  im2col={ours:.3f}ms  stock={stock:.3f}ms  speedup={stock / ours:.2f}x")
+    print(f"  current_allocated (NOT peak): {torch.mps.current_allocated_memory() / 1024**3:.2f}GiB")
+
+    # --- conv3d (SeedVR2-ish), appended in Task B.6 ---
+    x3 = torch.randn(1, 128, 5, 256, 256, device="mps", dtype=torch.float16)
+    w3 = torch.randn(128, 128, 3, 3, 3, device="mps", dtype=torch.float16)
+    if not verify(lambda: conv_im2col(x3, w3, None, 1, 1), x3, w3, padding=1):
+        print("DECISION: conv3d correctness FAIL -> do not ship regardless of speed")
+        return
+    torch.mps.empty_cache()
+    o3 = bench(lambda: conv_im2col(x3, w3, None, 1, 1))
+    cur = torch.mps.current_allocated_memory() / 1024**3  # current, NOT peak
+    s3 = bench(lambda: torch.nn.functional.conv3d(x3, w3, padding=1))
+    print(f"conv3d  im2col={o3:.3f}ms  stock={s3:.3f}ms  speedup={s3 / o3:.2f}x  "
+          f"current_alloc_after_ours={cur:.2f}GiB (NOT peak)")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/bench_conv_im2col.py
+++ b/dev/bench_conv_im2col.py
@@ -1,9 +1,14 @@
 # dev/bench_conv_im2col.py
+import os
+import sys
 import time
 
 import torch
 
-from _patches.conv_im2col_mps import conv_im2col
+# repo root (parent of dev/) on path so `_patches` imports when run as a script
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from _patches.conv_im2col_mps import conv_im2col  # noqa: E402
 
 
 def bench(fn, it=20, warmup=3):

--- a/dev/bench_fused_activation.py
+++ b/dev/bench_fused_activation.py
@@ -1,0 +1,32 @@
+"""Bench: fused SiLU epilogue vs (fused-no-act kernel + torch.silu)."""
+import os, time, torch
+os.environ.setdefault("ASFP8_INT8_EXT", "1")
+from _patches.int8_ext import loader
+mod = loader.module(); assert mod is not None; mod.warmup()
+
+dev = "mps"
+M, K, N = 4096, 1536, 6144
+x8 = torch.randint(-128, 128, (M, K), dtype=torch.int8, device=dev)
+w  = torch.randint(-128, 128, (N, K), dtype=torch.int8, device=dev)
+rs = (torch.rand(M, device=dev) * 0.01 + 0.001).float().contiguous()
+b  = torch.randn(N, device=dev, dtype=torch.bfloat16)
+
+def fused():     return mod.i8_matmul2d_nt_fused(x8, w, rs, b, 1)         # act=silu
+def separate():  return torch.nn.functional.silu(mod.i8_matmul2d_nt_fused(x8, w, rs, b, 0))
+
+# Correctness FIRST (review MAJOR #8): a fast-but-wrong kernel must fail before any timing.
+# Tolerance is one bf16 ulp (rtol=8e-3) + atol=2e-3 near zero — see D-results.md / the
+# test rationale: 2e-3 rtol is below bf16 precision and unsatisfiable at large magnitude.
+of, os_ = fused(), separate(); torch.mps.synchronize()
+md = (of.float() - os_.float()).abs().max().item()
+print(f"correctness: max|d|={md:.4g}")
+assert torch.allclose(of, os_, atol=2e-3, rtol=8e-3), f"CORRECTNESS FAIL: max|d|={md:.4g}"
+
+def bench(fn, it=50):
+    fn(); torch.mps.synchronize(); t = time.perf_counter()
+    for _ in range(it): fn()
+    torch.mps.synchronize(); return (time.perf_counter() - t) / it * 1e3
+
+f, s = bench(fused), bench(separate)
+print(f"M={M} K={K} N={N}: separate={s:.3f}ms fused={f:.3f}ms speedup={s/f:.2f}x")
+assert f <= s * 1.02, "fused must not be slower than separate"

--- a/dev/bench_fused_norm.py
+++ b/dev/bench_fused_norm.py
@@ -1,0 +1,76 @@
+# dev/bench_fused_norm.py
+"""Bench the fused kernel vs the separate-op torch composition at a DiT adaLN-tail shape.
+Reports first-call (compile) ms, steady-state ms, speedup, and an approximate achieved bandwidth.
+PASS = fused matches separate (allclose) AND ran on the kernel path AND fused < separate."""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import torch
+
+from _patches import fused_norm_mps as m
+from _patches.fused_norm_mps import fused_rmsnorm_modulate
+
+assert torch.backends.mps.is_available(), "bench needs an MPS device"
+
+rows, dim = 1 << 20, 1536
+dt = torch.float16
+x = torch.randn(rows, dim, device="mps", dtype=dt)
+w = torch.randn(dim, device="mps", dtype=dt)
+sc = torch.randn(dim, device="mps", dtype=dt)
+sh = torch.randn(dim, device="mps", dtype=dt)
+res = torch.randn(rows, dim, device="mps", dtype=dt)
+
+
+def separate():
+    h = torch.nn.functional.rms_norm(x, (dim,), w, 1e-6)
+    return res + h * (1.0 + sc) + sh
+
+
+def fused():
+    return fused_rmsnorm_modulate(x, w, 1e-6, sc, sh, res)
+
+
+# ---- correctness + kernel-path proof BEFORE timing ----
+out_f = fused()
+assert m._last_backend == "kernel", "fused() fell back to torch composition; benchmark would be a lie"
+out_s = separate()
+torch.mps.synchronize()
+maxdiff = (out_f.float() - out_s.float()).abs().max().item()
+assert torch.allclose(out_f.float(), out_s.float(), atol=5e-2, rtol=5e-2), \
+    f"CORRECTNESS FAIL: max abs diff {maxdiff:.4g} — do not trust the timing"
+print(f"correctness OK (max abs diff {maxdiff:.4g}, backend={m._last_backend})")
+
+# ---- first-call (compile) cost, measured on a fresh dtype lib ----
+m._libs.clear()
+torch.mps.synchronize()
+t0 = time.perf_counter()
+fused()
+torch.mps.synchronize()
+compile_ms = (time.perf_counter() - t0) * 1e3
+print(f"first-call (compile_shader) latency: {compile_ms:.1f} ms")
+
+
+def bench(fn, it=50, warmup=10):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t = time.perf_counter()
+    for _ in range(it):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t) / it * 1e3
+
+
+sep_ms = bench(separate)
+fus_ms = bench(fused)
+assert m._last_backend == "kernel", "fused path changed to fallback during timing"
+bytes_fused = 3 * rows * dim * x.element_size()  # read x + read residual + write out
+gbps = bytes_fused / (fus_ms * 1e-3) / 1e9
+print(f"rows={rows} dim={dim} dtype={dt}")
+print(f"separate={sep_ms:.3f}ms  fused={fus_ms:.3f}ms  speedup={sep_ms/fus_ms:.2f}x  "
+      f"fused~{gbps:.0f} GB/s (BW estimate only; no measured roofline)")
+assert fus_ms < sep_ms, "REGRESSION: fused slower than separate ops"

--- a/dev/bench_fused_swiglu.py
+++ b/dev/bench_fused_swiglu.py
@@ -1,0 +1,42 @@
+"""Bench: fused SwiGLU kernel vs (2 fused-no-act kernels + torch silu + mul)."""
+import os, time, torch
+os.environ.setdefault("ASFP8_INT8_EXT", "1")
+from _patches.int8_ext import loader
+mod = loader.module(); assert mod is not None; mod.warmup()
+dev = "mps"; M, K, N = 4096, 1536, 6144
+x8 = torch.randint(-128, 128, (M, K), dtype=torch.int8, device=dev)
+wg = torch.randint(-128, 128, (N, K), dtype=torch.int8, device=dev)
+wu = torch.randint(-128, 128, (N, K), dtype=torch.int8, device=dev)
+rsg = (torch.rand(M, device=dev) * 0.01 + 0.001).float().contiguous()
+rsu = (torch.rand(M, device=dev) * 0.01 + 0.001).float().contiguous()
+
+def fused():
+    return mod.i8_matmul2d_nt_swiglu(x8, wg, wu, rsg, rsu, None, None, 1)
+def unfused():
+    g = mod.i8_matmul2d_nt_fused(x8, wg, rsg, None, 0)
+    u = mod.i8_matmul2d_nt_fused(x8, wu, rsu, None, 0)
+    return torch.nn.functional.silu(g) * u
+
+# Correctness FIRST (review MAJOR #8): never report a speedup for a wrong gate kernel.
+# The fused kernel keeps act(gate) in fp32 (single rounding); the correct reference does the
+# same — torch silu in fp32 * up in fp32, rounded once (the unfused chain double-rounds the
+# silu intermediate to bf16, which is NOT what fusion targets). Tolerance = one bf16 ulp
+# (rtol=8e-3) + atol=2e-3 near zero. See docs/superpowers/results/D-results.md.
+of = fused()
+g = mod.i8_matmul2d_nt_fused(x8, wg, rsg, None, 0)
+u = mod.i8_matmul2d_nt_fused(x8, wu, rsu, None, 0)
+ref = (torch.nn.functional.silu(g.float()) * u.float()).to(torch.bfloat16)
+torch.mps.synchronize()
+md = (of.float() - ref.float()).abs().max().item()
+print(f"correctness: max|d|={md:.4g}")
+assert torch.allclose(of, ref, atol=2e-3, rtol=8e-3), f"CORRECTNESS FAIL: max|d|={md:.4g}"
+
+def bench(fn, it=50):
+    fn(); torch.mps.synchronize(); t = time.perf_counter()
+    for _ in range(it): fn()
+    torch.mps.synchronize(); return (time.perf_counter() - t) / it * 1e3
+f, s = bench(fused), bench(unfused)
+print(f"M={M} K={K} N={N}: unfused={s:.3f}ms fused={f:.3f}ms speedup={s/f:.2f}x")
+if f > s * 1.02:
+    print("DECISION (Open Q #4): fused gate is SLOWER -> mark single-pass kernel experimental, "
+          "ship the two-fused-calls + activation-multiply fallback as the default path.")

--- a/dev/bench_int4_vs_int8_paired.py
+++ b/dev/bench_int4_vs_int8_paired.py
@@ -1,0 +1,108 @@
+"""Paired int4-vs-int8 bench: both models in ONE process, evals INTERLEAVED.
+
+Why: separately-launched runs of the same model disagreed by 13% (4.135 vs 3.651
+s/eval), and a single 8-eval run drifts ~5% monotonically (thermal). Both are
+larger than the int4-vs-int8 effect being measured, so sequential process runs
+cannot resolve it. Interleaving A/B/A/B makes thermal state and drift common-mode
+to both arms; the paired per-round ratio is then meaningful even if the absolute
+numbers wander.
+
+Also sweeps M (latent size), because the harness (M=4096) and the live ComfyUI
+workflow disagree about the int4/int8 ratio (1.09x vs 1.95x) and M is one of the
+few things that differs.
+
+Run:
+  ASFP8_INT4_EXT=1 ASFP8_INT8_EXT=1 "<venv>/bin/python" dev/bench_int4_vs_int8_paired.py [rounds]
+"""
+
+import os
+import statistics
+import sys
+import time
+
+COMFY_MASTER = os.path.expanduser(os.environ.get("ASFP8_COMFY", "~/ComfyUI-Installs/ComfyUI/ComfyUI"))
+NODE_DIR = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-AppleSilicon-FP8"
+MODELS = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/models/diffusion_models"
+
+sys.path.insert(0, COMFY_MASTER)
+sys.path.insert(0, NODE_DIR)
+
+from _patches import psutil_vmstat  # noqa: E402
+
+psutil_vmstat.install()
+
+import torch  # noqa: E402
+
+import comfy.sd  # noqa: E402
+import comfy.model_management as mm  # noqa: E402
+
+from _patches import int4_linear_mps, int8_linear_kernel_mps, int8_linear_mps, int_mm_mps  # noqa: E402
+
+for _p in (int4_linear_mps, int_mm_mps, int8_linear_mps, int8_linear_kernel_mps):
+    _p.install()
+
+ROUNDS = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+
+ARMS = [
+    ("int4", os.path.join(MODELS, "krea2_turbo-int4_convrot.safetensors")),
+    ("int8", os.path.join(MODELS, "Krea2_Turbo_convrot_int8mixed.safetensors")),
+]
+
+loaded = []
+for name, path in ARMS:
+    print(f"loading {name} ...", flush=True)
+    m = comfy.sd.load_diffusion_model(path)
+    mm.load_models_gpu([m], force_full_load=True)
+    loaded.append((name, m, m.model.diffusion_model))
+
+device = mm.get_torch_device()
+
+
+def make_inputs(dm, dtype, hw):
+    c_in = (dm.input_embed.proj.in_features // (dm.input_embed.patch ** 2)
+            if hasattr(dm, "input_embed") else 16)
+    x = torch.randn(1, c_in, hw, hw, device=device, dtype=dtype)
+    context = torch.randn(1, 512, 12 * 2560, device=device, dtype=dtype)
+    ts = torch.full((1,), 0.5, device=device, dtype=dtype)
+    return x, ts, context
+
+
+def one_eval(dm, inputs):
+    with torch.no_grad():
+        t0 = time.perf_counter()
+        _ = dm(*inputs)
+        torch.mps.synchronize()
+        return time.perf_counter() - t0
+
+
+for hw in (96, 128, 160):
+    tokens = (hw // 2) ** 2
+    print(f"\n{'=' * 62}\nlatent {hw}x{hw}  (~{hw * 8}px, M={tokens} tokens)\n{'=' * 62}")
+
+    prepared = []
+    for name, m, dm in loaded:
+        inp = make_inputs(dm, m.model.get_dtype(), hw)
+        for _ in range(2):  # warmup this arm at this shape
+            one_eval(dm, inp)
+        prepared.append((name, dm, inp))
+
+    series = {n: [] for n, _, _ in prepared}
+    ratios = []
+    for r in range(ROUNDS):
+        got = {}
+        for name, dm, inp in prepared:  # interleaved within each round
+            t = one_eval(dm, inp)
+            series[name].append(t)
+            got[name] = t
+        ratios.append(got["int4"] / got["int8"])
+
+    for name in series:
+        s = sorted(series[name])
+        med = s[len(s) // 2]
+        spread = (s[-1] - s[0]) / med * 100
+        print(f"  {name}: median {med:.3f}s  (min {s[0]:.3f}, max {s[-1]:.3f}, spread {spread:.1f}%)")
+
+    med_r = statistics.median(ratios)
+    print(f"  paired int4/int8 ratio: median {med_r:.3f}  "
+          f"(min {min(ratios):.3f}, max {max(ratios):.3f}, n={ROUNDS})")
+    print(f"  -> int4 is {abs(1 - med_r) * 100:.1f}% {'SLOWER' if med_r > 1 else 'FASTER'} than int8")

--- a/dev/bench_mps_conv.py
+++ b/dev/bench_mps_conv.py
@@ -1,0 +1,72 @@
+# dev/bench_mps_conv.py
+"""Baseline stock MPS conv2d/conv3d vs the MEASURED matmul GEMM at the same M,N,K.
+Decides whether conv2d is already competitive (=> only conv3d needs the im2col kernel).
+No paper roofline is used for the go/no-go: we compare to the achieved same-shape GEMM."""
+import subprocess
+import time
+
+import torch
+
+
+def device_id():
+    try:
+        return subprocess.check_output(
+            ["system_profiler", "SPHardwareDataType"], text=True
+        )
+    except Exception as e:  # noqa: BLE001
+        return f"(system_profiler unavailable: {e!r})"
+
+
+def bench(fn, iters=20, warmup=3):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t) / iters * 1e3  # ms
+
+
+def gflops(flop, ms):
+    return flop / (ms * 1e-3) / 1e9
+
+
+def gemm_achieved(M, K, N, dtype=torch.float16):
+    """Measured achieved GFLOP/s of a stock MPS GEMM at the conv tile's M,N,K."""
+    a = torch.randn(M, K, device="mps", dtype=dtype)
+    b = torch.randn(N, K, device="mps", dtype=dtype)
+    ms = bench(lambda: a @ b.t())
+    return ms, gflops(2 * M * K * N, ms)
+
+
+def main():
+    print("=== device ===")
+    print(device_id())
+
+    # conv2d 3x3, 256ch, 512x512
+    x2 = torch.randn(1, 256, 512, 512, device="mps", dtype=torch.float16)
+    w2 = torch.randn(256, 256, 3, 3, device="mps", dtype=torch.float16)
+    ms2 = bench(lambda: torch.nn.functional.conv2d(x2, w2, padding=1))
+    P2, K2, Co2 = 512 * 512, 256 * 9, 256
+    gms2, gtf2 = gemm_achieved(P2, K2, Co2)
+    print(f"conv2d 3x3 256ch 512x512: {ms2:.3f} ms  {gflops(2 * P2 * K2 * Co2, ms2):.1f} GFLOP/s")
+    print(f"  measured GEMM @ M={P2},K={K2},N={Co2}: {gms2:.3f} ms  {gtf2:.1f} GFLOP/s "
+          f"(conv2d achieves {gflops(2 * P2 * K2 * Co2, ms2) / gtf2 * 100:.0f}% of achieved GEMM)")
+
+    # conv3d 3x3x3, 128ch, 5x256x256 (SeedVR2-ish)
+    x3 = torch.randn(1, 128, 5, 256, 256, device="mps", dtype=torch.float16)
+    w3 = torch.randn(128, 128, 3, 3, 3, device="mps", dtype=torch.float16)
+    ms3 = bench(lambda: torch.nn.functional.conv3d(x3, w3, padding=1))
+    P3, K3, Co3 = 5 * 256 * 256, 128 * 27, 128
+    gms3, gtf3 = gemm_achieved(P3, K3, Co3)
+    print(f"conv3d 3x3x3 128ch 5x256x256: {ms3:.3f} ms  {gflops(2 * P3 * K3 * Co3, ms3):.1f} GFLOP/s")
+    print(f"  measured GEMM @ M={P3},K={K3},N={Co3}: {gms3:.3f} ms  {gtf3:.1f} GFLOP/s "
+          f"(conv3d achieves {gflops(2 * P3 * K3 * Co3, ms3) / gtf3 * 100:.0f}% of achieved GEMM)")
+
+    alloc = torch.mps.driver_allocated_memory() / 1024**3
+    print(f"driver_allocated (current, NOT peak): {alloc:.2f} GiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/bench_rope_fast.py
+++ b/dev/bench_rope_fast.py
@@ -1,0 +1,82 @@
+# dev/bench_rope_fast.py
+"""Bench fused RoPE vs REAL eager over ALL FOUR public ops (+ cross-length) on a Flux-like shape.
+PASS = for each op: fused matches real eager (allclose) AND every call ran on the kernel path AND
+fused < eager. Reports ms/call + an estimated per-step win from the profiled rotary share."""
+import os, sys, time
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import torch
+from _patches import rope_fast_mps as m
+assert torch.backends.mps.is_available(), "bench needs MPS"
+m.install_for_test()   # capture real eager originals for the oracle/fallback
+# IMPORTANT: install_for_test() patches BOTH the eager package AND the eager.rope source module
+# (MAJOR 4 defence-in-depth), so `comfy_kitchen...rope.apply_rope1` is now our fused fn. The REAL
+# eager baseline is the captured originals in m._orig (computed before patching).
+# The captured single-tensor originals compute directly (no internal global lookup), so they are
+# the clean baseline. The captured PAIR originals are NOT usable: their body looks up apply_rope1
+# in rope.py's globals, which the defence-in-depth patch replaced -> they would delegate to the
+# fused kernel. The true eager pair is literally two true-single calls, so reconstruct it.
+eager_apply_rope1            = m._orig["apply_rope1"]
+eager_apply_rope_split_half1 = m._orig["apply_rope_split_half1"]
+def eager_apply_rope(xq, xk, fr):
+    return eager_apply_rope1(xq, fr), eager_apply_rope1(xk, fr)
+def eager_apply_rope_split_half(xq, xk, fr):
+    return eager_apply_rope_split_half1(xq, fr), eager_apply_rope_split_half1(xk, fr)
+
+B,H,L,D = 1,24,4608,128; halfD=D//2
+dt = torch.bfloat16
+x  = torch.randn(B,H,L,D, device="mps", dtype=dt)
+fr = torch.randn(1,1,L,halfD,2,2, device="mps", dtype=torch.float32)
+# cross-length key tensor (interleaved eager slices freqs_cis[:, :, :Lk], so Lk<L is valid):
+Lk = 512
+xk = torch.randn(B,H,Lk,D, device="mps", dtype=dt)
+# NOTE: eager apply_rope_split_half1 has NO cross-length slice (unlike apply_rope1), so a shorter
+# key would make eager split-half RAISE -- cross-length split-half is not an eager scenario. The
+# split-half pair is therefore benched at matching length (eager-valid) with a second full tensor.
+xk2 = torch.randn(B,H,L,D, device="mps", dtype=dt)
+
+def bench(fn, it=100, warm=20):
+    for _ in range(warm): fn()
+    torch.mps.synchronize(); t=time.perf_counter()
+    for _ in range(it): fn()
+    torch.mps.synchronize(); return (time.perf_counter()-t)/it*1e3
+
+# (op_label, eager_call, fused_call, expected_n_calls)
+CASES = [
+    ("apply_rope1 (interleaved)",
+        lambda: eager_apply_rope1(x, fr),
+        lambda: m.apply_rope1_fused(x, fr), 1),
+    ("apply_rope (pair, interleaved)",
+        lambda: eager_apply_rope(x, xk, fr),
+        lambda: m.apply_rope_fused_pair(x, xk, fr), 2),
+    ("apply_rope_split_half1 (split)",
+        lambda: eager_apply_rope_split_half1(x, fr),
+        lambda: m.apply_rope_split_half1_fused(x, fr), 1),
+    ("apply_rope_split_half (pair, split)",
+        lambda: eager_apply_rope_split_half(x, xk2, fr),
+        lambda: m.apply_rope_split_half_fused_pair(x, xk2, fr), 2),
+]
+
+failed = False
+for label, eager, fused, ncalls in CASES:
+    m._backend_events.clear()
+    out_f = fused()
+    kinds = [ev[1] for ev in m._backend_events]
+    assert len(kinds) == ncalls and all(k == "kernel" for k in kinds), \
+        f"{label}: expected {ncalls} kernel call(s), got {kinds}"
+    out_e = eager()
+    torch.mps.synchronize()
+    def _flat(o): return torch.cat([t.float().reshape(-1) for t in (o if isinstance(o, tuple) else (o,))])
+    maxdiff = (_flat(out_f) - _flat(out_e)).abs().max().item()
+    assert maxdiff < 5e-2, f"{label}: CORRECTNESS FAIL max abs diff {maxdiff:.4g}"
+    e_ms = bench(eager); f_ms = bench(fused)
+    speed = e_ms / f_ms
+    print(f"{label:36s}: eager={e_ms:7.3f}ms fused={f_ms:7.3f}ms speedup={speed:5.2f}x "
+          f"(maxdiff {maxdiff:.2g})")
+    if f_ms >= e_ms:
+        print(f"  REGRESSION: {label} fused not faster"); failed = True
+
+# estimated per-step win from the (interleaved) speedup; rotary ~7-12% of step (profiled).
+print("note: end-to-end win is HUMAN-gated (Task 7) and only applies to models whose rotary is "
+      "the comfy_kitchen path (Task 0c).")
+assert not failed, "at least one convention regressed or fell back"

--- a/dev/bench_torch_compile_fusion.py
+++ b/dev/bench_torch_compile_fusion.py
@@ -1,0 +1,326 @@
+"""Issue A benchmark: Inductor MPS fusion speedup on the DiT-block bandwidth-bound tail.
+
+Measures three configurations:
+  1. eager  — stock torch ops, no compile (baseline)
+  2. compiled (bw-tail only) — rms_norm + silu + residual, no linear
+  3. compiled (full block)   — rms_norm + linear + silu + residual
+
+Correctness is asserted BEFORE the timing loop. DECISION: CORRECTNESS_FAIL
+is emitted if compiled output diverges, regardless of speed.
+
+ADOPT_COMPILE requires BOTH:
+  - bw_tail speedup >= 1.5x (timing gate)
+  - Probe 0a dispatch_count <= 1 (fusion gate, confirmed in Task A.0)
+
+Run (from repo root, no ASFP8_PROFILE=1):
+  /Volumes/IMPERIAL\\ SPACE/AI/ComfyUI/.venv/bin/python dev/bench_torch_compile_fusion.py
+
+NOTE: First run includes Inductor compile time. Subsequent runs use the kernel
+cache. Warmup is done inside each bench() call to ensure only steady-state
+execution is timed.
+"""
+
+import time
+import sys
+
+import torch
+import torch.nn.functional as F
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+DEVICE = "mps"
+DTYPE = torch.float16
+B, S, D = 2, 4096, 1536   # production DiT shape
+WARMUP = 5
+ITERS = 50
+
+DECISION_THRESHOLD = 1.5   # bw-tail speedup threshold to adopt compile
+
+
+# ---------------------------------------------------------------------------
+# Blocks under test
+# ---------------------------------------------------------------------------
+
+def bw_tail(x, weight, W):
+    """Bandwidth-bound tail: rms_norm + silu + residual. No linear."""
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = F.silu(h)
+    return x + h
+
+
+def full_block(x, weight, W):
+    """Full DiT block tail: rms_norm + linear + silu + residual."""
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = (h.reshape(-1, h.shape[-1]) @ W.T).reshape(x.shape)
+    h = F.silu(h)
+    return x + h
+
+
+# ---------------------------------------------------------------------------
+# Fusion inspection
+# ---------------------------------------------------------------------------
+
+def inspect_graphs(fn, x, weight, W):
+    """Return (graph_count, break_reasons) for fn via torch._dynamo.explain."""
+    import torch._dynamo as dynamo
+    try:
+        explanation = dynamo.explain(fn)(x, weight, W)
+        return explanation.graph_count, [str(r) for r in explanation.break_reasons]
+    except Exception as e:
+        return -1, [str(e)]
+
+
+# ---------------------------------------------------------------------------
+# Correctness assertion (run BEFORE timing loop)
+# ---------------------------------------------------------------------------
+
+def assert_correctness(compiled_fn, eager_fn, x, weight, W, name):
+    """Assert compiled output matches eager within fp16 tolerance.
+
+    Returns True on pass, False on fail (never raises — caller records result).
+    """
+    try:
+        eager_out = eager_fn(x, weight, W)
+        compiled_out = compiled_fn(x, weight, W)
+        torch.mps.synchronize()
+        torch.testing.assert_close(
+            compiled_out, eager_out, atol=1e-2, rtol=1e-2,
+        )
+        print(f"  [{name}] correctness: PASS "
+              f"(max_abs={(compiled_out - eager_out).abs().max().item():.4f})")
+        return True
+    except AssertionError as e:
+        print(f"  [{name}] correctness: FAIL — {e}")
+        return False
+    except Exception as e:
+        print(f"  [{name}] correctness: ERROR — {type(e).__name__}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Bench harness — mirrors dev/bench_gemm.py
+# ---------------------------------------------------------------------------
+
+def bench(fn, x, weight, W, warmup=WARMUP, iters=ITERS):
+    """Return ms/call (steady-state, after warmup). Uses true GPU time via sync."""
+    for _ in range(warmup):
+        fn(x, weight, W)
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn(x, weight, W)
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+def measure_compile_latency(fn, make_inputs_fn):
+    """Measure first-call (cold) compile+execute latency in ms.
+
+    Inputs are allocated BEFORE the timer starts so the measurement
+    captures compile + first-dispatch only (not tensor allocation).
+    """
+    torch._dynamo.reset()
+    compiled = torch.compile(fn, backend="inductor")
+    x, weight, W = make_inputs_fn()
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    compiled(x, weight, W)
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) * 1e3
+
+
+def make_inputs(seed=42):
+    g = torch.Generator(device=DEVICE).manual_seed(seed)
+    x = torch.randn(B, S, D, device=DEVICE, dtype=DTYPE, generator=g)
+    weight = torch.randn(D, device=DEVICE, dtype=DTYPE, generator=g)
+    W = torch.randn(D, D, device=DEVICE, dtype=DTYPE, generator=g)
+    return x, weight, W
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def sep(width=70): print("-" * width)
+
+def main():
+    if not torch.backends.mps.is_available():
+        print("MPS not available — cannot benchmark. Exiting.")
+        sys.exit(1)
+
+    print(f"Issue A — torch.compile Inductor MPS fusion benchmark")
+    print(f"PyTorch {torch.__version__} | device={DEVICE} | dtype={DTYPE} | shape=({B},{S},{D})")
+    print(f"warmup={WARMUP} iters={ITERS} | decision threshold={DECISION_THRESHOLD}x")
+    sep()
+
+    x, weight, W = make_inputs()
+
+    # ------------------------------------------------------------------
+    # 1. Fusion inspection
+    # ------------------------------------------------------------------
+    print("\n[1] Fusion inspection (torch._dynamo.explain)")
+    print("    Note: graph_count=1 is necessary but NOT sufficient for fusion.")
+    print("    True fusion requires dispatch_count<=1 in Probe 0a (Task A.0).")
+    for name, fn in [("bw_tail", bw_tail), ("full_block", full_block)]:
+        gc, reasons = inspect_graphs(fn, x, weight, W)
+        print(f"  {name:12s}: graph_count={gc}  breaks={reasons or 'none'}")
+
+    # ------------------------------------------------------------------
+    # 2. Compile latency (cold first call, inputs pre-allocated)
+    # ------------------------------------------------------------------
+    print("\n[2] First-call (cold) compile latency")
+    try:
+        cold_bw = measure_compile_latency(bw_tail, make_inputs)
+        print(f"  bw_tail   cold compile+run: {cold_bw:.0f} ms")
+    except Exception as e:
+        print(f"  bw_tail   COMPILE FAILED: {e}")
+        cold_bw = None
+
+    torch._dynamo.reset()
+    try:
+        cold_full = measure_compile_latency(full_block, make_inputs)
+        print(f"  full_block cold compile+run: {cold_full:.0f} ms")
+    except Exception as e:
+        print(f"  full_block COMPILE FAILED: {e}")
+        cold_full = None
+
+    # ------------------------------------------------------------------
+    # 3. Steady-state benchmark (correctness first, then timing)
+    # ------------------------------------------------------------------
+    print("\n[3] Steady-state benchmark (correctness asserted before timing)")
+    sep()
+
+    results = {}
+    correctness_ok = {}
+
+    # -- bw_tail eager --
+    eager_bw_ms = bench(bw_tail, x, weight, W)
+    results["eager_bw_ms"] = eager_bw_ms
+    print(f"  bw_tail   eager:    {eager_bw_ms:.3f} ms")
+
+    # -- bw_tail compiled --
+    try:
+        torch._dynamo.reset()
+        compiled_bw = torch.compile(bw_tail, backend="inductor")
+        # warmup (triggers compilation on first call)
+        for _ in range(WARMUP):
+            compiled_bw(x, weight, W)
+        torch.mps.synchronize()
+
+        # Correctness BEFORE timing
+        correctness_ok["bw_tail"] = assert_correctness(
+            compiled_bw, bw_tail, x, weight, W, "bw_tail"
+        )
+
+        comp_bw_ms = bench(compiled_bw, x, weight, W, warmup=0)
+        results["comp_bw_ms"] = comp_bw_ms
+        speedup_bw = eager_bw_ms / comp_bw_ms
+        results["speedup_bw"] = speedup_bw
+        print(f"  bw_tail   compiled: {comp_bw_ms:.3f} ms  speedup={speedup_bw:.2f}x")
+    except Exception as e:
+        print(f"  bw_tail   compiled: FAILED ({type(e).__name__}: {str(e)[:100]})")
+        results["comp_bw_ms"] = None
+        results["speedup_bw"] = None
+        correctness_ok["bw_tail"] = False
+
+    # -- full_block eager --
+    eager_full_ms = bench(full_block, x, weight, W)
+    results["eager_full_ms"] = eager_full_ms
+    print(f"  full_block eager:    {eager_full_ms:.3f} ms")
+
+    # -- full_block compiled --
+    try:
+        torch._dynamo.reset()
+        compiled_full = torch.compile(full_block, backend="inductor")
+        for _ in range(WARMUP):
+            compiled_full(x, weight, W)
+        torch.mps.synchronize()
+
+        # Correctness BEFORE timing
+        correctness_ok["full_block"] = assert_correctness(
+            compiled_full, full_block, x, weight, W, "full_block"
+        )
+
+        comp_full_ms = bench(compiled_full, x, weight, W, warmup=0)
+        results["comp_full_ms"] = comp_full_ms
+        speedup_full = eager_full_ms / comp_full_ms
+        results["speedup_full"] = speedup_full
+        print(f"  full_block compiled: {comp_full_ms:.3f} ms  speedup={speedup_full:.2f}x")
+    except Exception as e:
+        print(f"  full_block compiled: FAILED ({type(e).__name__}: {str(e)[:100]})")
+        results["comp_full_ms"] = None
+        results["speedup_full"] = None
+        correctness_ok["full_block"] = False
+
+    # ------------------------------------------------------------------
+    # 4. Roofline check (presented as range, not a single confident bound)
+    # ------------------------------------------------------------------
+    print("\n[4] Bandwidth roofline analysis (range — see Task A.0 Probe 0a for dispatch truth)")
+    # rms_norm bytes: optimistic (1 read) vs conservative (2 reads)
+    per_tensor = B * S * D * 2  # bytes for one fp16 tensor
+    # Optimistic: rms_norm = 1 read + 1 write; silu = 1+1; residual = 2+1
+    eager_bytes_optimistic = per_tensor * (2 + 2 + 3)
+    # Conservative: rms_norm = 2 reads + 1 write; silu = 1+1; residual = 2+1
+    eager_bytes_conservative = per_tensor * (3 + 2 + 3)
+    fused_bytes = per_tensor * 3   # read x + read res + write out
+    bw_gbps = 400.0
+    ro_eager_opt = eager_bytes_optimistic / (bw_gbps * 1e9) * 1e3
+    ro_eager_con = eager_bytes_conservative / (bw_gbps * 1e9) * 1e3
+    ro_fused = fused_bytes / (bw_gbps * 1e9) * 1e3
+    print(f"  Roofline (M5 Max @400 GB/s):")
+    print(f"    eager  3-kernel min (optimistic):     {ro_eager_opt:.3f} ms  ({eager_bytes_optimistic/1e6:.0f} MB)")
+    print(f"    eager  3-kernel min (conservative):   {ro_eager_con:.3f} ms  ({eager_bytes_conservative/1e6:.0f} MB)")
+    print(f"    fused  1-kernel min:                  {ro_fused:.3f} ms  ({fused_bytes/1e6:.0f} MB)")
+    print(f"    max achievable speedup range: {ro_eager_opt/ro_fused:.2f}x – {ro_eager_con/ro_fused:.2f}x")
+    if results.get("comp_bw_ms") and results.get("eager_bw_ms"):
+        achieved = results["eager_bw_ms"] / results["comp_bw_ms"]
+        print(f"    achieved: {achieved:.2f}x vs theoretical range "
+              f"{ro_eager_opt/ro_fused:.2f}–{ro_eager_con/ro_fused:.2f}x")
+
+    # ------------------------------------------------------------------
+    # 5. Decision (requires BOTH speedup AND probe-0a dispatch_count)
+    # ------------------------------------------------------------------
+    print("\n[5] Decision")
+    sep()
+    speedup_bw = results.get("speedup_bw")
+    bw_correctness = correctness_ok.get("bw_tail", False)
+
+    if not bw_correctness:
+        decision = "CORRECTNESS_FAIL"
+        detail = (
+            "bw_tail compiled output diverged from eager. "
+            "Do NOT adopt compile. Issues D and E proceed at FULL scope."
+        )
+    elif speedup_bw is None:
+        decision = "COMPILE_FAILED"
+        detail = "Inductor MPS raised an error. Issues D and E proceed at FULL scope."
+    elif speedup_bw >= DECISION_THRESHOLD:
+        decision = "ADOPT_COMPILE_PENDING_PROBE_0A"
+        detail = (
+            f"bw-tail speedup={speedup_bw:.2f}x >= {DECISION_THRESHOLD}x threshold "
+            f"AND correctness passes. "
+            "FINAL DECISION requires Probe 0a dispatch_count <= 1 (check Task A.0 results). "
+            "If dispatch_count > 1, speedup reflects Python-overhead reduction only "
+            "(not DRAM traffic reduction) -> downgrade to HAND_KERNELS_NEEDED. "
+            "If dispatch_count <= 1 -> ADOPT_COMPILE: Issues D and E SHRINK to "
+            "'only what compile leaves behind' (primarily GEMM epilogue fusions)."
+        )
+    else:
+        decision = "HAND_KERNELS_NEEDED"
+        detail = (
+            f"bw-tail speedup={speedup_bw:.2f}x < {DECISION_THRESHOLD}x threshold. "
+            "Inductor MPS generates separate Metal kernels rather than a fused one. "
+            "Issues D and E proceed at FULL scope."
+        )
+
+    print(f"  DECISION: {decision}")
+    print(f"  {detail}")
+    sep()
+    print("\nPaste this output into the commit message for issue-A.")
+    print("Cross-reference with Task A.0 Probe 0a dispatch count before finalising.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/inspect_inductor_mps_fusion.py
+++ b/dev/inspect_inductor_mps_fusion.py
@@ -1,0 +1,103 @@
+"""Issue A: Inspect what Inductor MPS actually fuses for the DiT-block tail.
+
+Uses torch._dynamo.explain to count graphs and print break reasons.
+Uses TORCH_COMPILE_DEBUG=1 to print the generated lowered IR, from which
+the extern_kernels count gives the true Metal dispatch count.
+
+Runs at BOTH production shape (2,4096,1536) and small shape (1,256,512).
+Full output written to /tmp/inductor_inspect_A.txt — do not truncate with head.
+
+Run:
+  TORCH_COMPILE_DEBUG=1 \\
+    /Volumes/IMPERIAL\\ SPACE/AI/ComfyUI/.venv/bin/python \\
+    dev/inspect_inductor_mps_fusion.py 2>&1 | tee /tmp/inductor_inspect_A.txt
+"""
+import os
+import sys
+import torch
+import torch.nn.functional as F
+import torch._dynamo as dynamo
+
+DEVICE = "mps"
+DTYPE = torch.float16
+
+SHAPES = [
+    ("small (1,256,512)", 1, 256, 512),
+    ("production (2,4096,1536)", 2, 4096, 1536),
+]
+
+
+def make(b, s, d):
+    g = torch.Generator(device=DEVICE).manual_seed(0)
+    x = torch.randn(b, s, d, device=DEVICE, dtype=DTYPE, generator=g)
+    weight = torch.randn(d, device=DEVICE, dtype=DTYPE, generator=g)
+    W = torch.randn(d, d, device=DEVICE, dtype=DTYPE, generator=g)
+    return x, weight, W
+
+
+def bw_tail(x, weight, W):
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = F.silu(h)
+    return x + h
+
+
+def full_block(x, weight, W):
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = (h.reshape(-1, x.shape[-1]) @ W.T).reshape(x.shape)
+    h = F.silu(h)
+    return x + h
+
+
+def report(name, fn, b, s, d):
+    print(f"\n{'='*60}")
+    print(f"  {name}  shape=({b},{s},{d})")
+    print(f"{'='*60}")
+
+    x, weight, W = make(b, s, d)
+
+    # Graph structure
+    torch._dynamo.reset()
+    try:
+        explanation = dynamo.explain(fn)(x, weight, W)
+        print(f"  graph_count : {explanation.graph_count}")
+        print(f"  break_reasons: {[str(r) for r in explanation.break_reasons] or 'none'}")
+    except Exception as e:
+        print(f"  dynamo.explain failed: {e}")
+
+    # Lowered IR (Inductor) — printed by TORCH_COMPILE_DEBUG=1
+    print(f"\n  [Compiling with Inductor "
+          f"(lowered ops appear below if TORCH_COMPILE_DEBUG=1)]")
+    import torch._inductor.config as ind_cfg
+    old_debug = getattr(ind_cfg, "debug", False)
+    try:
+        ind_cfg.debug = True
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, backend="inductor", fullgraph=False)
+        compiled(x, weight, W)
+        torch.mps.synchronize()
+    except Exception as e:
+        print(f"  compile/run failed: {e}")
+    finally:
+        ind_cfg.debug = old_debug
+
+
+def main():
+    print("Issue A — Inductor MPS fusion inspector")
+    print(f"PyTorch {torch.__version__}")
+    print("Full output written to /tmp/inductor_inspect_A.txt via tee.")
+    print("Key things to count in Inductor debug output:")
+    print("  - 'extern_kernels': each = one separate MPS dispatch")
+    print("  - 'ComputedBuffer' with multiple ops: fused into 1 kernel")
+    print("  - rms_norm decomposition: 'aten.native_group_norm' or manual ops?")
+    print()
+
+    for shape_name, b, s, d in SHAPES:
+        for fn_name, fn in [("bw_tail", bw_tail), ("full_block", full_block)]:
+            report(f"{fn_name}", fn, b, s, d)
+
+    print("\nDone. Paste extern_kernels count for each shape into docs/superpowers/results/A-results.md.")
+    print("PASS threshold: bw_tail production shape extern_kernels (actual calls) == 0 (all fused).")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/inspect_inductor_mps_fusion.py
+++ b/dev/inspect_inductor_mps_fusion.py
@@ -86,7 +86,11 @@ def main():
     print(f"PyTorch {torch.__version__}")
     print("Full output written to /tmp/inductor_inspect_A.txt via tee.")
     print("Key things to count in Inductor debug output:")
-    print("  - 'extern_kernels': each = one separate MPS dispatch")
+    print("  - 'extern_kernels.' (with dot — actual method calls, e.g. extern_kernels.mm):")
+    print("    each call = one separate extern MPS dispatch.")
+    print("    NOTE: output_code.py always imports extern_kernels at the top — count only")
+    print("    'extern_kernels.' (dot) occurrences, not the bare 'extern_kernels' import line.")
+    print("  - 'compile_mps_shader': each = one fused Metal kernel (good)")
     print("  - 'ComputedBuffer' with multiple ops: fused into 1 kernel")
     print("  - rms_norm decomposition: 'aten.native_group_norm' or manual ops?")
     print()
@@ -95,8 +99,9 @@ def main():
         for fn_name, fn in [("bw_tail", bw_tail), ("full_block", full_block)]:
             report(f"{fn_name}", fn, b, s, d)
 
-    print("\nDone. Paste extern_kernels count for each shape into docs/superpowers/results/A-results.md.")
-    print("PASS threshold: bw_tail production shape extern_kernels (actual calls) == 0 (all fused).")
+    print("\nDone. Paste extern_kernels. (dot) call count for each shape into docs/superpowers/results/A-results.md.")
+    print("PASS threshold: bw_tail production shape extern_kernels. actual calls == 0 (all fused into Metal shader).")
+    print("NOTE: output_code.py always has 'from ... import extern_kernels' — that import line does NOT count.")
 
 
 if __name__ == "__main__":

--- a/dev/probe_F_flux_seam.py
+++ b/dev/probe_F_flux_seam.py
@@ -1,0 +1,134 @@
+"""Issue-F Task -1 — HARD PRE-WIRE GATE (HUMAN-REQUIRED): probe a real Flux-2-Klein load.
+
+This script CANNOT be run autonomously by the implementing agent — it needs Flux-2-Klein-9B
+(fp8) ACTUALLY LOADED in ComfyUI. The repo's INVESTIGATION_FACTS.md (S16) records that a prior
+fp8-Linear seam assumption was WRONG, so patch #20 (fp8_linear_kernel_mps) ships DEFAULT OFF and
+its wiring is treated as UNVALIDATED until this probe confirms three things on a live model:
+
+  (1) THE SEAM  — which class actually owns the fp8 Linear.forward, and that it is entered
+                  BEFORE torch._scaled_mm (i.e. before the activation is fp8-quantized).
+  (2) SCALE SHAPE — the weight dequant scale is scalar (numel 1) vs per-output-channel [N].
+  (3) ACT RANGE — real per-layer |x|.max() vs fp16's 65504 (the wrapper casts bf16->half).
+
+HOW TO RUN (human):
+  1. Launch ComfyUI with the env:
+        ASFP8_FP8_NATIVE=1 ASFP8_PROFILE=1 <comfyui launch>
+  2. Load a Flux-2-Klein-9B fp8 workflow and queue ONE 1024^2 render.
+  3. Either: paste the body below into a ComfyUI python console after the model object is in
+     scope, OR import this module and call probe(model) from a custom node / breakpoint, where
+     `model` is the DiT module (e.g. the loaded UNet/transformer torch.nn.Module).
+
+The probe is READ-ONLY: it installs temporary hooks/wrappers, runs/observes ONE step, then
+restores everything. It prints four findings and (if pointed at docs/) can be pasted into
+docs/superpowers/results/F-results.md under "Task -1 (real-model gate)".
+
+DECISION MATRIX (drives whether patch #20 can be enabled):
+  seam class   : MRO includes comfy.ops...mixed_precision_ops...Linear AND FORWARD logs BEFORE
+                 scaled_mm  -> proceed (wrapper target as written).
+                 If fp8_ops.Linear -> re-point install() at fp8_ops.Linear.forward_comfy_cast_weights.
+                 If manual_cast.Linear -> OUT OF SCOPE, stop.
+                 If FORWARD never logs before scaled_mm -> activation quantized upstream; seam wrong, stop.
+  scale shape  : () or (1,) -> scalar branch.  (N,) -> per-channel branch. Both already coded.
+  layout_cls   : TensorCoreFP8Layout / ...E4M3Layout + _qdata.dtype==float8_e4m3fn -> eligible.
+                 E5M2 / float8_e5m2 -> NOT eligible (kernel is e4m3-only); those layers fall back.
+  act |max|    : all << 65504 -> leave range guard off, document the bound.
+                 any >~ 65504 -> enable ASFP8_FP8_NATIVE_RANGE_GUARD=1, record outlier layers.
+"""
+import torch
+
+
+def probe(model, run_one_step=None):
+    """Run the three-part probe against a live Flux-2 `model` (an nn.Module).
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The loaded DiT (transformer) whose fp8 Linear layers we want to inspect.
+    run_one_step : callable | None
+        Optional zero-arg callable that triggers exactly ONE forward step of the model
+        (e.g. a single sampler step). If None, the OPTRACE and ACT-RANGE sections that need
+        a live forward are skipped with a warning; the static SEAM+SCALE dump still runs.
+    """
+    # ---------------------------------------------------------------------------------------
+    # (1) SEAM + SCALE SHAPE: find one eligible DiT fp8 Linear and dump its structure.
+    # ---------------------------------------------------------------------------------------
+    target = None
+    for name, m in model.named_modules():
+        w = getattr(m, "weight", None)
+        if hasattr(w, "_layout_cls") and str(w._layout_cls).startswith("TensorCoreFP8"):
+            print("NAME      :", name)
+            print("MRO       :", type(m).__mro__)            # <-- IS mixed_precision_ops.Linear in here?
+            print("layout_cls:", w._layout_cls)              # TensorCoreFP8Layout / ...E4M3Layout / ...E5M2Layout
+            print("qdata     :", tuple(w._qdata.shape), w._qdata.dtype, w._qdata.device)
+            sc = w._params.scale
+            sc_shape = tuple(sc.shape) if hasattr(sc, "shape") else "scalar"
+            print("scale     :", sc_shape, "numel", sc.numel(), sc.dtype, sc.device)
+            print("quant_fmt :", getattr(m, "quant_format", None), "layout_type:", getattr(m, "layout_type", None))
+            target = m
+            break
+    if target is None:
+        print("PROBE: no fp8 (TensorCoreFP8*) Linear found in this model — wrong model or wrong seam.")
+        return
+
+    if run_one_step is None:
+        print("PROBE: run_one_step not provided; skipping OPTRACE + ACT-RANGE (need a live forward).")
+        return
+
+    # ---------------------------------------------------------------------------------------
+    # (2) OPTRACE: confirm the candidate Linear.forward is ENTERED before torch._scaled_mm.
+    # ---------------------------------------------------------------------------------------
+    hits = []
+    _orig_smm = torch._scaled_mm
+
+    def _trace_smm(*a, **k):
+        hits.append("scaled_mm")
+        return _orig_smm(*a, **k)
+
+    cls = type(target)
+    _of = cls.forward
+
+    def _trace_fwd(self, *a, **k):
+        hits.append(f"FORWARD:{cls.__module__}.{cls.__qualname__}")
+        return _of(self, *a, **k)
+
+    torch._scaled_mm = _trace_smm
+    cls.forward = _trace_fwd
+    try:
+        run_one_step()
+    finally:
+        torch._scaled_mm = _orig_smm
+        cls.forward = _of
+    # EXPECT: "FORWARD:comfy.ops...Linear" appears, and BEFORE the matching "scaled_mm".
+    print("TRACE:", hits[:8])
+
+    # ---------------------------------------------------------------------------------------
+    # (3) ACTIVATION RANGE: forward pre-hook on first ~10 eligible fp8 Linears for ONE step.
+    # ---------------------------------------------------------------------------------------
+    seen = {}
+
+    def mk(name):
+        def f(mod, inp):
+            x = inp[0].detach()
+            seen[name] = float(x.float().abs().amax().cpu())
+        return f
+
+    handles = []
+    for name, m in model.named_modules():
+        w = getattr(m, "weight", None)
+        if hasattr(w, "_layout_cls") and str(w._layout_cls).startswith("TensorCoreFP8"):
+            handles.append(m.register_forward_pre_hook(mk(name)))
+            if len(handles) >= 10:
+                break
+    try:
+        run_one_step()
+    finally:
+        for h in handles:
+            h.remove()
+    print("ACT |max| per layer:", sorted(seen.items(), key=lambda kv: -kv[1])[:10], " (fp16 max 65504)")
+    print("PROBE DONE — fill in docs/superpowers/results/F-results.md 'Task -1' with these four findings.")
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    print("This is a HUMAN-RUN probe. Import it inside ComfyUI and call "
+          "probe(model, run_one_step=<one-sampler-step>).")

--- a/dev/probe_compile_shader_dispatch.py
+++ b/dev/probe_compile_shader_dispatch.py
@@ -1,0 +1,40 @@
+# dev/probe_compile_shader_dispatch.py
+"""B.0b probe: (1) device-int* PRM scalars arrive intact under compile_shader,
+(2) the 2D threadgroup grid maps with no axis transposition."""
+import torch
+
+_PRM_SRC = """
+#include <metal_stdlib>
+using namespace metal;
+kernel void prm_echo(device const int* PRM [[buffer(0)]], device int* O [[buffer(1)]],
+                     uint gid [[thread_position_in_grid]]) {
+    if (gid < 5) O[gid] = PRM[gid];
+}
+"""
+lib = torch.mps.compile_shader(_PRM_SRC)
+prm = torch.tensor([7, 11, 13, 17, 19], dtype=torch.int32, device="mps")
+out = torch.zeros(5, dtype=torch.int32, device="mps")
+lib.prm_echo(prm, out, threads=(32, 1, 1), group_size=(32, 1, 1))
+torch.mps.synchronize()
+print("PRM echo:", out.cpu().tolist(), "expect [7, 11, 13, 17, 19] ->",
+      "PASS" if out.cpu().tolist() == [7, 11, 13, 17, 19] else "FAIL")
+
+_GRID_SRC = """
+#include <metal_stdlib>
+using namespace metal;
+// write the (tx,ty) threadgroup coords of each block into G[ty*GX + tx]
+kernel void grid_echo(device int* G [[buffer(0)]], device const int* DIM [[buffer(1)]],
+                      uint3 tg [[threadgroup_position_in_grid]]) {
+    const int GX = DIM[0];
+    G[int(tg.y) * GX + int(tg.x)] = int(tg.x) * 100 + int(tg.y);
+}
+"""
+gx, gy, TG = 3, 2, 32
+lib2 = torch.mps.compile_shader(_GRID_SRC)
+G = torch.full((gx * gy,), -1, dtype=torch.int32, device="mps")
+DIM = torch.tensor([gx, gy], dtype=torch.int32, device="mps")
+lib2.grid_echo(G, DIM, threads=(gx * TG, gy, 1), group_size=(TG, 1, 1))
+torch.mps.synchronize()
+got = G.cpu().tolist()
+want = [tx * 100 + ty for ty in range(gy) for tx in range(gx)]
+print("grid echo:", got, "expect", want, "->", "PASS" if got == want else "FAIL (axis transposed?)")

--- a/dev/probe_fused_norm.py
+++ b/dev/probe_fused_norm.py
@@ -1,0 +1,89 @@
+# dev/probe_fused_norm.py
+"""Task 0 empirical probes for issue E. Compiles + runs the three compile_shader facts the
+fused-norm kernel depends on, prints PASS/FAIL for each, and exits non-zero if a BLOCKER probe
+fails. Run BEFORE implementing the kernel; record the output in the commit message."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import torch
+
+if not (torch.backends.mps.is_available() and hasattr(torch.mps, "compile_shader")):
+    print("SKIP: needs MPS + torch.mps.compile_shader")
+    sys.exit(0)
+
+failures = []
+
+# ---- probe #1: grid.y ~= 2^24 dispatch (does a giant non-x grid dimension work?) ----
+GRID_SRC = r"""
+#include <metal_stdlib>
+using namespace metal;
+kernel void grid_probe(device uint* out [[buffer(0)]],
+                       uint3 tgid [[threadgroup_position_in_grid]]) {
+    out[tgid.y] = tgid.y;
+}
+"""
+try:
+    rows = 1 << 24
+    out = torch.zeros(rows, dtype=torch.int32, device="mps")  # ~64 MiB
+    lib = torch.mps.compile_shader(GRID_SRC)
+    lib.grid_probe(out, threads=(1, rows, 1), group_size=(1, 1, 1))
+    torch.mps.synchronize()
+    idx = [0, rows // 2, rows - 1]
+    ok = all(int(out[i].item()) == i for i in idx)
+    print(f"PROBE#1 grid.y=2^24 single-dim dispatch: {'PASS' if ok else 'FAIL'} "
+          f"(checked {idx} -> {[int(out[i].item()) for i in idx]})")
+    if not ok:
+        print("  -> NOTE: production kernel z-tiles anyway (row = z*ny + y), so this is informational.")
+except Exception as e:
+    print(f"PROBE#1 grid.y=2^24 single-dim dispatch: FAIL/raised ({e})")
+    print("  -> NOTE: production kernel z-tiles anyway; informational, not a blocker.")
+
+# ---- probe #2: Python scalar -> constant int&/float& binding (optional simplification) ----
+SCALAR_SRC = r"""
+#include <metal_stdlib>
+using namespace metal;
+kernel void scalar_probe(device float* out [[buffer(0)]],
+                         constant int& n [[buffer(1)]],
+                         constant float& eps [[buffer(2)]]) {
+    out[0] = float(n) + eps;
+}
+"""
+try:
+    out = torch.zeros(1, dtype=torch.float32, device="mps")
+    lib = torch.mps.compile_shader(SCALAR_SRC)
+    lib.scalar_probe(out, 7, 0.5, threads=(1, 1, 1), group_size=(1, 1, 1))
+    torch.mps.synchronize()
+    ok = abs(float(out[0].item()) - 7.5) < 1e-4
+    print(f"PROBE#2 constant& scalar binding: {'PASS (simplification available)' if ok else 'FAIL'}")
+    print("  -> design uses device-tensor meta/epsb regardless; this is informational only.")
+except Exception as e:
+    print(f"PROBE#2 constant& scalar binding: NOT AVAILABLE ({e}) -> confirms device-buffer design")
+
+# ---- probe #3: bfloat literal cast in MSL (BLOCKER for treating bf16 tests as success) ----
+BF16_SRC = r"""
+#include <metal_stdlib>
+using namespace metal;
+kernel void bf16_cast(device bfloat* out [[buffer(0)]]) {
+    out[0] = bfloat(1.25f);
+}
+"""
+try:
+    out = torch.zeros(1, dtype=torch.bfloat16, device="mps")
+    lib = torch.mps.compile_shader(BF16_SRC)
+    lib.bf16_cast(out, threads=(1, 1, 1), group_size=(1, 1, 1))
+    torch.mps.synchronize()
+    ok = abs(float(out[0].float().item()) - 1.25) < 1e-2
+    print(f"PROBE#3 bfloat(y) cast compiles+runs: {'PASS' if ok else 'FAIL'} (got {float(out[0].float().item())})")
+    if not ok:
+        failures.append("probe#3 bfloat cast")
+except Exception as e:
+    print(f"PROBE#3 bfloat(y) cast compiles+runs: FAIL ({e})")
+    failures.append("probe#3 bfloat cast")
+
+if failures:
+    print(f"BLOCKER probe(s) failed: {failures} -> bf16 path must be disabled or fixed before use.")
+    sys.exit(1)
+print("Task 0 probes done.")

--- a/dev/probe_int4_layout_conflict.py
+++ b/dev/probe_int4_layout_conflict.py
@@ -1,0 +1,125 @@
+"""Does ComfyUI-INT4-Fast's stub layout registration change the int4 path?
+
+Real ComfyUI logs "Int4Fast: Registered TensorCoreConvRotW4A4Layout dynamically",
+which only fires when the key is ABSENT from comfy.quant_ops.QUANT_ALGOS — i.e.
+INT4-Fast inserts its own empty `class ...(QuantizedLayout): pass` stub. The
+headless harness never imports custom nodes, so it sees whatever comfy/kitchen
+registers. That is a real difference between harness (int4/int8 = 1.09x) and live
+ComfyUI (1.95x).
+
+This prints who owns each layout key before/after importing INT4-Fast, then
+benches the model under the requested condition.
+
+  ASFP8_LOAD_INT4FAST=1  import ComfyUI-INT4-Fast first (simulate live ComfyUI)
+
+Run:
+  "<venv>/bin/python" dev/probe_int4_layout_conflict.py <ckpt> [evals]
+"""
+
+import importlib.util
+import os
+import sys
+import time
+
+COMFY_MASTER = os.path.expanduser(os.environ.get("ASFP8_COMFY", "~/ComfyUI-Installs/ComfyUI/ComfyUI"))
+NODE_DIR = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-AppleSilicon-FP8"
+INT4FAST_DIR = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-INT4-Fast"
+
+sys.path.insert(0, COMFY_MASTER)
+sys.path.insert(0, NODE_DIR)
+
+from _patches import psutil_vmstat  # noqa: E402
+
+psutil_vmstat.install()
+
+import torch  # noqa: E402
+
+import comfy.sd  # noqa: E402
+import comfy.model_management as mm  # noqa: E402
+
+
+def dump_algos(tag):
+    from comfy.quant_ops import QUANT_ALGOS
+    print(f"\n--- QUANT_ALGOS [{tag}] ---")
+    for k in sorted(QUANT_ALGOS):
+        if "ConvRot" in k or "convrot" in k or "INT8" in k:
+            cls = QUANT_ALGOS[k]
+            mod = getattr(cls, "__module__", "?")
+            # a stub has no meaningful body: no Params, no ops
+            has_params = hasattr(cls, "Params")
+            print(f"  {k:38s} <- {mod}  (Params={has_params})")
+
+
+dump_algos("before custom nodes")
+
+if os.environ.get("ASFP8_LOAD_INT4FAST") == "1":
+    spec = importlib.util.spec_from_file_location(
+        "ComfyUI_INT4_Fast", os.path.join(INT4FAST_DIR, "__init__.py"))
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["ComfyUI_INT4_Fast"] = m
+    sys.path.insert(0, os.path.dirname(INT4FAST_DIR))
+    spec.loader.exec_module(m)
+    print("\n[probe] imported ComfyUI-INT4-Fast")
+    dump_algos("after INT4-Fast import")
+
+from _patches import int4_linear_mps  # noqa: E402
+
+int4_linear_mps.install()
+
+# count how many times our patched dispatcher actually runs
+_hits = {"n": 0}
+_patched_fn = None
+import comfy_kitchen.tensor.convrot_w4a4 as ck_convrot  # noqa: E402
+
+_patched_fn = ck_convrot.convrot_w4a4_linear
+
+
+def _counting(*a, **kw):
+    _hits["n"] += 1
+    return _patched_fn(*a, **kw)
+
+
+ck_convrot.convrot_w4a4_linear = _counting
+
+ckpt = sys.argv[1]
+n_evals = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+
+model = comfy.sd.load_diffusion_model(ckpt)
+mm.load_models_gpu([model], force_full_load=True)
+dm = model.model.diffusion_model
+
+sample = None
+n_quant = 0
+for name, mod in dm.named_modules():
+    w = getattr(mod, "weight", None)
+    if w is not None and w.__class__.__name__ == "QuantizedTensor":
+        n_quant += 1
+        if sample is None:
+            sample = (name, type(w._params).__module__ + "." + type(w._params).__qualname__)
+print(f"\nquantized layers: {n_quant}")
+print(f"sample params class: {sample}")
+
+device = mm.get_torch_device()
+dtype = model.model.get_dtype()
+c_in = (dm.input_embed.proj.in_features // (dm.input_embed.patch ** 2)
+        if hasattr(dm, "input_embed") else 16)
+x = torch.randn(1, c_in, 128, 128, device=device, dtype=dtype)
+context = torch.randn(1, 512, 12 * 2560, device=device, dtype=dtype)
+ts = torch.full((1,), 0.5, device=device, dtype=dtype)
+
+with torch.no_grad():
+    for _ in range(2):
+        _ = dm(x, ts, context)
+        torch.mps.synchronize()
+    hits_before = _hits["n"]
+    times = []
+    for i in range(n_evals):
+        t0 = time.perf_counter()
+        _ = dm(x, ts, context)
+        torch.mps.synchronize()
+        times.append(time.perf_counter() - t0)
+
+per_eval = (_hits["n"] - hits_before) / n_evals
+times = sorted(times)
+print(f"\nconvrot_w4a4_linear calls/eval: {per_eval:.0f}  (0 => our patch is BYPASSED)")
+print(f"median {times[len(times) // 2]:.3f} s/eval (min {times[0]:.3f}, n={n_evals})")

--- a/dev/probe_int4_matmul2d.py
+++ b/dev/probe_int4_matmul2d.py
@@ -1,0 +1,93 @@
+"""Probe: MPP matmul2d with packed-int4 weights on M5 (the facts:461 W4 probe).
+
+Answers:
+  1. Does it compile/run at Metal 4.1? (int4b_format gated like fp8)
+  2. Nibble order: does MPP's int4b match comfy-kitchen's packing
+     (low nibble = even column, signed two's complement)?
+  3. Speed at Krea2/FLUX shapes: W4A8 (int8xint4b->int32) and
+     W4A16 (bf16xint4b->float) vs MPS bf16 GEMM.
+
+Run:
+  "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python" dev/probe_int4_matmul2d.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("ASFP8_INT4_EXT", "1")
+
+import torch  # noqa: E402
+
+from _patches.int4_ext import loader  # noqa: E402
+
+mod = loader.module()
+if mod is None:
+    print("BUILD FAILED — see loader output above")
+    sys.exit(1)
+print("extension built OK")
+
+dev = "mps"
+torch.manual_seed(0)
+
+
+def pack_lo_even(q):  # comfy-kitchen order: low nibble = even column
+    lo = q[..., 0::2].to(torch.int32) & 0x0F
+    hi = q[..., 1::2].to(torch.int32) & 0x0F
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+def pack_hi_even(q):  # swapped hypothesis
+    lo = q[..., 1::2].to(torch.int32) & 0x0F
+    hi = q[..., 0::2].to(torch.int32) & 0x0F
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+M, K, N = 256, 512, 384
+a8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=dev)
+q4 = torch.randint(-8, 8, (N, K), dtype=torch.int8, device=dev)  # full nibble range
+ref = (a8.to(torch.int32).cpu() @ q4.to(torch.int32).cpu().T)
+
+for name, packer in (("lo=even (kitchen)", pack_lo_even), ("hi=even (swapped)", pack_hi_even)):
+    w4 = packer(q4).contiguous()
+    C = mod.i8i4_matmul2d_nt(a8, w4, K, N).cpu()
+    exact = torch.equal(C, ref)
+    maxdiff = (C - ref).abs().max().item()
+    print(f"W4A8  nibble order {name}: exact={exact} maxdiff={maxdiff}")
+
+# W4A16 correctness (float accumulate; compare vs fp32 reference)
+abf = torch.randn(M, K, dtype=torch.bfloat16, device=dev)
+ref_f = abf.float().cpu() @ q4.float().cpu().T
+for name, packer in (("lo=even (kitchen)", pack_lo_even), ("hi=even (swapped)", pack_hi_even)):
+    w4 = packer(q4).contiguous()
+    C = mod.bf16i4_matmul2d_nt(abf, w4, K, N).cpu()
+    rel = ((C - ref_f).abs().max() / ref_f.abs().max()).item()
+    print(f"W4A16 nibble order {name}: max rel diff={rel:.3e}")
+
+
+def bench(fn, iters=30, warmup=5):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+print("\nspeed @ Krea2-ish shapes (NOTE: contended if GPU busy)")
+for (M, K, N) in ((4096, 6144, 6144), (4096, 6144, 24576), (4608, 4608, 4608)):
+    a8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=dev)
+    abf = torch.randn(M, K, dtype=torch.bfloat16, device=dev)
+    wbf = torch.randn(N, K, dtype=torch.bfloat16, device=dev)
+    w4 = pack_lo_even(torch.randint(-8, 8, (N, K), dtype=torch.int8, device=dev)).contiguous()
+
+    t_bf = bench(lambda: torch.nn.functional.linear(abf, wbf))
+    t_w4a8 = bench(lambda: mod.i8i4_matmul2d_nt(a8, w4, K, N))
+    t_w4a16 = bench(lambda: mod.bf16i4_matmul2d_nt(abf, w4, K, N))
+    tf = 2 * M * K * N / 1e12
+    print(f"  M{M} K{K} N{N}: bf16 {t_bf:6.2f}ms ({tf / t_bf * 1e3:5.1f} TF/s) | "
+          f"W4A8 {t_w4a8:6.2f}ms ({tf / t_w4a8 * 1e3:5.1f} TF/s) | "
+          f"W4A16 {t_w4a16:6.2f}ms ({tf / t_w4a16 * 1e3:5.1f} TF/s)")

--- a/dev/probe_int4_tune.py
+++ b/dev/probe_int4_tune.py
@@ -1,0 +1,131 @@
+"""Sweep int4b matmul2d tile configs (dv_i4 vs tg_i4) and compare to the int8 kernel.
+
+Tests the claim that our 84 TF/s int4 number was an untuned-kernel artifact, not
+an M5 int4 ceiling. Every config is verified bit-exact against the int32 reference
+before it is timed — a fast wrong kernel is not a result.
+
+Run:
+  "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python" dev/probe_int4_tune.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("ASFP8_INT4_EXT", "1")
+os.environ.setdefault("ASFP8_INT8_EXT", "1")
+
+import torch  # noqa: E402
+from torch.utils.cpp_extension import load as cpp_load  # noqa: E402
+
+from _patches.int4_ext import loader as i4_loader  # noqa: E402
+from _patches.int8_ext import loader as i8_loader  # noqa: E402
+
+_NOSPACE = "/tmp/asfp8_build"
+
+
+def load_tune():
+    import torch.utils.cpp_extension as cpp
+    here = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_patches", "int4_ext")
+    src = os.path.abspath(os.path.join(here, "int4_tune.mm"))
+    build_dir = os.path.join(_NOSPACE, "int4_tune")
+    os.makedirs(build_dir, exist_ok=True)
+    saved = cpp.TORCH_LIB_PATH
+    try:
+        cpp.TORCH_LIB_PATH = i4_loader._nospace_torch_lib()
+        return cpp_load(name="asfp8_int4_tune", sources=[src],
+                        extra_cflags=["-std=c++17", "-ObjC++"],
+                        extra_ldflags=["-framework", "Metal", "-framework", "Foundation"],
+                        build_directory=build_dir, verbose=False)
+    finally:
+        cpp.TORCH_LIB_PATH = saved
+
+
+mt = load_tune()
+m8 = i8_loader.module()
+if mt is None or m8 is None:
+    print("BUILD FAILED")
+    sys.exit(1)
+print("tune + int8 extensions built OK\n")
+
+dev = "mps"
+torch.manual_seed(0)
+
+
+def pack_lo_even(q):
+    lo = q[..., 0::2].to(torch.int32) & 0x0F
+    hi = q[..., 1::2].to(torch.int32) & 0x0F
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+def bench(fn, iters=20, warmup=5):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+# (BM, BN, NSG, BK, use_tg)
+CONFIGS = [
+    (64, 64, 4, 0, 0),      # current shipped probe — the 84 TF/s baseline
+    (128, 64, 4, 0, 0),
+    (128, 128, 4, 0, 0),
+    (256, 64, 4, 0, 0),
+    (128, 128, 8, 0, 0),
+    (256, 128, 8, 0, 0),
+    (64, 64, 4, 128, 1),    # tg_i4 staging
+    (128, 64, 4, 128, 1),
+    (128, 128, 4, 128, 1),
+    (128, 128, 4, 256, 1),
+    (256, 128, 8, 128, 1),
+    (256, 128, 8, 256, 1),
+]
+
+M, K, N = 4096, 6144, 6144
+a8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=dev)
+q4 = torch.randint(-8, 8, (N, K), dtype=torch.int8, device=dev)
+w4 = pack_lo_even(q4).contiguous()
+w8 = torch.randint(-127, 128, (N, K), dtype=torch.int8, device=dev)
+abf = torch.randn(M, K, dtype=torch.bfloat16, device=dev)
+wbf = torch.randn(N, K, dtype=torch.bfloat16, device=dev)
+
+print(f"shape M{M} K{K} N{N}\ncomputing int32 reference on CPU...")
+ref = (a8.to(torch.int32).cpu() @ q4.to(torch.int32).cpu().T)
+tf = 2 * M * K * N / 1e12
+
+t_bf = bench(lambda: torch.nn.functional.linear(abf, wbf))
+t_i8 = bench(lambda: m8.i8_matmul2d_nt(a8, w8))
+print(f"\nbaselines:")
+print(f"  bf16       {t_bf:6.2f}ms ({tf / t_bf * 1e3:6.1f} TF/s)")
+print(f"  int8xint8  {t_i8:6.2f}ms ({tf / t_i8 * 1e3:6.1f} TF/s)   <- target to beat\n")
+
+print(f"{'BM':>4} {'BN':>4} {'NSG':>4} {'BK':>4} {'mode':>5} {'exact':>6} {'ms':>8} {'TF/s':>7} {'vs int8':>8}")
+print("-" * 62)
+best = None
+for (BM, BN, NSG, BK, tg) in CONFIGS:
+    mode = "tg_i4" if tg else "dv_i4"
+    try:
+        C = mt.i8i4_tuned(a8, w4, K, N, BM, BN, NSG, BK if BK else 2, tg)
+        exact = torch.equal(C.cpu(), ref)
+        if not exact:
+            print(f"{BM:>4} {BN:>4} {NSG:>4} {BK:>4} {mode:>5} {'WRONG':>6}  (skipped)")
+            continue
+        t = bench(lambda: mt.i8i4_tuned(a8, w4, K, N, BM, BN, NSG, BK if BK else 2, tg))
+        tfs = tf / t * 1e3
+        print(f"{BM:>4} {BN:>4} {NSG:>4} {BK:>4} {mode:>5} {'yes':>6} {t:>8.2f} {tfs:>7.1f} {t_i8 / t:>7.2f}x")
+        if best is None or t < best[0]:
+            best = (t, BM, BN, NSG, BK, mode)
+    except Exception as e:
+        msg = str(e).split("\n")[0][:70]
+        print(f"{BM:>4} {BN:>4} {NSG:>4} {BK:>4} {mode:>5} {'ERR':>6}  {msg}")
+
+if best:
+    t, BM, BN, NSG, BK, mode = best
+    print(f"\nbest int4: BM{BM} BN{BN} NSG{NSG} BK{BK} {mode} -> {t:.2f}ms ({tf / t * 1e3:.1f} TF/s)")
+    print(f"  vs int8 kernel: {t_i8 / t:.2f}x   |  vs bf16: {t_bf / t:.2f}x")
+    print(f"  vs shipped int4 probe: see BM64 BN64 NSG4 dv_i4 row above")

--- a/dev/probe_int4_vs_int8.py
+++ b/dev/probe_int4_vs_int8.py
@@ -1,0 +1,67 @@
+"""Head-to-head: bf16 vs int8xint8 vs W4A8 (int8xint4b) in ONE process.
+
+Settles whether int4 can beat int8 on M5 at Krea2/FLUX shapes, or whether the
+weight-byte saving buys nothing because the GEMM is compute-bound.
+
+Run:
+  "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python" dev/probe_int4_vs_int8.py
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("ASFP8_INT4_EXT", "1")
+os.environ.setdefault("ASFP8_INT8_EXT", "1")
+
+import torch  # noqa: E402
+
+from _patches.int4_ext import loader as i4_loader  # noqa: E402
+from _patches.int8_ext import loader as i8_loader  # noqa: E402
+
+m4 = i4_loader.module()
+m8 = i8_loader.module()
+if m4 is None or m8 is None:
+    print(f"BUILD FAILED int4={m4 is not None} int8={m8 is not None}")
+    sys.exit(1)
+print("both extensions built OK")
+
+dev = "mps"
+torch.manual_seed(0)
+
+
+def pack_lo_even(q):
+    lo = q[..., 0::2].to(torch.int32) & 0x0F
+    hi = q[..., 1::2].to(torch.int32) & 0x0F
+    return (lo | (hi << 4)).to(torch.uint8)
+
+
+def bench(fn, iters=30, warmup=5):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+print("\nsame process, same shapes — GEMM throughput only (no rotation/quant):")
+for (M, K, N) in ((4096, 6144, 6144), (4096, 6144, 24576), (4608, 4608, 4608)):
+    a8 = torch.randint(-127, 128, (M, K), dtype=torch.int8, device=dev)
+    abf = torch.randn(M, K, dtype=torch.bfloat16, device=dev)
+    wbf = torch.randn(N, K, dtype=torch.bfloat16, device=dev)
+    w8 = torch.randint(-127, 128, (N, K), dtype=torch.int8, device=dev)
+    w4 = pack_lo_even(torch.randint(-8, 8, (N, K), dtype=torch.int8, device=dev)).contiguous()
+
+    t_bf = bench(lambda: torch.nn.functional.linear(abf, wbf))
+    t_i8 = bench(lambda: m8.i8_matmul2d_nt(a8, w8))
+    t_w4a8 = bench(lambda: m4.i8i4_matmul2d_nt(a8, w4, K, N))
+    tf = 2 * M * K * N / 1e12
+    print(f"  M{M} K{K} N{N}:")
+    print(f"    bf16      {t_bf:6.2f}ms ({tf / t_bf * 1e3:5.1f} TF/s)  1.00x")
+    print(f"    int8xint8 {t_i8:6.2f}ms ({tf / t_i8 * 1e3:5.1f} TF/s)  {t_bf / t_i8:.2f}x")
+    print(f"    W4A8      {t_w4a8:6.2f}ms ({tf / t_w4a8 * 1e3:5.1f} TF/s)  {t_bf / t_w4a8:.2f}x"
+          f"   |  vs int8: {t_i8 / t_w4a8:.2f}x")

--- a/dev/probe_matmul2d_dtype.py
+++ b/dev/probe_matmul2d_dtype.py
@@ -1,0 +1,45 @@
+# dev/probe_matmul2d_dtype.py
+"""B.0 probe: does the EXACT direct device-operand matmul2d with an fp32 cooperative
+destination compile + run for half / bfloat / float? Records which dtypes are usable.
+Nothing downstream may proceed for a dtype that fails here."""
+import torch
+
+_SRC = """
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal; using namespace mpp::tensor_ops;
+kernel void probe(device @T@* A [[buffer(0)]], device @T@* B [[buffer(1)]],
+                  device float* O [[buffer(2)]], uint3 tg [[threadgroup_position_in_grid]]) {
+  constexpr auto desc = matmul2d_descriptor(16,16,16,false,true,false,
+      matmul2d_descriptor::mode::multiply_accumulate);
+  matmul2d<desc, execution_simdgroups<1>> op;
+  auto a = tensor<device @T@, dextents<int,2>, tensor_inline>(A, dextents<int,2>{16,16}, array<int,2>{1,16});
+  auto b = tensor<device @T@, dextents<int,2>, tensor_inline>(B, dextents<int,2>{16,16}, array<int,2>{1,16});
+  using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(a)>;
+  using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(b)>;
+  auto c = op.get_destination_cooperative_tensor<AT,BT,float>();
+  for (uint16_t i=0; i<c.get_capacity(); ++i) if (c.is_valid_element(i)) c[i] = 0.0f;
+  op.run(a,b,c);
+  for (uint16_t i=0; i<c.get_capacity(); ++i) if (c.is_valid_element(i)) O[i] = c[i];
+}
+"""
+
+RESULTS = {}
+for name, dt in [("half", torch.float16), ("bfloat", torch.bfloat16), ("float", torch.float32)]:
+    try:
+        lib = torch.mps.compile_shader(_SRC.replace("@T@", name))
+        torch.manual_seed(0)
+        A = torch.randn(16, 16, device="mps", dtype=dt)
+        B = torch.randn(16, 16, device="mps", dtype=dt)
+        O = torch.zeros(16, 16, device="mps", dtype=torch.float32)
+        lib.probe(A, B, O, threads=(32, 1, 1), group_size=(32, 1, 1))
+        torch.mps.synchronize()
+        ref = A.float() @ B.float().t()          # NT: A @ B^T
+        maxdiff = (O - ref).abs().max().item()
+        ok = maxdiff < 2e-1
+        RESULTS[name] = ("PASS" if ok else f"NUMFAIL maxdiff={maxdiff:.3g}")
+    except Exception as e:
+        RESULTS[name] = f"COMPILE/RUN FAIL: {e!r}"
+
+for k, v in RESULTS.items():
+    print(f"matmul2d <{k},{k},float> : {v}")

--- a/dev/probe_matmul2d_dtype_scatter.py
+++ b/dev/probe_matmul2d_dtype_scatter.py
@@ -1,0 +1,58 @@
+# dev/probe_matmul2d_dtype_scatter.py
+"""B.0 probe (CORRECTED READOUT). The sibling probe_matmul2d_dtype.py reads the
+cooperative-tensor result with a LINEAR `O[i] = c[i]`, but element i of a cooperative
+tensor does NOT map to row-major position i -- it maps to (row,col) via
+get_multidimensional_index. That linear readout scrambles the result and yields a
+spurious ~14.5 maxdiff for EVERY dtype (uncorrelated layout), which is a readout bug,
+not a kernel-capability failure. This variant scatters c[i] to O[row*N+col] exactly the
+way the production gemm_nt_bias store epilogue (Section 2.3) does, and is the faithful
+test of "does <T,T,float> cooperative-accumulate matmul2d run + produce correct A@B^T".
+"""
+import torch
+
+_SRC = """
+#include <metal_stdlib>
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+using namespace metal; using namespace mpp::tensor_ops;
+kernel void probe(device @T@* A [[buffer(0)]], device @T@* B [[buffer(1)]],
+                  device float* O [[buffer(2)]], uint3 tg [[threadgroup_position_in_grid]]) {
+  constexpr auto desc = matmul2d_descriptor(16,16,16,false,true,false,
+      matmul2d_descriptor::mode::multiply_accumulate);
+  matmul2d<desc, execution_simdgroups<1>> op;
+  auto a = tensor<device @T@, dextents<int,2>, tensor_inline>(A, dextents<int,2>{16,16}, array<int,2>{1,16});
+  auto b = tensor<device @T@, dextents<int,2>, tensor_inline>(B, dextents<int,2>{16,16}, array<int,2>{1,16});
+  using AT = __tensor_ops_detail::__remove_addrspace_t<decltype(a)>;
+  using BT = __tensor_ops_detail::__remove_addrspace_t<decltype(b)>;
+  auto c = op.get_destination_cooperative_tensor<AT,BT,float>();
+  for (uint16_t i=0; i<c.get_capacity(); ++i) if (c.is_valid_element(i)) c[i] = 0.0f;
+  op.run(a,b,c);
+  for (uint16_t i=0; i<c.get_capacity(); ++i) {
+    if (!c.is_valid_element(i)) continue;
+    auto idx = c.get_multidimensional_index(i);   // idx[0]=col, idx[1]=row (NT)
+    const int row = int(idx[1]), col = int(idx[0]);
+    O[row*16 + col] = c[i];
+  }
+}
+"""
+
+RESULTS = {}
+for name, dt in [("half", torch.float16), ("bfloat", torch.bfloat16), ("float", torch.float32)]:
+    try:
+        lib = torch.mps.compile_shader(_SRC.replace("@T@", name))
+        torch.manual_seed(0)
+        A = torch.randn(16, 16, device="mps", dtype=dt)
+        B = torch.randn(16, 16, device="mps", dtype=dt)
+        O = torch.zeros(16, 16, device="mps", dtype=torch.float32)
+        lib.probe(A, B, O, threads=(32, 1, 1), group_size=(32, 1, 1))
+        torch.mps.synchronize()
+        ref = A.float() @ B.float().t()          # NT: A @ B^T
+        maxdiff = (O - ref).abs().max().item()
+        nonzero = (O.abs() > 0).any().item()
+        tol = {"half": 0.5, "bfloat": 1.0, "float": 1e-3}[name]
+        ok = nonzero and maxdiff < tol
+        RESULTS[name] = ("PASS" if ok else f"NUMFAIL maxdiff={maxdiff:.3g} nonzero={nonzero}")
+    except Exception as e:
+        RESULTS[name] = f"COMPILE/RUN FAIL: {e!r}"
+
+for k, v in RESULTS.items():
+    print(f"matmul2d <{k},{k},float> (scatter readout) : {v}")

--- a/dev/probe_matmul2d_dtypes.py
+++ b/dev/probe_matmul2d_dtypes.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""G2 — M5 matmul2d operand dtype capability probe.
+
+For each candidate dtype (signed char/half/bfloat/float/fp8_e4m3/fp8_e5m2) this
+generates a SINGLE-KERNEL Metal source, compiles it IN ISOLATION under Metal 4.1
+(so one dtype's compile failure never aborts the others), dispatches a tiny matmul,
+and records compile/run/correctness vs a torch fp32 reference computed from the
+DECODED stored operands. Appends the capability matrix to INVESTIGATION_FACTS.md.
+
+Usage:
+    python dev/probe_matmul2d_dtypes.py            # run + append to INVESTIGATION_FACTS.md
+    python dev/probe_matmul2d_dtypes.py --dry-run  # print only, do not write
+
+Gates: issue B (conv GEMM precision). Does NOT gate W4A8 (sub-byte int4 — separate probe).
+Autonomously runnable on MPS — no ComfyUI, no model weights.
+"""
+from __future__ import annotations
+import argparse
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Generic ObjC++ host: compile_probe(src, fn) and probe_one(src, fn, A,B,C,...).
+# NO per-dtype kernels embedded here — Python generates one source per dtype and
+# passes it in, so each dtype compiles in its own MTLLibrary (Codex BLOCKER 1),
+# and Metal compile success is reported via has_fn from newFunctionWithName
+# (Codex BLOCKER 2), never via Python binding presence.
+# ---------------------------------------------------------------------------
+
+_OBJCPP_SRC = r"""
+#include <torch/extension.h>
+#include <ATen/mps/MPSStream.h>
+#include <ATen/mps/MPSDevice.h>
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+using namespace at::mps;
+
+static id<MTLLibrary> compile_lib(const std::string& src, std::string& err_out) {
+    id<MTLDevice> dev = MPSDevice::getInstance()->device();
+    MTLCompileOptions* opts = [MTLCompileOptions new];
+    opts.languageVersion = MTLLanguageVersion4_1;
+    NSError* err = nil;
+    id<MTLLibrary> lib = [dev newLibraryWithSource:
+        [NSString stringWithUTF8String:src.c_str()] options:opts error:&err];
+    if (!lib) {
+        err_out = std::string(err && err.localizedDescription
+            ? err.localizedDescription.UTF8String : "unknown compile error");
+    }
+    return lib;
+}
+
+// Compile-only probe (Task 0). Returns compile_ok / compile_error / has_fn.
+static py::dict compile_probe(const std::string& src, const std::string& fn_name) {
+    py::dict r;
+    r["compile_ok"] = false; r["compile_error"] = std::string("");
+    r["has_fn"] = false;
+    std::string cerr;
+    id<MTLLibrary> lib = compile_lib(src, cerr);
+    if (!lib) { r["compile_error"] = cerr; return r; }
+    r["compile_ok"] = true;
+    if (!fn_name.empty()) {
+        id<MTLFunction> fn = [lib newFunctionWithName:
+            [NSString stringWithUTF8String:fn_name.c_str()]];
+        r["has_fn"] = (fn != nil);
+    }
+    return r;
+}
+
+// Compile-in-isolation + dispatch. Returns per-stage status so a failure in any
+// stage still yields a structured row instead of aborting the whole matrix.
+static py::dict probe_one(const std::string& src, const std::string& fn_name,
+                          torch::Tensor A, torch::Tensor B, torch::Tensor C,
+                          int64_t M, int64_t N, int64_t K, int64_t NSG) {
+    py::dict r;
+    r["compile_ok"] = false; r["compile_error"] = std::string("");
+    r["has_fn"] = false;
+    r["pso_ok"] = false; r["pso_error"] = std::string("");
+    r["run_ok"] = false; r["run_error"] = std::string("");
+
+    std::string cerr;
+    id<MTLLibrary> lib = compile_lib(src, cerr);
+    if (!lib) { r["compile_error"] = cerr; return r; }
+    r["compile_ok"] = true;
+
+    NSString* ns = [NSString stringWithUTF8String:fn_name.c_str()];
+    id<MTLFunction> fn = [lib newFunctionWithName:ns];
+    if (!fn) { return r; }   // compiled but kernel guarded out -> has_fn=false (COMPILE_SKIP)
+    r["has_fn"] = true;
+
+    NSError* perr = nil;
+    id<MTLDevice> dev = MPSDevice::getInstance()->device();
+    id<MTLComputePipelineState> pso =
+        [dev newComputePipelineStateWithFunction:fn error:&perr];
+    if (!pso) {
+        r["pso_error"] = std::string(perr && perr.localizedDescription
+            ? perr.localizedDescription.UTF8String : "unknown pso error");
+        return r;
+    }
+    r["pso_ok"] = true;
+
+    // ---- validation BEFORE any bit-cast (Codex BLOCKER 10) ----
+    TORCH_CHECK(A.is_mps() && B.is_mps() && C.is_mps(), "A,B,C must be MPS tensors");
+    TORCH_CHECK(A.is_contiguous() && B.is_contiguous() && C.is_contiguous(),
+                "A,B,C must be contiguous");
+    TORCH_CHECK(A.dim()==2 && B.dim()==2 && C.dim()==2, "A,B,C must be 2-D");
+    TORCH_CHECK(A.size(0)==M && A.size(1)==K, "A must be [M,K]");
+    TORCH_CHECK(B.size(0)==N && B.size(1)==K, "B must be [N,K]");
+    TORCH_CHECK(C.size(0)==M && C.size(1)==N, "C must be [M,N]");
+
+    MPSStream* stream = getCurrentMPSStream();
+    id<MTLBuffer> aBuf = __builtin_bit_cast(id<MTLBuffer>, A.storage().data());
+    id<MTLBuffer> bBuf = __builtin_bit_cast(id<MTLBuffer>, B.storage().data());
+    id<MTLBuffer> cBuf = __builtin_bit_cast(id<MTLBuffer>, C.storage().data());
+    const NSUInteger aOff = A.storage_offset()*A.element_size();
+    const NSUInteger bOff = B.storage_offset()*B.element_size();
+    const NSUInteger cOff = C.storage_offset()*C.element_size();
+    int Mi=(int)M, Ni=(int)N, Ki=(int)K;
+    const NSUInteger gx=(NSUInteger)((M+63)/64), gy=(NSUInteger)((N+63)/64);
+    @try {
+        dispatch_sync(stream->queue(), ^(){
+            @autoreleasepool {
+                id<MTLComputeCommandEncoder> enc = stream->commandEncoder();
+                [enc setComputePipelineState:pso];
+                [enc setBuffer:aBuf offset:aOff atIndex:0];
+                [enc setBuffer:bBuf offset:bOff atIndex:1];
+                [enc setBuffer:cBuf offset:cOff atIndex:2];
+                [enc setBytes:&Mi length:sizeof(int) atIndex:3];
+                [enc setBytes:&Ni length:sizeof(int) atIndex:4];
+                [enc setBytes:&Ki length:sizeof(int) atIndex:5];
+                [enc dispatchThreadgroups:MTLSizeMake(gx,gy,1)
+                    threadsPerThreadgroup:MTLSizeMake((NSUInteger)(NSG*32),1,1)];
+            }
+        });
+        stream->synchronize(SyncType::COMMIT_AND_WAIT);
+        r["run_ok"] = true;
+    } @catch (NSException* ex) {
+        r["run_error"] = std::string(ex.reason ? ex.reason.UTF8String : "objc exception");
+    }
+    return r;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("compile_probe", &compile_probe, "compile one Metal source; report compile_ok/has_fn");
+    m.def("probe_one", &probe_one, "compile one source in isolation and dispatch it");
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Per-dtype Metal source generation (one single-kernel source per candidate).
+# ---------------------------------------------------------------------------
+
+_HDR = (
+    "#include <metal_stdlib>\n"
+    "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>\n"
+    "using namespace metal;\n"
+    "using namespace mpp::tensor_ops;\n"
+    "// Cooperative tensors cannot cross a function boundary; write-out via macro.\n"
+    "#define WRITEOUT(Cb, cC, m0, n0, M, N) \\\n"
+    "    for (uint16_t _i=0;_i<cC.get_capacity();++_i) { \\\n"
+    "        if (!cC.is_valid_element(_i)) continue; \\\n"
+    "        auto _idx = cC.get_multidimensional_index(_i); \\\n"
+    "        const int _r=int(_idx[1]),_c=int(_idx[0]); \\\n"
+    "        if (m0+_r>=M||n0+_c>=N) continue; \\\n"
+    "        Cb[ulong(_r)*N+_c]=cC[_i]; }\n"
+)
+
+# (metal element type, C buffer type, accumulator type, zero-literal)
+_TYPED = {
+    "signed_char": ("signed char", "int",   "int",   "0"),
+    "half":        ("half",        "float", "float", "0.0f"),
+    "bfloat":      ("bfloat",      "float", "float", "0.0f"),
+    "float":       ("float",       "float", "float", "0.0f"),
+}
+
+# fp8 candidate -> (metal type, macro)
+_FP8 = {
+    "fp8_e4m3": ("metal_fp8_e4m3_format", "__HAVE_METAL_FP8_E4M3_FORMAT_TYPE__"),
+    "fp8_e5m2": ("metal_fp8_e5m2_format", "__HAVE_METAL_FP8_E5M2_FORMAT_TYPE__"),
+}
+
+
+def _metal_src(dtype_name: str) -> str:
+    """Return a complete single-kernel Metal source named `probe_kernel` for one dtype."""
+    if dtype_name in _TYPED:
+        elem, cty, accum, zero = _TYPED[dtype_name]
+        body = f"""
+kernel void probe_kernel(
+    device {elem}* A [[buffer(0)]], device {elem}* B [[buffer(1)]],
+    device {cty}* C [[buffer(2)]],
+    constant int& M [[buffer(3)]], constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]], uint3 tgid [[threadgroup_position_in_grid]])
+{{
+    constexpr int BM=64, BN=64, NSG=4;
+    const int m0=int(tgid.x)*BM, n0=int(tgid.y)*BN;
+    if (m0>=M||n0>=N) return;
+    constexpr auto desc = matmul2d_descriptor(BM,BN,static_cast<int>(dynamic_extent),
+        false,true,false,matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc,execution_simdgroups<NSG>> op;
+    auto mA=tensor<device {elem},dextents<int,2>,tensor_inline>(
+                A+ulong(m0)*K,dextents<int,2>{{K,min(BM,M-m0)}},array<int,2>{{1,K}});
+    auto mB=tensor<device {elem},dextents<int,2>,tensor_inline>(
+                B+ulong(n0)*K,dextents<int,2>{{K,min(BN,N-n0)}},array<int,2>{{1,K}});
+    using AT=__tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT=__tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC=op.get_destination_cooperative_tensor<AT,BT,{accum}>();
+    for (uint16_t i=0;i<cC.get_capacity();++i) if(cC.is_valid_element(i)) cC[i]={zero};
+    op.run(mA,mB,cC);
+    device {cty}* Cb=C+ulong(m0)*N+n0;
+    WRITEOUT(Cb,cC,m0,n0,M,N)
+}}
+"""
+        return _HDR + body
+
+    if dtype_name in _FP8:
+        mtype, macro = _FP8[dtype_name]
+        body = f"""
+#if defined({macro})
+kernel void probe_kernel(
+    device uchar* rawA [[buffer(0)]], device uchar* rawB [[buffer(1)]],
+    device float* C    [[buffer(2)]],
+    constant int& M [[buffer(3)]], constant int& N [[buffer(4)]],
+    constant int& K [[buffer(5)]], uint3 tgid [[threadgroup_position_in_grid]])
+{{
+    using fp8_t = metal::{mtype};
+    constexpr int BM=64, BN=64, NSG=4;
+    const int m0=int(tgid.x)*BM, n0=int(tgid.y)*BN;
+    if (m0>=M||n0>=N) return;
+    constexpr auto desc = matmul2d_descriptor(BM,BN,static_cast<int>(dynamic_extent),
+        false,true,false,matmul2d_descriptor::mode::multiply_accumulate);
+    matmul2d<desc,execution_simdgroups<NSG>> op;
+    // fp8 tensor data_handle_type is `device uchar*` (1 byte/elem), so pass the
+    // raw uchar* directly — NOT cast to fp8_t* (mirrors production gemm_fp8_nt,
+    // _patches/fp8_ext/fp8_matmul2d.mm:96).
+    auto mA=tensor<device fp8_t,dextents<int,2>,tensor_inline>(
+                rawA+ulong(m0)*K,
+                dextents<int,2>{{K,min(BM,M-m0)}},array<int,2>{{1,K}});
+    auto mB=tensor<device fp8_t,dextents<int,2>,tensor_inline>(
+                rawB+ulong(n0)*K,
+                dextents<int,2>{{K,min(BN,N-n0)}},array<int,2>{{1,K}});
+    using AT=__tensor_ops_detail::__remove_addrspace_t<decltype(mA)>;
+    using BT=__tensor_ops_detail::__remove_addrspace_t<decltype(mB)>;
+    auto cC=op.get_destination_cooperative_tensor<AT,BT,float>();
+    for (uint16_t i=0;i<cC.get_capacity();++i) if(cC.is_valid_element(i)) cC[i]=0.0f;
+    op.run(mA,mB,cC);
+    device float* Cb=C+ulong(m0)*N+n0;
+    WRITEOUT(Cb,cC,m0,n0,M,N)
+}}
+#endif  // {macro}
+"""
+        return _HDR + body
+
+    raise ValueError(f"unknown dtype {dtype_name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Extension builder (mirrors _patches/int8_ext/loader.py)
+# ---------------------------------------------------------------------------
+
+_NOSPACE_ROOT = "/tmp/asfp8_build"
+_BUILD_DIR    = os.path.join(_NOSPACE_ROOT, "probe_ext")
+
+
+def _nospace_torch_lib() -> str:
+    """No-space symlink to torch/lib (fixes cpp_extension unquoted -L on this path)."""
+    import torch.utils.cpp_extension as cpp
+    real = cpp.TORCH_LIB_PATH
+    if " " not in real:
+        return real
+    os.makedirs(_NOSPACE_ROOT, exist_ok=True)
+    link = os.path.join(_NOSPACE_ROOT, "torchlib")
+    if os.path.islink(link):
+        os.unlink(link)
+    os.symlink(real, link)
+    return link
+
+
+def _ensure_ninja() -> bool:
+    if shutil.which("ninja"):
+        return True
+    try:
+        import ninja
+        bin_dir = getattr(ninja, "BIN_DIR", None) or os.path.join(
+            os.path.dirname(ninja.__file__), "data", "bin"
+        )
+        if os.path.isdir(bin_dir):
+            os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+    except Exception as e:
+        print(f"[probe_dtypes] ninja import failed: {e!r}", file=sys.stderr)
+    return bool(shutil.which("ninja"))
+
+
+def build_extension():
+    """Write the generic ObjC++ host to a no-space temp path and compile via cpp_extension."""
+    if shutil.which("xcrun") is None:
+        print("[probe_dtypes] xcrun not found — install Xcode CLI tools.", file=sys.stderr)
+        return None
+    if not _ensure_ninja():
+        print("[probe_dtypes] ninja binary not on PATH (pip install ninja).", file=sys.stderr)
+        return None
+    try:
+        import torch.utils.cpp_extension as cpp
+        from torch.utils.cpp_extension import load as cpp_load
+    except Exception as e:
+        print(f"[probe_dtypes] cpp_extension unavailable: {e!r}", file=sys.stderr)
+        return None
+
+    os.makedirs(_BUILD_DIR, exist_ok=True)
+    src_path = os.path.join(_BUILD_DIR, "probe_matmul2d_host.mm")
+    Path(src_path).write_text(_OBJCPP_SRC)
+
+    saved = cpp.TORCH_LIB_PATH
+    try:
+        cpp.TORCH_LIB_PATH = _nospace_torch_lib()
+        mod = cpp_load(
+            name="asfp8_probe_host",
+            sources=[src_path],
+            extra_cflags=["-std=c++17", "-ObjC++"],
+            extra_ldflags=["-framework", "Metal", "-framework", "Foundation"],
+            build_directory=_BUILD_DIR,
+            verbose=False,
+        )
+    except Exception as e:
+        print(f"[probe_dtypes] build FAILED: {e!r}", file=sys.stderr)
+        mod = None
+    finally:
+        cpp.TORCH_LIB_PATH = saved
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Per-dtype probe helpers
+# ---------------------------------------------------------------------------
+
+def _make_fp8_uint8(shape, dtype_str):
+    """uint8 tensor on MPS whose bytes are fp8 values, plus the decoded fp32 reference.
+
+    CPU torch float8 cast (MPS cannot cast fp8), then byte-view to uint8 -> MPS.
+    The decoded reference is the SAME quantized tensor cast back to float, matching
+    the principle of _patches/_common.decode_fp8. No clamping.
+    """
+    import torch
+    fp32 = torch.randn(shape) * 0.5
+    fp8_dtype = torch.float8_e4m3fn if "e4m3" in dtype_str else torch.float8_e5m2
+    fp8_cpu = fp32.to(fp8_dtype)
+    return fp8_cpu.view(torch.uint8).to("mps"), fp8_cpu.float()
+
+
+def run_probe(mod, dtype_name, M=64, N=64, K=128):
+    """Run one dtype probe. Returns dict:
+    compile_ok, has_fn, pso_ok, run_ok, max_err, exact, latency_ms, verdict, detail.
+    verdict in {PASS, FAIL, COMPILE_FAIL, COMPILE_SKIP, RUN_FAIL}.
+    """
+    import torch
+    res = dict(compile_ok=False, has_fn=False, pso_ok=False, run_ok=False,
+               max_err=float("nan"), exact=False, latency_ms=float("nan"),
+               verdict="", detail="")
+
+    cfg = {
+        "signed_char": (torch.int8,    torch.int32),
+        "half":        (torch.float16,  torch.float32),
+        "bfloat":      (torch.bfloat16, torch.float32),
+        "float":       (torch.float32,  torch.float32),
+        "fp8_e4m3":    ("fp8",          torch.float32),
+        "fp8_e5m2":    ("fp8",          torch.float32),
+    }
+    if dtype_name not in cfg:
+        res["verdict"] = "FAIL"; res["detail"] = "unknown dtype"; return res
+    op_dtype, c_dtype = cfg[dtype_name]
+
+    src = _metal_src(dtype_name)
+
+    # -- build operands (reference uses DECODED stored values for EVERY dtype) ----
+    torch.manual_seed(42)
+    if dtype_name.startswith("fp8"):
+        A_mps, A_ref = _make_fp8_uint8((M, K), dtype_name)
+        B_mps, B_ref = _make_fp8_uint8((N, K), dtype_name)
+        A_mps = A_mps.contiguous(); B_mps = B_mps.contiguous()
+    elif dtype_name == "signed_char":
+        A_cpu = torch.randint(-64, 64, (M, K), dtype=torch.int8)
+        B_cpu = torch.randint(-64, 64, (N, K), dtype=torch.int8)
+        A_mps = A_cpu.to("mps").contiguous(); B_mps = B_cpu.to("mps").contiguous()
+        A_ref = A_cpu.float(); B_ref = B_cpu.float()
+    else:
+        A_mps = torch.randn(M, K).to(op_dtype).to("mps").contiguous()
+        B_mps = torch.randn(N, K).to(op_dtype).to("mps").contiguous()
+        # Codex MAJOR 4: reference = decoded STORED operands, not unrounded fp32.
+        A_ref = A_mps.cpu().float(); B_ref = B_mps.cpu().float()
+
+    C_mps = torch.zeros(M, N, dtype=c_dtype, device="mps").contiguous()
+    ref = A_ref @ B_ref.t()
+
+    # -- compile-in-isolation + dispatch ----------------------------------------
+    t0 = time.perf_counter()
+    st = mod.probe_one(src, "probe_kernel", A_mps, B_mps, C_mps, M, N, K, 4)
+    torch.mps.synchronize()
+    res["latency_ms"] = (time.perf_counter() - t0) * 1e3
+    res["compile_ok"] = bool(st["compile_ok"])
+    res["has_fn"]     = bool(st["has_fn"])
+    res["pso_ok"]     = bool(st["pso_ok"])
+    res["run_ok"]     = bool(st["run_ok"])
+
+    if not res["compile_ok"]:
+        res["verdict"] = "COMPILE_FAIL"; res["detail"] = st["compile_error"]; return res
+    if not res["has_fn"]:
+        # compiled but kernel guarded out (fp8 macro absent, etc.)
+        res["verdict"] = "COMPILE_SKIP"
+        res["detail"] = "kernel absent (macro/type not available on this SDK)"
+        return res
+    if not res["pso_ok"]:
+        res["verdict"] = "COMPILE_FAIL"; res["detail"] = st["pso_error"]; return res
+    if not res["run_ok"]:
+        res["verdict"] = "RUN_FAIL"; res["detail"] = st["run_error"]; return res
+
+    # -- correctness (+ SPY: prove the real kernel ran, not a no-op) ------------
+    out = C_mps.cpu()
+    if dtype_name == "signed_char":
+        ref_i32 = ref.round().to(torch.int32)
+        res["exact"] = bool(torch.equal(out, ref_i32))
+        res["max_err"] = float((out.float() - ref).abs().max().item())
+        # SPY: a no-op/fallback would leave C all-zero; a real GEMM does not.
+        nonzero = bool(out.abs().sum().item() != 0)
+        if res["exact"] and nonzero:
+            res["verdict"] = "PASS"
+        else:
+            res["verdict"] = "FAIL"
+            res["detail"] = (f"exact={res['exact']} nonzero={nonzero} "
+                             f"max_err={res['max_err']:.3g}")
+        return res
+
+    out_f = out.float()
+    res["max_err"] = float((out_f - ref).abs().max().item())
+    tol = {"half": 0.5, "bfloat": 1.0, "float": 1e-3,
+           "fp8_e4m3": 0.5, "fp8_e5m2": 0.5}[dtype_name]
+    # SPY: C must differ from the all-zero init for a real kernel run.
+    nonzero = bool(out_f.abs().sum().item() != 0)
+    if res["max_err"] <= tol and nonzero:
+        res["verdict"] = "PASS"
+    else:
+        res["verdict"] = "FAIL"
+        res["detail"] = f"max_err={res['max_err']:.3g} > tol={tol} or nonzero={nonzero}"
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Gate decisions (Codex MAJOR 6: fp8 PASS gates an FP8 path ONLY, not W4A8).
+# ---------------------------------------------------------------------------
+
+CANDIDATES = ["signed_char", "half", "bfloat", "float", "fp8_e4m3", "fp8_e5m2"]
+
+DECISIONS = {
+    "half":     "issue B conv GEMM can use fp16 operands on tensor units",
+    "bfloat":   "issue B conv GEMM can use bf16 operands on tensor units",
+    "float":    "fp32 cooperative path legal (perf NOT proven here)",
+    "fp8_e4m3": "FP8 e4m3 operand path viable (regresses existing fp8fp8_matmul2d_nt); NOT W4A8",
+    "fp8_e5m2": "FP8 e5m2 operand path viable (informational); NOT W4A8",
+}
+
+
+def build_section(rows):
+    lines = [
+        "",
+        "## S-G2 — M5 matmul2d operand dtype support (probe_matmul2d_dtypes.py)",
+        "",
+        "Machine: M5 Max / macOS 27 / PyTorch 2.11 / Metal 4.1 (MTLLanguageVersion4_1).",
+        "NT layout (A[M,K] @ Bᵀ, B[N,K]), BM=BN=64, NSG=4, K=128.",
+        "Reference: torch fp32 matmul of DECODED stored operands. Each dtype compiled in",
+        "its own MTLLibrary (a compile failure of one dtype does not affect the others).",
+        "Latency is INFORMATIONAL ONLY (launch-dominated; not a tensor-unit perf signal).",
+        "",
+        "| dtype        | compile | run  | max_err | latency | verdict | gates (issue B / FP8 only) |",
+        "|--------------|---------|------|---------|---------|---------|----------------------------|",
+    ]
+    for r in rows:
+        d = r["name"]
+        c = "OK" if r["res"]["compile_ok"] else "FAIL"
+        run = "OK" if r["res"]["run_ok"] else ("—" if not r["res"]["has_fn"] else "FAIL")
+        e = r["res"]["max_err"]
+        e_s = f"{e:.3g}" if e == e else "—"
+        lat = r["res"]["latency_ms"]
+        l_s = f"{lat:.2f}ms" if lat == lat else "—"
+        verdict = r["res"]["verdict"] or "—"
+        gate = DECISIONS.get(d, "—")
+        lines.append(f"| {d:<12} | {c:<7} | {run:<4} | {e_s:<7} | {l_s:<7} | {verdict:<7} | {gate} |")
+    lines += [
+        "",
+        "**Decision rule:**",
+        "- half or bfloat PASS → issue B conv GEMM can use that dtype on tensor units.",
+        "- half AND bfloat both FAIL → issue B must keep int8 operands (current path).",
+        "- fp8_e4m3 PASS → confirms the existing fp8×fp8 NT path (fp8fp8_matmul2d_nt) regression.",
+        "- fp8_e5m2 PASS → e5m2 operand path is usable (informational).",
+        "- W4A8 is NOT decided here: it needs a separate int4/uint4 packing + correctness probe.",
+        "- float PASS proves legality ONLY; it does NOT prove tensor-unit performance.",
+        "",
+        f"Probe run: {time.strftime('%Y-%m-%d %H:%M %Z')}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="G2 matmul2d dtype probe")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print results without appending to INVESTIGATION_FACTS.md")
+    args = parser.parse_args()
+
+    import torch
+    if not torch.backends.mps.is_available():
+        print("ERROR: MPS not available on this machine.", file=sys.stderr)
+        sys.exit(1)
+
+    print("[probe_dtypes] building host extension (first run: ~30 s for JIT compile) …")
+    mod = build_extension()
+    if mod is None:
+        print("ERROR: extension build failed; see stderr above.", file=sys.stderr)
+        sys.exit(1)
+
+    rows = []
+    for d in CANDIDATES:
+        print(f"  probing {d} …", end=" ", flush=True)
+        r = run_probe(mod, d)
+        e = f"{r['max_err']:.3g}" if r["max_err"] == r["max_err"] else "—"
+        lat = f"{r['latency_ms']:.2f}ms" if r["latency_ms"] == r["latency_ms"] else "—"
+        print(f"compile={'T' if r['compile_ok'] else 'F'} has_fn={'T' if r['has_fn'] else 'F'} "
+              f"run={'T' if r['run_ok'] else 'F'}  max_err={e}  lat={lat}  {r['verdict']} "
+              f"{('('+r['detail']+')') if r['detail'] else ''}")
+        rows.append({"name": d, "res": r})
+
+    section = build_section(rows)
+    print()
+    print(section)
+
+    if not args.dry_run:
+        facts_path = Path(__file__).parent.parent / "INVESTIGATION_FACTS.md"
+        if facts_path.exists():
+            with open(facts_path, "a") as f:
+                f.write("\n" + section + "\n")
+            print(f"[probe_dtypes] appended to {facts_path}")
+        else:
+            print(f"[probe_dtypes] WARNING: {facts_path} not found; did not append.",
+                  file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/probe_matmul2d_task0.py
+++ b/dev/probe_matmul2d_task0.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""G2 Task 0 — empirical compile-only probes for matmul2d dtype facts.
+
+Compiles tiny single-kernel Metal sources under MTLLanguageVersion4_1 and records,
+per fact, whether the relevant type / instantiation / macro is available on THIS SDK.
+Gates the downstream per-dtype dispatch probe (dev/probe_matmul2d_dtypes.py).
+"""
+from __future__ import annotations
+import sys
+# Reuse the extension builder + source templates from the main probe module.
+import importlib.util, pathlib
+_p = pathlib.Path(__file__).parent / "probe_matmul2d_dtypes.py"
+_spec = importlib.util.spec_from_file_location("probe_matmul2d_dtypes", _p)
+_probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_probe)
+
+
+def _hdr() -> str:
+    return (
+        "#include <metal_stdlib>\n"
+        "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>\n"
+        "using namespace metal;\n"
+        "using namespace mpp::tensor_ops;\n"
+    )
+
+
+def main():
+    import torch
+    if not torch.backends.mps.is_available():
+        print("ERROR: MPS not available.", file=sys.stderr); sys.exit(1)
+    mod = _probe.build_extension()
+    if mod is None:
+        print("ERROR: host extension build failed; see stderr.", file=sys.stderr); sys.exit(1)
+
+    probes = []
+
+    # 0.3a — does <half,half,float> get_destination_cooperative_tensor compile?
+    for ty in ("half", "bfloat", "float"):
+        src = _probe._metal_src(ty)              # full single-kernel source for this dtype
+        r = mod.compile_probe(src, "probe_kernel")
+        probes.append((f"matmul2d<{ty}> + <{ty},{ty},float> accum compiles",
+                       bool(r["compile_ok"] and r["has_fn"]), r["compile_error"]))
+
+    # 0.3b — signed char control compiles
+    r = mod.compile_probe(_probe._metal_src("signed_char"), "probe_kernel")
+    probes.append(("matmul2d<signed char> + int accum compiles",
+                   bool(r["compile_ok"] and r["has_fn"]), r["compile_error"]))
+
+    # 0.4 — fp8 e4m3 / e5m2 SEPARATE macro availability (verbatim from Codex review item 8).
+    # We compile the type-reference under each macro and look up the function: if the macro
+    # is undefined the kernel body is empty -> compiles but has_fn detection below.
+    fp8_probe = lambda macro, ty: _hdr() + (
+        "kernel void p(device uchar* x [[buffer(0)]]) {\n"
+        f"#if {macro}\n"
+        f"  using t = metal::{ty};\n"
+        "  device t* y = (device t*)x;\n"
+        "  (void)y;\n"
+        "#else\n"
+        "  // macro absent on this SDK; reference a compile-time failure marker so the\n"
+        "  // probe can DISTINGUISH 'macro absent' from 'type present but broken'.\n"
+        "  x[0] = x[0];\n"
+        "#endif\n"
+        "}\n"
+    )
+    for macro, ty, label in (
+        ("__HAVE_METAL_FP8_E4M3_FORMAT_TYPE__", "metal_fp8_e4m3_format", "fp8 e4m3 type"),
+        ("__HAVE_METAL_FP8_E5M2_FORMAT_TYPE__", "metal_fp8_e5m2_format", "fp8 e5m2 type"),
+    ):
+        # Macro-true variant: only compiles cleanly if both macro defined AND type valid.
+        src_true = _hdr() + (
+            "kernel void p(device uchar* x [[buffer(0)]]) {\n"
+            f"  using t = metal::{ty};\n"
+            "  device t* y = (device t*)x; (void)y;\n"
+            "}\n"
+        )
+        r = mod.compile_probe(src_true, "p")
+        probes.append((f"{label} available under Metal 4.1",
+                       bool(r["compile_ok"] and r["has_fn"]), r["compile_error"]))
+
+    print("\n=== G2 Task 0 — compile-only probe results ===")
+    lines = ["", "## S-G2-Task0 — matmul2d dtype API facts (compile-only)", "",
+             "| fact | result | error |", "|------|--------|-------|"]
+    for label, ok, err in probes:
+        verdict = "PASS" if ok else "FAIL"
+        e = (err or "").replace("\n", " ")[:80] or "—"
+        print(f"  {label:<52} {verdict}   {e}")
+        lines.append(f"| {label} | {verdict} | {e} |")
+    section = "\n".join(lines)
+
+    facts = pathlib.Path(__file__).parent.parent / "INVESTIGATION_FACTS.md"
+    if facts.exists():
+        with open(facts, "a") as f:
+            f.write("\n" + section + "\n")
+        print(f"\n[task0] appended to {facts}")
+    else:
+        print(f"\n[task0] WARNING: {facts} not found; not appended.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/probe_metal_transcendentals.py
+++ b/dev/probe_metal_transcendentals.py
@@ -1,0 +1,44 @@
+"""Probe: which transcendental spellings compile under the MPS Metal path, and do they
+match torch.nn.functional within the planned tolerance? Records a verdict the plan gates on."""
+import torch
+
+assert torch.backends.mps.is_available(), "probe must run on MPS"
+assert hasattr(torch.mps, "compile_shader"), \
+    "torch.mps.compile_shader missing; fall back to a tiny .mm via loader (see note below)"
+
+
+def try_compile(name, body):
+    src = (
+        "#include <metal_stdlib>\n"
+        "using namespace metal;\n"
+        "kernel void k(device const float* in [[buffer(0)]],\n"
+        "              device float* out [[buffer(1)]],\n"
+        "              uint i [[thread_position_in_grid]]) {\n"
+        f"    float x = in[i];\n    {body}\n"
+        "}\n"
+    )
+    try:
+        lib = torch.mps.compile_shader(src)
+        print(f"[{name}] COMPILE OK")
+        return lib
+    except Exception as e:
+        print(f"[{name}] COMPILE FAIL: {type(e).__name__}: {e}")
+        return None
+
+
+# 1) does precise:: namespace expose exp/tanh?
+try_compile("precise.exp_tanh", "out[i] = precise::exp(-x) + precise::tanh(x);")
+# 2) fast (default) exp/tanh as a fallback if precise is unavailable
+try_compile("fast.exp_tanh", "out[i] = exp(-x) + tanh(x);")
+# 3) erf for gelu-default (act=3) — unqualified
+try_compile("erf.unqualified", "out[i] = erf(x);")
+# 4) erf qualified
+try_compile("erf.metal", "out[i] = metal::erf(x);")
+
+# If compiles succeed, also check numeric parity for SiLU/GELU-tanh at the planned tolerance.
+def run(lib, n=4096):
+    x = (torch.randn(n, dtype=torch.float32, device="mps"))
+    out = torch.empty_like(x)
+    return x, out, lib
+
+print("PROBE COMPLETE — record per-symbol COMPILE OK/FAIL above.")

--- a/dev/probe_rope_cost.py
+++ b/dev/probe_rope_cost.py
@@ -1,0 +1,16 @@
+# dev/probe_rope_cost.py — anchor the current eager apply_rope cost on a Flux-like shape.
+import time, torch
+import comfy_kitchen.backends.eager.rope as r
+assert torch.backends.mps.is_available()
+B,H,L,D = 1,24,4608,128; halfD=D//2
+x  = torch.randn(B,H,L,D, device="mps", dtype=torch.bfloat16)
+fr = torch.randn(1,1,L,halfD,2,2, device="mps", dtype=torch.float32)   # precomputed table
+
+def bench(fn, it=50, warm=10):
+    for _ in range(warm): fn()
+    torch.mps.synchronize(); t=time.perf_counter()
+    for _ in range(it): fn()
+    torch.mps.synchronize(); return (time.perf_counter()-t)/it*1e3
+
+print(f"interleaved apply_rope1     : {bench(lambda: r.apply_rope1(x, fr)):.3f} ms/call")
+print(f"split-half apply_rope_split1: {bench(lambda: r.apply_rope_split_half1(x, fr)):.3f} ms/call")

--- a/dev/probe_rope_runtime.py
+++ b/dev/probe_rope_runtime.py
@@ -1,0 +1,52 @@
+# dev/probe_rope_runtime.py — import-once ORIGIN logger. HUMAN runs a few steps of Flux-2/Ideogram-4.
+# Answers BLOCKER 1: is the measured 'rotary' bucket the comfy_kitchen custom-op path, or a
+# non-comfy_kitchen rotary (e.g. KJNodes _ideogram4_apply_rope_lowp)?
+import sys, torch
+_seen = set()
+
+# Note: torch.ops.comfy_kitchen.* entries are not reassignable, so we cannot wrap them directly.
+# Instead we wrap the EAGER attrs below: the custom op dispatches to eager via
+# registry.get_implementation, so "an eager attr fired" IS proof the comfy_kitchen path executed.
+# is_comfy_kitchen is derived from each fired function's __module__.
+
+def _wrap(label, fn):
+    def w(*a, **k):
+        key = label + ":" + getattr(fn, "__qualname__", "?")
+        if key not in _seen:
+            _seen.add(key)
+            t = a[0] if a else None
+            f = k.get("freqs_cis", a[-1] if a else None)
+            print(f"[ROPE-ORIGIN] fired label={label} "
+                  f"module={getattr(fn,'__module__','?')} qualname={getattr(fn,'__qualname__','?')} "
+                  f"id={id(fn)} is_comfy_kitchen={str(getattr(fn,'__module__','')).startswith('comfy_kitchen')}",
+                  flush=True)
+            try:
+                print(f"             x.rank={t.dim()} x.shape={tuple(t.shape)} x.dtype={t.dtype} "
+                      f"x.contig={t.is_contiguous()} freqs.rank={f.dim()} freqs.shape={tuple(f.shape)} "
+                      f"freqs.dtype={f.dtype}", flush=True)
+            except Exception:
+                pass
+        return fn(*a, **k)
+    return w
+
+# (a) comfy_kitchen eager attrs — firing here proves the comfy_kitchen path.
+import comfy_kitchen.backends.eager as e
+for n in ("apply_rope", "apply_rope1", "apply_rope_split_half", "apply_rope_split_half1"):
+    setattr(e, n, _wrap("comfy_kitchen.eager", getattr(e, n)))
+
+# (b) non-comfy_kitchen rotary names across already-imported modules (KJNodes etc.).
+_NAMES = ("apply_rope", "apply_rotary_emb", "_ideogram4_apply_rope_lowp",
+          "rope_apply", "apply_rotary_pos_emb")
+for _mod_name, _mod in list(sys.modules.items()):
+    if _mod is None or _mod_name.startswith("comfy_kitchen"):
+        continue
+    for _fn_name in _NAMES:
+        _fn = getattr(_mod, _fn_name, None)
+        if callable(_fn) and getattr(_fn, "__code__", None) is not None:
+            try:
+                setattr(_mod, _fn_name, _wrap(f"{_mod_name}.{_fn_name}", _fn))
+            except Exception:
+                pass
+
+print("[ROPE-ORIGIN] installed; run one Flux-2 and one Ideogram-4 render, then read which "
+      "label(s) fire and whether is_comfy_kitchen=True.", flush=True)

--- a/dev/probe_rope_source.py
+++ b/dev/probe_rope_source.py
@@ -1,0 +1,10 @@
+# dev/probe_rope_source.py — confirm the slow-path hypothesis from the installed source.
+import inspect, comfy_kitchen.backends.eager.rope as r
+src = inspect.getsource(r)
+assert "view_as_complex" not in src and "polar" not in src, \
+    "hypothesis wrong: eager DOES use complex multiply — revisit the kernel design"
+assert "addcmul_" in src and "movedim" in src, "eager source changed; re-read before building"
+print("CONFIRMED: eager rope is real-2x2-matrix; interleaved uses reshape+mul+addcmul_+cast,")
+print("           split-half uses reshape+movedim+mul+mul+add+movedim+cast (multi-launch).")
+print("apply_rope1 src:\n", inspect.getsource(r.apply_rope1))
+print("apply_rope_split_half1 src:\n", inspect.getsource(r.apply_rope_split_half1))

--- a/dev/probe_torch_compile_mps.py
+++ b/dev/probe_torch_compile_mps.py
@@ -224,7 +224,7 @@ torch.mps.synchronize()
 t1=time.perf_counter()
 print(f"cold_ms={(t1-t0)*1e3:.0f}")
 """
-    python = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python"
+    python = sys.executable  # the interpreter running this probe (portable across machines)
 
     # Cold run (empty cache)
     with tempfile.TemporaryDirectory() as cache1:

--- a/dev/probe_torch_compile_mps.py
+++ b/dev/probe_torch_compile_mps.py
@@ -1,0 +1,467 @@
+"""Task A.0 — Empirical probes for torch.compile Inductor MPS.
+
+Run ALL probes before starting Tasks A.1–A.4. Record pass/fail inline.
+
+Usage (from repo root):
+  TORCH_COMPILE_DEBUG=1 TORCH_LOGS=recompiles \\
+    "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python" \\
+    dev/probe_torch_compile_mps.py 2>&1 | tee /tmp/probe_a0.txt
+
+Do NOT set ASFP8_PROFILE=1 or ASFP8_INT8_EXT=1 for probes 0a-0d.
+Probes 0e-0f intentionally install patches to test interactions.
+"""
+
+import os, sys, subprocess, time, tempfile
+import torch
+import torch.nn.functional as F
+
+DEVICE = "mps"
+DTYPE = torch.float16
+B, S, D = 2, 4096, 1536
+
+
+def make(b=B, s=S, d=D, seed=0):
+    g = torch.Generator(device=DEVICE).manual_seed(seed)
+    x = torch.randn(b, s, d, device=DEVICE, dtype=DTYPE, generator=g)
+    w = torch.randn(d, device=DEVICE, dtype=DTYPE, generator=g)
+    return x, w
+
+
+def sep():
+    print("-" * 60)
+
+
+# ---------------------------------------------------------------------------
+# Probe 0a — F.rms_norm dispatch count (BLOCKER for ADOPT_COMPILE)
+# ---------------------------------------------------------------------------
+
+def probe_0a_rms_norm_dispatch():
+    """Does Inductor MPS fuse rms_norm+silu+residual into 1 Metal dispatch?
+
+    PASS: bw_tail production shape shows <=1 extern_kernel in lowered IR.
+    FAIL: bw_tail shows >=3 extern_kernels (separate dispatches, no true fusion).
+
+    Graph capture (graph_count=1) is necessary but NOT sufficient.
+    The extern_kernels count from TORCH_COMPILE_DEBUG=1 is the real test.
+    """
+    sep()
+    print("[Probe 0a] rms_norm+silu+residual dispatch count")
+    print("  -> Count 'extern_kernels' in TORCH_COMPILE_DEBUG=1 output.")
+    print("     PASS if bw_tail production shape has <=1 extern_kernel.")
+    print("     FAIL if >=3 (Inductor emits separate Metal dispatches).")
+
+    import torch._dynamo as dynamo
+
+    def bw_tail(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = F.silu(h)
+        return x + h
+
+    def rms_only(x, w):
+        return F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+
+    for shape_name, (b, s, d) in [
+        ("small (1,256,512)", (1, 256, 512)),
+        ("production (2,4096,1536)", (B, S, D)),
+    ]:
+        print(f"\n  Shape: {shape_name}")
+        x, w = make(b, s, d)
+
+        # Graph break count (necessary but not sufficient)
+        try:
+            torch._dynamo.reset()
+            expl = dynamo.explain(bw_tail)(x, w)
+            print(f"    bw_tail graph_count={expl.graph_count}  "
+                  f"breaks={[str(r) for r in expl.break_reasons] or 'none'}")
+        except Exception as e:
+            print(f"    dynamo.explain failed: {e}")
+
+        # Compile + run bw_tail with fullgraph=True
+        try:
+            torch._dynamo.reset()
+            import torch._inductor.config as ind_cfg
+            old_debug = getattr(ind_cfg, "debug", False)
+            ind_cfg.debug = True
+            try:
+                c = torch.compile(bw_tail, backend="inductor", fullgraph=True)
+                c(x, w)
+                torch.mps.synchronize()
+                print(f"    bw_tail compile(fullgraph=True): OK")
+            finally:
+                ind_cfg.debug = old_debug
+        except Exception as e:
+            print(f"    bw_tail compile(fullgraph=True): FAILED — "
+                  f"{type(e).__name__}: {str(e)[:200]}")
+
+        # rms_only decomposition: does it lower to multiple dispatches on its own?
+        try:
+            torch._dynamo.reset()
+            cr = torch.compile(rms_only, backend="inductor", fullgraph=True)
+            cr(x, w)
+            torch.mps.synchronize()
+            print(f"    rms_only compile(fullgraph=True): OK")
+        except Exception as e:
+            print(f"    rms_only compile(fullgraph=True): FAILED — "
+                  f"{type(e).__name__}: {str(e)[:200]}")
+
+
+# ---------------------------------------------------------------------------
+# Probe 0b — fullgraph=True (BLOCKER)
+# ---------------------------------------------------------------------------
+
+def probe_0b_fullgraph():
+    """BLOCKER: does fullgraph=True succeed for bw_tail and full_block?
+
+    Default fullgraph=False silently falls back for un-capturable ops.
+    fullgraph=True raises immediately on any graph break, making issues visible.
+    """
+    sep()
+    print("[Probe 0b] fullgraph=True compile")
+
+    W = torch.randn(D, D, device=DEVICE, dtype=DTYPE)
+
+    def bw_tail(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = F.silu(h)
+        return x + h
+
+    def full_block(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = (h.reshape(-1, D) @ W.T).reshape(x.shape)
+        h = F.silu(h)
+        return x + h
+
+    x, w = make()
+    for name, fn in [("bw_tail", bw_tail), ("full_block", full_block)]:
+        torch._dynamo.reset()
+        try:
+            c = torch.compile(fn, backend="inductor", fullgraph=True)
+            out = c(x, w)
+            torch.mps.synchronize()
+            print(f"  {name} fullgraph=True: PASS")
+        except Exception as e:
+            print(f"  {name} fullgraph=True: FAIL — {type(e).__name__}: {str(e)[:200]}")
+
+
+# ---------------------------------------------------------------------------
+# Probe 0c — dynamic=True shapes (BLOCKER if follow-on wraps real DiT modules)
+# ---------------------------------------------------------------------------
+
+def probe_0c_dynamic_shapes():
+    """BLOCKER for auto-wiring: does dynamic=True recompile per sequence length?
+
+    Run with TORCH_LOGS=recompiles to see recompilation events.
+    PASS: no 'Recompiling' in output when switching between shapes.
+    FAIL (use-per-fixed-shape only): recompile happens at each new S.
+    """
+    sep()
+    print("[Probe 0c] dynamic=True cross-shape recompile check")
+    print("  (set TORCH_LOGS=recompiles in env to see recompile events)")
+
+    def bw_tail(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = F.silu(h)
+        return x + h
+
+    torch._dynamo.reset()
+    try:
+        c = torch.compile(bw_tail, backend="inductor", dynamic=True)
+        w = torch.randn(D, device=DEVICE, dtype=DTYPE)
+
+        x1, _ = make(B, S, D)
+        c(x1, w)
+        torch.mps.synchronize()
+        print(f"  Shape (2,4096,1536): OK")
+
+        x2, _ = make(B, 9216, D)
+        c(x2, w)
+        torch.mps.synchronize()
+        print(f"  Shape (2,9216,1536): OK")
+
+        x3, _ = make(B, S, D)
+        c(x3, w)
+        torch.mps.synchronize()
+        print(f"  Shape (2,4096,1536) again: OK")
+
+        print("  Check TORCH_LOGS=recompiles output for 'Recompiling' entries.")
+        print("  PASS: zero recompiles on shape (2,4096,1536) after (2,9216,1536).")
+    except Exception as e:
+        print(f"  dynamic=True FAILED: {type(e).__name__}: {str(e)[:300]}")
+
+
+# ---------------------------------------------------------------------------
+# Probe 0d — subprocess cold compile latency (BLOCKER for ComfyUI wiring)
+# ---------------------------------------------------------------------------
+
+def probe_0d_cold_latency():
+    """BLOCKER for ComfyUI wiring: real cold compile latency from a fresh process.
+
+    In-process torch._dynamo.reset() does not simulate a cold cache state.
+    This probe spawns a subprocess so the OS starts fresh, and uses a
+    temporary TORCHINDUCTOR_CACHE_DIR to isolate cold vs warm persistent cache.
+
+    PASS: cold < 30s (acceptable for model load time).
+    FAIL: cold > 60s (unacceptable for ComfyUI startup).
+    """
+    sep()
+    print("[Probe 0d] Cold compile latency (subprocess, fresh cache)")
+
+    script = """
+import os, time, torch, torch.nn.functional as F
+DEVICE="mps"; DTYPE=torch.float16; B,S,D=2,4096,1536
+# Allocate inputs BEFORE starting timer (timer measures compile only)
+x = torch.randn(B,S,D,device=DEVICE,dtype=DTYPE)
+w = torch.randn(D,device=DEVICE,dtype=DTYPE)
+def bw_tail(x,w):
+    h=F.rms_norm(x,(x.shape[-1],),w,1e-6)
+    h=F.silu(h)
+    return x+h
+c=torch.compile(bw_tail,backend="inductor")
+torch.mps.synchronize()
+t0=time.perf_counter()
+c(x,w)
+torch.mps.synchronize()
+t1=time.perf_counter()
+print(f"cold_ms={(t1-t0)*1e3:.0f}")
+"""
+    python = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python"
+
+    # Cold run (empty cache)
+    with tempfile.TemporaryDirectory() as cache1:
+        env = os.environ.copy()
+        env["TORCHINDUCTOR_CACHE_DIR"] = cache1
+        r = subprocess.run(
+            [python, "-c", script],
+            capture_output=True, text=True, env=env, timeout=300,
+        )
+        cold_lines = [l for l in r.stdout.splitlines() if "cold_ms" in l]
+        if cold_lines:
+            print(f"  Cold (empty cache): {cold_lines[-1]}")
+        else:
+            print(f"  Cold run failed. stderr: {r.stderr[-500:] if r.stderr else 'none'}")
+
+    # Warm persistent cache (run twice, second = cache hit)
+    with tempfile.TemporaryDirectory() as cache2:
+        env2 = os.environ.copy()
+        env2["TORCHINDUCTOR_CACHE_DIR"] = cache2
+        subprocess.run([python, "-c", script], capture_output=True, text=True,
+                       env=env2, timeout=300)
+        r2 = subprocess.run([python, "-c", script], capture_output=True, text=True,
+                            env=env2, timeout=300)
+        warm_lines = [l for l in r2.stdout.splitlines() if "cold_ms" in l]
+        if warm_lines:
+            print(f"  Warm (persistent cache hit): {warm_lines[-1]}")
+        else:
+            print(f"  Warm run failed. stderr: {r2.stderr[-500:] if r2.stderr else 'none'}")
+
+    print("  PASS if cold_ms < 30000. FAIL if cold_ms > 60000.")
+
+
+# ---------------------------------------------------------------------------
+# Probe 0e — rmsnorm_mps_large.install() interaction (BLOCKER for ADOPT_COMPILE)
+# ---------------------------------------------------------------------------
+
+def probe_0e_rmsnorm_patch_interaction():
+    """BLOCKER: does Dynamo graph-break when rmsnorm_mps_large is installed?
+
+    rmsnorm_mps_large globally replaces F.rms_norm with a Python wrapper
+    containing control-flow (device check + row-count threshold). Dynamo may
+    or may not be able to trace through this, depending on the Python ops used.
+
+    PASS: graph_count=1 on both fast branch and forced manual branch.
+    FAIL: graph_count > 1 or exception — ADOPT_COMPILE scoped to unpatched only.
+    """
+    sep()
+    print("[Probe 0e] rmsnorm_mps_large.install() + compile(bw_tail)")
+
+    sys.path.insert(0, "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-AppleSilicon-FP8")
+
+    try:
+        import _patches.rmsnorm_mps_large as rml
+        rml.install()
+        print(f"  rmsnorm_mps_large installed (_THRESHOLD=2^21={rml._THRESHOLD})")
+    except Exception as e:
+        print(f"  rmsnorm_mps_large install FAILED: {e} — probe skipped")
+        return
+
+    import torch._dynamo as dynamo
+
+    def bw_tail(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = F.silu(h)
+        return x + h
+
+    # Fast branch (rows << _THRESHOLD, uses stock fused kernel)
+    x_small, w_small = make(1, 64, 64)
+    torch._dynamo.reset()
+    try:
+        expl = dynamo.explain(bw_tail)(x_small, w_small)
+        print(f"  Fast branch (rows=64): graph_count={expl.graph_count}  "
+              f"breaks={[str(r) for r in expl.break_reasons] or 'none'}")
+    except Exception as e:
+        print(f"  Fast branch explain FAILED: {e}")
+
+    # Forced manual branch (set _THRESHOLD=0 so all inputs hit fp32 path)
+    try:
+        orig_thresh = rml._THRESHOLD
+        rml._THRESHOLD = 0
+        torch._dynamo.reset()
+        try:
+            expl2 = dynamo.explain(bw_tail)(x_small, w_small)
+            print(f"  Manual branch (thresh=0): graph_count={expl2.graph_count}  "
+                  f"breaks={[str(r) for r in expl2.break_reasons] or 'none'}")
+        finally:
+            rml._THRESHOLD = orig_thresh
+    except AttributeError:
+        print("  _THRESHOLD attribute not found on rml module — inspect patch internals")
+    except Exception as e:
+        print(f"  Manual branch test FAILED: {e}")
+
+    print("  PASS if graph_count=1 on both branches.")
+    print("  FAIL if graph_count>1 — ADOPT_COMPILE limited to unpatched synthetic functions.")
+
+
+# ---------------------------------------------------------------------------
+# Probe 0f — ASFP8_PROFILE=1 graph break (MAJOR operational incompatibility)
+# ---------------------------------------------------------------------------
+
+def probe_0f_profile_graph_break():
+    """Do mps_profile wrappers (F.rms_norm, F.linear, torch.matmul, etc.) cause graph breaks?
+
+    mps_profile wraps: F.rms_norm, F.linear, F.conv2d, F.conv3d, F.layer_norm,
+                       torch.matmul, torch.bmm.
+    It does NOT wrap F.silu.
+
+    PASS: graph_count=1 (wrappers are transparent to Dynamo).
+    FAIL: graph_count>1 — ASFP8_PROFILE=1 and ASFP8_TORCH_COMPILE=1 mutually exclusive.
+    """
+    sep()
+    print("[Probe 0f] ASFP8_PROFILE=1 graph break check")
+
+    sys.path.insert(0, "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-AppleSilicon-FP8")
+    os.environ["ASFP8_PROFILE"] = "1"
+
+    try:
+        import _patches.mps_profile as prof
+        prof.install()
+        print("  mps_profile installed (wraps F.rms_norm, F.linear, "
+              "torch.matmul, torch.bmm, SDPA, layernorm, convs)")
+    except Exception as e:
+        print(f"  mps_profile install FAILED: {e} — probe skipped")
+        os.environ.pop("ASFP8_PROFILE", None)
+        return
+
+    import torch._dynamo as dynamo
+
+    def bw_tail(x, w):
+        h = F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+        h = F.silu(h)
+        return x + h
+
+    x, w = make(1, 256, 512)
+    torch._dynamo.reset()
+    try:
+        expl = dynamo.explain(bw_tail)(x, w)
+        print(f"  With mps_profile: graph_count={expl.graph_count}  "
+              f"breaks={[str(r) for r in expl.break_reasons] or 'none'}")
+        if expl.graph_count > 1:
+            print("  -> ASFP8_PROFILE=1 and ASFP8_TORCH_COMPILE=1 are MUTUALLY EXCLUSIVE.")
+        else:
+            print("  -> mps_profile wrappers are transparent to Dynamo. Compatible.")
+    except Exception as e:
+        print(f"  explain with mps_profile FAILED: {e}")
+    finally:
+        os.environ.pop("ASFP8_PROFILE", None)
+
+
+# ---------------------------------------------------------------------------
+# Probe 0g — fp16 rms_norm fp32 upcast check (MAJOR correctness gate)
+# ---------------------------------------------------------------------------
+
+def probe_0g_fp16_rmsnorm_precision():
+    """Does Inductor upcast rms_norm reduction to fp32, or run it in fp16?
+
+    Absence of NaN on random data is not sufficient. This probe uses stress
+    inputs with large magnitude (amplifies fp16 vs fp32 difference) and compares
+    compiled output against a manual fp32 reference.
+
+    PASS:  max_abs < 0.1 (compiled output close to fp32 reference; fp32 upcast likely).
+    WARN:  0.1 <= max_abs < 1.0 (fp16 accumulation suspected; borderline).
+    FAIL:  max_abs >= 1.0 (fp16 accumulation confirmed; correctness risk on large magnitudes).
+    """
+    sep()
+    print("[Probe 0g] fp16 rms_norm fp32 upcast check (stress inputs, fp32 reference)")
+
+    def rms_only(x, w):
+        return F.rms_norm(x, (x.shape[-1],), w, 1e-6)
+
+    # Stress inputs: large magnitude to amplify fp16 vs fp32 difference
+    # Use CPU fp32 for ground truth, then cast to fp16 for MPS
+    x_cpu = torch.randn(2, 4096, 1536, dtype=torch.float32) * 10.0
+    x_mps = x_cpu.half().to(DEVICE)
+    w_cpu = torch.ones(1536, dtype=torch.float32)
+    w_mps = w_cpu.half().to(DEVICE)
+
+    # fp32 CPU reference (ground truth)
+    with torch.no_grad():
+        ref_fp32 = rms_only(x_cpu, w_cpu)
+
+    # eager fp16 on MPS for comparison baseline
+    with torch.no_grad():
+        out_eager = rms_only(x_mps, w_mps)
+    torch.mps.synchronize()
+    eager_diff = (out_eager.float().cpu() - ref_fp32).abs().max().item()
+    print(f"  Eager fp16 vs fp32 ref: max_abs={eager_diff:.4f}")
+
+    # compiled fp16 on MPS
+    torch._dynamo.reset()
+    try:
+        c = torch.compile(rms_only, backend="inductor")
+        c(x_mps, w_mps)  # warmup/compile
+        torch.mps.synchronize()
+        with torch.no_grad():
+            out_compiled = c(x_mps, w_mps)
+        torch.mps.synchronize()
+        compiled_diff = (out_compiled.float().cpu() - ref_fp32).abs().max().item()
+        print(f"  Compiled fp16 vs fp32 ref: max_abs={compiled_diff:.4f}")
+
+        if compiled_diff < 0.1:
+            print("  PASS — compiled output close to fp32 ref (fp32 accumulation likely).")
+        elif compiled_diff < 1.0:
+            print("  WARN — moderate diff; fp16 accumulation suspected but borderline.")
+        else:
+            print("  FAIL — large diff; fp16 accumulation confirmed; correctness risk.")
+    except Exception as e:
+        print(f"  compile FAILED: {type(e).__name__}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 60)
+    print("Task A.0 — Empirical probes for torch.compile Inductor MPS")
+    print(f"PyTorch {torch.__version__} | MPS: {torch.backends.mps.is_available()}")
+    print("=" * 60)
+
+    if not torch.backends.mps.is_available():
+        print("MPS not available. Cannot run probes.")
+        sys.exit(1)
+
+    probe_0a_rms_norm_dispatch()
+    probe_0b_fullgraph()
+    probe_0c_dynamic_shapes()
+    probe_0d_cold_latency()
+    probe_0e_rmsnorm_patch_interaction()
+    probe_0f_profile_graph_break()
+    probe_0g_fp16_rmsnorm_precision()
+
+    sep()
+    print("\nAll probes complete.")
+    print("Record results in docs/superpowers/results/A-results.md before proceeding to Task A.1.")
+    print("Gate: ADOPT_COMPILE requires Probe 0a dispatch_count<=1 AND Probe 0b OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/smoke_int4_convrot.py
+++ b/dev/smoke_int4_convrot.py
@@ -1,0 +1,118 @@
+"""Smoke + micro-bench for ConvRot W4A4 (int4) on MPS via comfy master + kitchen 0.2.19.
+
+Run with the ComfyUI venv python:
+  "/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python" dev/smoke_int4_convrot.py
+
+Injects the master worktree + isolated kitchen 0.2.19 (does NOT touch the live install).
+
+Measures per-Linear-call cost on Ideogram/Krea-shaped GEMMs:
+  1. plain bf16 F.linear                        (upper bound / reference)
+  2. int8-style: dequant int8 weight -> F.linear (what int8 models do w/ our patch)
+  3. eager convrot_w4a4 dispatch (F.linear on QuantizedTensor) = what INT4 models do today
+  4. proposed quick fix: rotate act (grouped GEMM) + W4 unpack->bf16 + F.linear (no act round-trip)
+plus correctness of (3)/(4) vs reference.
+"""
+
+import os
+import sys
+import time
+
+CK_TARGET = os.environ.get("ASFP8_CK_TARGET", "")  # venv kitchen is new enough now
+COMFY_MASTER = os.path.expanduser(os.environ.get("ASFP8_COMFY", "~/ComfyUI-Installs/ComfyUI/ComfyUI"))
+NODE_DIR = "/Volumes/IMPERIAL SPACE/AI/ComfyUI/custom_nodes/ComfyUI-AppleSilicon-FP8"
+
+if CK_TARGET:
+    sys.path.insert(0, CK_TARGET)
+sys.path.insert(0, COMFY_MASTER)
+sys.path.insert(0, NODE_DIR)
+
+from _patches import psutil_vmstat  # noqa: E402
+
+psutil_vmstat.install()
+
+import torch  # noqa: E402
+
+import comfy_kitchen  # noqa: E402
+import comfy.quant_ops as q  # noqa: E402
+
+print("kitchen:", comfy_kitchen.__version__, os.path.dirname(comfy_kitchen.__file__))
+print("layout present:", hasattr(q, "TensorCoreConvRotW4A4Layout"))
+
+from comfy_kitchen.registry import registry  # noqa: E402
+
+impl = registry.get_implementation("convrot_w4a4_linear", kwargs=None)
+print("convrot_w4a4_linear impl:", impl.__module__)
+
+dev = "mps"
+torch.manual_seed(0)
+
+M, K, N = 4096, 4608, 4608  # Ideogram/Krea-shaped
+x = torch.randn(M, K, device=dev, dtype=torch.bfloat16)
+w = torch.randn(N, K, device=dev, dtype=torch.bfloat16) * 0.02
+
+Layout = q.TensorCoreConvRotW4A4Layout
+qdata, params = Layout.quantize(w.float(), convrot_groupsize=256, quant_group_size=64,
+                                stochastic_rounding=0, linear_dtype="int4")
+qt = q.QuantizedTensor(qdata, "TensorCoreConvRotW4A4Layout", params)
+print("qdata:", qdata.dtype, tuple(qdata.shape), "scale:", params.scale.dtype, tuple(params.scale.shape))
+
+# int8 comparison weight (per-row symmetric, like int8-fast dequant path)
+w_absmax = w.float().abs().amax(dim=1, keepdim=True).clamp(min=1e-10)
+w8_scale = w_absmax / 127.0
+w8 = (w.float() / w8_scale).round().clamp(-127, 127).to(torch.int8)
+
+ref = torch.nn.functional.linear(x.float(), w.float())
+
+# --- correctness: eager convrot dispatch
+y_convrot = torch.nn.functional.linear(x, qt)
+err_convrot = (y_convrot.float() - ref).abs().mean() / ref.abs().mean()
+
+# --- proposed quick fix: keep rotated basis, no activation quant round-trip
+from comfy_kitchen.backends.eager.convrot_w4a4 import (  # noqa: E402
+    _build_hadamard, _rotate_activation, _unpack_int4_row_major)
+
+
+def w4a16_rotated(x, qdata, scale, groupsize=256):
+    h = _build_hadamard(groupsize, device=x.device, dtype=x.dtype)
+    x_rot = _rotate_activation(x, h, groupsize)
+    w_rot = _unpack_int4_row_major(qdata).to(x.dtype) * scale.to(x.device, x.dtype).reshape(-1, 1)
+    return torch.nn.functional.linear(x_rot, w_rot)
+
+
+y_fix = w4a16_rotated(x, qdata.to(dev), params.scale)
+err_fix = (y_fix.float() - ref).abs().mean() / ref.abs().mean()
+
+print(f"rel err  eager convrot W4A4: {err_convrot.item():.4%}")
+print(f"rel err  quickfix W4A16    : {err_fix.item():.4%}")
+
+
+def bench(fn, iters=30, warmup=5):
+    for _ in range(warmup):
+        fn()
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.mps.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+qdata_mps = qdata.to(dev)
+scale_mps = params.scale.to(dev)
+qt_mps = q.QuantizedTensor(qdata_mps, "TensorCoreConvRotW4A4Layout",
+                           type(params)(scale=scale_mps, orig_dtype=params.orig_dtype,
+                                        orig_shape=params.orig_shape,
+                                        convrot_groupsize=params.convrot_groupsize,
+                                        quant_group_size=params.quant_group_size,
+                                        linear_dtype=params.linear_dtype))
+
+t_bf16 = bench(lambda: torch.nn.functional.linear(x, w))
+t_int8 = bench(lambda: torch.nn.functional.linear(x, (w8.to(torch.bfloat16) * w8_scale.to(torch.bfloat16))))
+t_convrot = bench(lambda: torch.nn.functional.linear(x, qt_mps))
+t_fix = bench(lambda: w4a16_rotated(x, qdata_mps, scale_mps))
+
+print(f"\nper-call ms @ M={M} K={K} N={N}")
+print(f"  bf16 F.linear            : {t_bf16:7.3f}")
+print(f"  int8 dequant + F.linear  : {t_int8:7.3f}")
+print(f"  eager convrot W4A4 (now) : {t_convrot:7.3f}   ({t_convrot / t_int8:.2f}x vs int8)")
+print(f"  quickfix W4A16 (proposed): {t_fix:7.3f}   ({t_fix / t_int8:.2f}x vs int8)")

--- a/docs/superpowers/profiles/2026-06-30-ideogram4-and-wan-breakdown.md
+++ b/docs/superpowers/profiles/2026-06-30-ideogram4-and-wan-breakdown.md
@@ -1,0 +1,121 @@
+# Per-op GPU-time breakdown — 2026-06-30
+
+Profiles collected with `ASFP8_PROFILE=1 ASFP8_PROFILE_INTERVAL=20` after the G1
+seam additions (activation + rotary seams). Each run serializes the GPU; wall time is
+~2-4× longer than normal; the *relative shares* are what matter for prioritization.
+
+---
+
+## Task 0 probe result
+
+nn.SiLU dispatches through F.silu: [FILL: YES / NO]
+nn.GELU dispatches through F.gelu: [FILL: YES / NO]
+Additional wraps applied (if bypass detected): [FILL: none / nn.SiLU.forward + nn.GELU.forward]
+
+---
+
+## Run 1 — Ideogram 4 (int8 convrot, ASFP8_INT8_EXT=1)
+
+**Config:** [FILL: resolution, steps, sampler, ComfyUI version, mtlflashattn ON/OFF]
+
+**Launch command:**
+```
+ASFP8_PROFILE=1 ASFP8_PROFILE_INTERVAL=20 ASFP8_INT8_EXT=1 \
+  python main.py --listen --port 8188 2>&1 | tee /tmp/ideogram4_profile.log
+```
+
+**Profiler output (paste the final cumulative dump from terminal):**
+```
+[FILL: paste [AppleSilicon-FP8/mps_profile] GPU-time breakdown block here]
+[Label: phase = denoising, step N of M, or "full run if no crash"]
+```
+
+**Parsed table:**
+
+| Op bucket     | Time (s) | Share (%) | Calls | ms/call |
+|---------------|----------|-----------|-------|---------|
+| attention     | [FILL]   | [FILL]    |       |         |
+| linear        | [FILL]   | [FILL]    |       |         |
+| conv2d        | [FILL]   | [FILL]    |       |         |
+| conv3d        | [FILL]   | [FILL]    |       |         |
+| rmsnorm       | [FILL]   | [FILL]    |       |         |
+| layernorm     | [FILL]   | [FILL]    |       |         |
+| activation    | [FILL]   | [FILL]    |       |         |
+| rotary        | [FILL]   | [FILL]    |       |         |
+| matmul        | [FILL]   | [FILL]    |       |         |
+| bmm           | [FILL]   | [FILL]    |       |         |
+| gguf_dequant  | [FILL]   | [FILL]    |       |         |
+| \<unwrapped\> | [FILL]   | [FILL]    |  n/a  |   n/a   |
+
+**COMMIT_AND_WAIT hypothesis:**
+- Dominant linear shape (M, K, N): [FILL]
+- ASFP8_INT8_EXT active: [FILL: YES/NO]
+- linear ms/call observed: [FILL]
+- Hypothesis: if ms/call > 2ms for M≤64, COMMIT_AND_WAIT at int8_matmul2d_tuned.mm:117 may be firing. Requires per-shape confirmation before acting.
+
+---
+
+## Run 2 — Wan 2.2 720p (4–6 steps)
+
+> NOTE: Wan 2.2 visual output may be incorrect (separate correctness issue).
+> The time distribution is valid regardless of output quality.
+> Confirm the run completes without Python exception before trusting these numbers.
+> If a crash occurs, label the dump with the phase/step reached (see Step C2).
+
+**Config:** [FILL: resolution=720p, steps, sampler, model variant, mtlflashattn ON/OFF]
+
+**Launch command:**
+```
+ASFP8_PROFILE=1 ASFP8_PROFILE_INTERVAL=20 \
+  python main.py --listen --port 8188 2>&1 | tee /tmp/wan_profile.log
+```
+
+**Profiler output (paste the final cumulative dump):**
+```
+[FILL]
+[Label: phase = denoising step N of M / crashed after step N / full run]
+```
+
+**Parsed table:**
+
+| Op bucket     | Time (s) | Share (%) | Calls | ms/call |
+|---------------|----------|-----------|-------|---------|
+| attention     | [FILL]   | [FILL]    |       |         |
+| linear        | [FILL]   | [FILL]    |       |         |
+| conv2d        | [FILL]   | [FILL]    |       |         |
+| conv3d        | [FILL]   | [FILL]    |       |         |
+| rmsnorm       | [FILL]   | [FILL]    |       |         |
+| layernorm     | [FILL]   | [FILL]    |       |         |
+| activation    | [FILL]   | [FILL]    |       |         |
+| rotary        | [FILL]   | [FILL]    |       |         |
+| matmul        | [FILL]   | [FILL]    |       |         |
+| bmm           | [FILL]   | [FILL]    |       |         |
+| gguf_dequant  | [FILL]   | [FILL]    |       |         |
+| \<unwrapped\> | [FILL]   | [FILL]    |  n/a  |   n/a   |
+
+---
+
+## Diagnosis checklist
+
+Before reading the ranking:
+- [ ] `rotary` shows > 0% for Wan (it must: Wan uses rope_apply / apply_rope_comfy1 etc.)
+- [ ] `rotary` for ideogram4: if 0%, confirm `_ideogram4_apply_rope_lowp` was the active path (check KJNodes node used in workflow); 0% may be correct if that node was not used
+- [ ] `activation` > 0% for both models (non-zero confirms F.silu/gelu/glu wrap fired)
+- [ ] If `activation` ≈ 0% but `<unwrapped>` is large, Task 0 probe likely showed bypass — add nn.SiLU.forward/nn.GELU.forward wraps and re-run
+- [ ] Linear ms/call vs shape hypothesis documented (COMMIT_AND_WAIT section above)
+- [ ] Partial dumps (if run crashed) are labeled with phase/step and only used for ranking if at least one full denoising step completed
+
+---
+
+## Combined ranking and priority override
+
+[FILL after both tables are complete]
+
+Priority ranking by GPU-time share (combined ideogram4 + Wan, descending):
+1. [FILL] — X%  →  [roadmap item]
+2. [FILL] — X%  →  [roadmap item]
+3. ...
+
+**Override verdict:** [Does this ranking agree with the default A→B→C→D→E roadmap order?
+List any items whose priority changes. Example: "C (rotary) should move ahead of B (conv)
+because rotary is 18% vs conv 4% in Wan."]

--- a/docs/superpowers/results/A-results.md
+++ b/docs/superpowers/results/A-results.md
@@ -1,0 +1,200 @@
+# Issue A — torch.compile Inductor MPS Fusion Sweep: Results
+
+Date: 2026-06-30
+PyTorch: 2.11.0  Machine: M5 Max macOS 27
+Branch: impl/A
+Shape: (2, 4096, 1536) fp16 (production DiT hidden dim)
+
+---
+
+## Task A.0 — Probe Results
+
+### Probe 0a — rms_norm+silu+residual dispatch count (BLOCKER)
+
+| Shape | graph_count | breaks | fullgraph=True | rms_only fullgraph |
+|---|---|---|---|---|
+| small (1,256,512) | 1 | none | OK | OK |
+| production (2,4096,1536) | 1 | none | OK | OK |
+
+**extern_kernel actual calls in output_code.py:**
+- bw_tail (small): NO output_code.py generated — 0 extern_kernel calls (pure MPS Metal, fully fused)
+- bw_tail (production): NO output_code.py generated — 0 extern_kernel calls (pure MPS Metal, fully fused)
+- full_block (small): 1 actual `extern_kernels.mm` call (GEMM only)
+- full_block (production): 1 actual `extern_kernels.mm` call (GEMM only)
+
+**Result: PASS** — bw_tail production has 0 extern_kernel calls (better than <=1 gate).
+Inductor fuses rms_norm+silu+residual into a single pure-MPS Metal kernel.
+
+### Probe 0b — fullgraph=True compile (BLOCKER)
+
+| Function | Result |
+|---|---|
+| bw_tail | PASS |
+| full_block | PASS |
+
+### Probe 0c — dynamic=True cross-shape recompile
+
+All three shapes (2,4096,1536), (2,9216,1536), (2,4096,1536) ran OK.
+No recompiles observed for repeated shape. **PASS.**
+
+### Probe 0d — Cold compile latency (subprocess, fresh cache)
+
+| Run | Latency |
+|---|---|
+| Cold (empty cache) | 399 ms |
+| Warm (persistent cache hit) | 183 ms |
+| Benchmark first-call (in-process) | 257 ms |
+
+**PASS** — cold_ms=399 well under 30,000 ms threshold.
+
+### Probe 0e — rmsnorm_mps_large.install() interaction
+
+| Branch | graph_count | breaks |
+|---|---|---|
+| Fast branch (rows=64, below threshold) | 1 | none |
+| Manual branch (_THRESHOLD=0, forced fp32 path) | 1 | none |
+
+**PASS** — rmsnorm_mps_large is transparent to Dynamo.
+ADOPT_COMPILE applies to the real ComfyUI patch stack, not just synthetic unpatched functions.
+
+### Probe 0f — ASFP8_PROFILE=1 graph break
+
+| With mps_profile | graph_count | Result |
+|---|---|---|
+| bw_tail | 3 | FAIL |
+
+Break reason: `time.perf_counter` in mps_profile.py wrapper (lines 92, 95) is not traceable by Dynamo.
+
+**FAIL — ASFP8_PROFILE=1 and ASFP8_TORCH_COMPILE=1 are MUTUALLY EXCLUSIVE.**
+A follow-on patch must enforce this with an env-var guard at activation time.
+
+### Probe 0g — fp16 rms_norm fp32 upcast check
+
+| | max_abs vs fp32 ref |
+|---|---|
+| Eager fp16 MPS | 0.0035 — confirms fp32 accumulation in eager |
+| Compiled fp16 MPS | CppCompileError (path-spaces issue, only on no_grad recompile path) |
+
+The CppCompileError occurs only when Inductor generates a C++ wrapper during a recompile
+triggered by `torch.no_grad()` (grad_mode guard failure). The path `/Volumes/IMPERIAL SPACE/...`
+has a space that breaks the linker `-L` flag. Normal forward-pass compilation (Probes 0a/0b)
+succeeds without this issue.
+
+Compiled path confirmed via pytest: `test_compiled_rms_norm_fp32_reference` passes with
+max_abs < 5e-2 vs fp32 manual reference on 10x-scale stress inputs.
+
+**Partial — fp32 accumulation in eager confirmed; compiled stress test passes via pytest.**
+
+---
+
+## Task A.2 — Benchmark Results
+
+Configuration: (2,4096,1536) fp16, warmup=5, iters=50, M5 Max MPS
+
+| Config | Eager (ms) | Compiled (ms) | Speedup | Correctness |
+|---|---|---|---|---|
+| bw_tail (no linear) | 0.429 | 0.143 | **2.99x** | PASS (max_abs=0.0156) |
+| full_block (with linear) | 0.991 | 0.946 | 1.05x | PASS (atol=0.1) |
+
+Cold compile latency (in-process): bw_tail=257ms, full_block=34ms
+
+### Roofline Analysis (M5 Max @400 GB/s)
+
+| | Bytes (MB) | Min time (ms) |
+|---|---|---|
+| Eager 3-kernel (optimistic) | 176 | 0.440 |
+| Eager 3-kernel (conservative) | 201 | 0.503 |
+| Fused 1-kernel | 75 | 0.189 |
+
+- Theoretical speedup range: 2.33x – 2.67x
+- **Achieved: 2.99x** — exceeds roofline upper bound, confirming true DRAM-traffic reduction plus launch-overhead elimination
+
+---
+
+## Task A.3 — Fusion Inspector Results
+
+### ir_post_fusion for full_block production (2,4096,1536)
+
+Scheduler nodes (post-fusion):
+1. `op0_op1` — **FusedSchedulerNode** (rms_norm: op0=variance reduction upcast fp32 + op1=apply rsqrt+scale, fused into ONE Metal kernel with fp32 accumulation)
+2. `op2` — **ExternKernelSchedulerNode**: `extern_kernels.mm` (the GEMM — expected, compute-bound)
+3. `op3` — **SchedulerNode**: silu + residual add (one MPS pointwise kernel)
+
+For **bw_tail**: no output_code.py generated at all — Inductor uses pure MPS Metal path with
+zero extern_kernel dispatches. The rms_norm (with fp32 accumulation upcast confirmed in op0) +
+silu + residual are fused into a single pass.
+
+### Dispatch counts summary
+
+| Function | Shape | Actual extern_kernel calls | MPS Metal dispatches |
+|---|---|---|---|
+| bw_tail | (1,256,512) | 0 | 1 (fully fused) |
+| bw_tail | (2,4096,1536) | 0 | 1 (fully fused) |
+| full_block | (1,256,512) | 1 (GEMM only) | 3 (norm fused; GEMM separate; silu+res fused) |
+| full_block | (2,4096,1536) | 1 (GEMM only) | 3 (norm fused; GEMM separate; silu+res fused) |
+
+---
+
+## Task A.4 — Final Decision
+
+### Gate Checklist
+
+- [x] Probe 0a: bw_tail production extern_kernels = 0 (fully fused, 0 actual calls)
+- [x] Probe 0b: fullgraph=True PASS for both bw_tail and full_block
+- [x] bw_tail speedup = 2.99x >= 1.5x threshold
+- [x] bw_tail correctness: PASS (max_abs=0.0156 vs eager; max_abs < 5e-2 vs fp32 ref)
+
+### DECISION: ADOPT_COMPILE
+
+All four gate conditions are met. Inductor MPS on PyTorch 2.11 genuinely fuses
+rms_norm + silu + residual into a single Metal kernel for the DiT-block bandwidth-bound
+tail, eliminating 2 DRAM round-trips and achieving 2.99x speedup at production shape.
+
+### Impact on Issues D and E
+
+- **Issue D** (activation epilogue fusion into GEMM): **SHRINKS** — the post-GEMM
+  silu+residual is already fused by Inductor (op3 in full_block). Only GEMM-internal
+  epilogue fusion (e.g., bias folding, rescale into GEMM kernel) remains out of Inductor's
+  reach and may warrant a hand-kernel.
+
+- **Issue E** (fused norm+modulation+residual): **SHRINKS significantly** — the basic
+  rms_norm+silu+residual chain is handled by compile. Modulation (AdaLN scale/shift)
+  adds pointwise ops that Inductor can also fuse. Only model-specific fused single-kernel
+  implementations would beat compile here.
+
+### Operational Constraints (from probes)
+
+1. **ASFP8_PROFILE=1 is mutually exclusive with ASFP8_TORCH_COMPILE=1** (Probe 0f).
+   A follow-on patch must enforce this with an env-var guard at activation time.
+
+2. **CppCompileError with spaces in path** (Probe 0g): Only triggers on no_grad recompile.
+   Normal forward-pass compilation (no grad_mode change) works correctly.
+   The follow-on patch must wrap compilation in try/except to handle this gracefully.
+
+3. **rmsnorm_mps_large is transparent to Dynamo** (Probe 0e): ADOPT_COMPILE applies
+   to the real ComfyUI patch stack (not just synthetic unpatched functions).
+
+4. **dynamic=True** (Probe 0c): No recompiles observed between shapes. A single compiled
+   function handles variable sequence lengths without per-shape specialization overhead.
+
+### Follow-on Plan (out of Issue A scope)
+
+Create `_patches/torch_compile_mps.py`:
+- Gate: `ASFP8_TORCH_COMPILE=1` env var
+- Guard: refuse to activate if `ASFP8_PROFILE=1`
+- Pattern: wrap DiT-block module.forward with `torch.compile(backend="inductor")`
+- Error handling: try/except BackendCompilerFailed + CppCompileError -> log + skip (never fatal)
+- Register in `__init__.py` patch list
+
+### pytest Test Summary
+
+```
+tests/test_torch_compile_fusion.py::test_bw_tail_compiled_matches_eager PASSED
+tests/test_torch_compile_fusion.py::test_full_block_compiled_matches_eager PASSED
+tests/test_torch_compile_fusion.py::test_bw_tail_no_graph_breaks PASSED
+tests/test_torch_compile_fusion.py::test_bw_tail_shapes[1-256-512] PASSED
+tests/test_torch_compile_fusion.py::test_bw_tail_shapes[2-1024-768] PASSED
+tests/test_torch_compile_fusion.py::test_bw_tail_shapes[1-4096-1536] PASSED
+tests/test_torch_compile_fusion.py::test_compiled_rms_norm_fp32_reference PASSED
+7 passed, 0 failed, 0 skipped
+```

--- a/docs/superpowers/results/A-results.md
+++ b/docs/superpowers/results/A-results.md
@@ -17,8 +17,8 @@ Shape: (2, 4096, 1536) fp16 (production DiT hidden dim)
 | production (2,4096,1536) | 1 | none | OK | OK |
 
 **extern_kernel actual calls in output_code.py:**
-- bw_tail (small): NO output_code.py generated — 0 extern_kernel calls (pure MPS Metal, fully fused)
-- bw_tail (production): NO output_code.py generated — 0 extern_kernel calls (pure MPS Metal, fully fused)
+- bw_tail (small): output_code.py IS generated (at `torch_compile_debug/run_*/torchinductor/model__0_inference_0.0/output_code.py`) — 0 `extern_kernels.` method calls; 1 `compile_mps_shader` Metal kernel (rms_norm+silu+residual fully fused). The `extern_kernels` import is always present in the template but is never called.
+- bw_tail (production): output_code.py IS generated — 0 `extern_kernels.` method calls; 1 `compile_mps_shader` Metal kernel (rms_norm+silu+residual fully fused)
 - full_block (small): 1 actual `extern_kernels.mm` call (GEMM only)
 - full_block (production): 1 actual `extern_kernels.mm` call (GEMM only)
 
@@ -93,21 +93,34 @@ Configuration: (2,4096,1536) fp16, warmup=5, iters=50, M5 Max MPS
 
 | Config | Eager (ms) | Compiled (ms) | Speedup | Correctness |
 |---|---|---|---|---|
-| bw_tail (no linear) | 0.429 | 0.143 | **2.99x** | PASS (max_abs=0.0156) |
+| bw_tail (no linear) | 0.429 | 0.143 | **2.42x–2.99x** (best run: 2.99x; independent verification: 2.42x) | PASS (max_abs=0.0156) |
 | full_block (with linear) | 0.991 | 0.946 | 1.05x | PASS (atol=0.1) |
+
+**M1 note — run-to-run variance**: The eager baseline varies ~18% across runs on the same machine (thermal
+state, background load, GPU clock gating). Compiled time is stable (~0.143–0.145 ms). The speedup
+therefore ranges from 2.42x (independent verification run) to 2.99x (original measurement). The 1.5x
+gate is cleared by a wide margin in all observed runs.
 
 Cold compile latency (in-process): bw_tail=257ms, full_block=34ms
 
-### Roofline Analysis (M5 Max @400 GB/s)
+### Roofline Analysis (M5 Max)
 
-| | Bytes (MB) | Min time (ms) |
-|---|---|---|
-| Eager 3-kernel (optimistic) | 176 | 0.440 |
-| Eager 3-kernel (conservative) | 201 | 0.503 |
-| Fused 1-kernel | 75 | 0.189 |
+**M2 note — bandwidth assumption**: The original roofline used 400 GB/s (conservative). M5 Max
+measured bandwidth is ~530–550 GB/s (Apple spec: 546 GB/s). At 530 GB/s the fused-kernel
+floor is 75 MB / 530 GB/s ≈ 0.142 ms, matching the observed compiled time exactly. The
+independently verified 2.42x speedup falls within the corrected theoretical range of 2.33x–2.67x.
+The original "exceeds upper bound" observation was an artifact of the conservative bandwidth
+assumption, not evidence of launch-overhead elimination beyond DRAM-traffic reduction.
 
-- Theoretical speedup range: 2.33x – 2.67x
-- **Achieved: 2.99x** — exceeds roofline upper bound, confirming true DRAM-traffic reduction plus launch-overhead elimination
+| | Bytes (MB) | Min time @400 GB/s (ms) | Min time @530 GB/s (ms) |
+|---|---|---|---|
+| Eager 3-kernel (optimistic) | 176 | 0.440 | 0.332 |
+| Eager 3-kernel (conservative) | 201 | 0.503 | 0.379 |
+| Fused 1-kernel | 75 | 0.188 | 0.142 |
+
+- Theoretical speedup range (400 GB/s): 2.33x – 2.67x
+- Theoretical speedup range (530 GB/s): 2.33x – 2.67x (same ratio, bandwidth cancels)
+- **Observed range: 2.42x–2.99x** — consistent with pure DRAM-traffic reduction at realistic bandwidth
 
 ---
 
@@ -120,9 +133,13 @@ Scheduler nodes (post-fusion):
 2. `op2` — **ExternKernelSchedulerNode**: `extern_kernels.mm` (the GEMM — expected, compute-bound)
 3. `op3` — **SchedulerNode**: silu + residual add (one MPS pointwise kernel)
 
-For **bw_tail**: no output_code.py generated at all — Inductor uses pure MPS Metal path with
-zero extern_kernel dispatches. The rms_norm (with fp32 accumulation upcast confirmed in op0) +
-silu + residual are fused into a single pass.
+For **bw_tail**: output_code.py IS generated at
+`torch_compile_debug/run_*/torchinductor/model__0_inference_0.0/output_code.py` and
+contains 0 `extern_kernels.` method calls (the `extern_kernels` import is always emitted by the
+template but is never invoked). Inductor lowers all ops into a single `compile_mps_shader`
+Metal kernel (`mps_lib_0` in the file). The rms_norm fp32 accumulation is confirmed by the
+`threadgroup float tmp_acc_0` reduction in that shader; silu and residual are fused into the
+same pass.
 
 ### Dispatch counts summary
 
@@ -141,21 +158,26 @@ silu + residual are fused into a single pass.
 
 - [x] Probe 0a: bw_tail production extern_kernels = 0 (fully fused, 0 actual calls)
 - [x] Probe 0b: fullgraph=True PASS for both bw_tail and full_block
-- [x] bw_tail speedup = 2.99x >= 1.5x threshold
+- [x] bw_tail speedup = 2.42x–2.99x (best: 2.99x; independent run: 2.42x) >= 1.5x threshold
 - [x] bw_tail correctness: PASS (max_abs=0.0156 vs eager; max_abs < 5e-2 vs fp32 ref)
 
 ### DECISION: ADOPT_COMPILE
 
 All four gate conditions are met. Inductor MPS on PyTorch 2.11 genuinely fuses
 rms_norm + silu + residual into a single Metal kernel for the DiT-block bandwidth-bound
-tail, eliminating 2 DRAM round-trips and achieving 2.99x speedup at production shape.
+tail, eliminating 2 DRAM round-trips and achieving 2.42x–2.99x speedup at production shape
+(variance driven by eager-baseline thermal/load variation; see M1 note in benchmark section).
 
 ### Impact on Issues D and E
 
-- **Issue D** (activation epilogue fusion into GEMM): **SHRINKS** — the post-GEMM
-  silu+residual is already fused by Inductor (op3 in full_block). Only GEMM-internal
-  epilogue fusion (e.g., bias folding, rescale into GEMM kernel) remains out of Inductor's
-  reach and may warrant a hand-kernel.
+- **Issue D** (activation epilogue fusion into GEMM): **REMAINS FULLY RELEVANT** — the
+  full_block lowers to THREE dispatches: (1) rms_norm Metal shader, (2) `extern_kernels.mm`
+  GEMM, (3) silu+residual Metal shader. The silu and residual ARE fused with each other
+  (op3 / mps_lib_1), but are NOT fused into the GEMM. The GEMM writes its output (`buf2`)
+  to DRAM; mps_lib_1 reads it back. This GEMM→DRAM→silu round-trip is exactly what
+  Issue D targets. Hand-kernels that fold the GEMM epilogue (bias, rescale, silu, residual)
+  into the GEMM itself — eliminating the DRAM round-trip — remain fully warranted and are
+  NOT made redundant by compile.
 
 - **Issue E** (fused norm+modulation+residual): **SHRINKS significantly** — the basic
   rms_norm+silu+residual chain is handled by compile. Modulation (AdaLN scale/shift)

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -1,0 +1,53 @@
+# Issue B — empirical / probe results
+
+Environment: M5 Max, macOS 27.0 (arm64), PyTorch 2.11.0, MPS available, Metal 4.1.
+Python: `/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python` (cpython 3.12.11).
+
+## Task B.0 — matmul2d operand-dtype probe (HARD GATE)
+
+### B.0 dtype probe (plan's verbatim script, `dev/probe_matmul2d_dtype.py`)
+
+```
+matmul2d <half,half,float> : NUMFAIL maxdiff=14.5
+matmul2d <bfloat,bfloat,float> : NUMFAIL maxdiff=14.5
+matmul2d <float,float,float> : NUMFAIL maxdiff=14.5
+```
+
+Diagnosis: the kernel COMPILES and RUNS for all dtypes (no compile/run exception). The
+NUMFAIL is a **readout bug in the probe**, not a capability failure. The probe reads the
+cooperative-tensor result with a linear `O[i] = c[i]`, but element `i` of a cooperative
+tensor maps to a `(row,col)` via `get_multidimensional_index`, not to row-major position
+`i`. The linear readout scrambles the result, producing an identical spurious maxdiff
+(~14.5, i.e. uncorrelated layout) for EVERY dtype. The production GEMM (Section 2.3)
+correctly scatters via `get_multidimensional_index`; the probe did not.
+
+### B.0 dtype probe — CORRECTED readout (`dev/probe_matmul2d_dtype_scatter.py`)
+
+Faithful test using the exact production scatter (`O[row*N+col] = c[i]` with
+`row=idx[1], col=idx[0]`), tolerances half<0.5 / bf16<1.0 / fp32<1e-3, plus a non-zero
+(SPY) check that the result is not all-zero:
+
+```
+matmul2d <half,half,float> (scatter readout) : PASS
+matmul2d <bfloat,bfloat,float> (scatter readout) : PASS
+matmul2d <float,float,float> (scatter readout) : PASS
+```
+
+This matches the handed-down G2 empirical result (all 6 candidates compile+run+CORRECT,
+NT layout, float accumulator) exactly. The `<half,half,float>` fp32-accumulate cooperative
+destination is CONFIRMED — no design revision (v2 threadgroup-float / .mm setBytes) needed.
+
+**Decision gate result: PASS for half, bfloat, AND float.** `_DT` exposes all three
+(`float16`→"half", `bfloat16`→"bfloat", `float32`→"float").
+
+### B.0b dispatch probe (`dev/probe_compile_shader_dispatch.py`)
+
+```
+PRM echo: [7, 11, 13, 17, 19] expect [7, 11, 13, 17, 19] -> PASS
+grid echo: [0, 100, 200, 1, 101, 201] expect [0, 100, 200, 1, 101, 201] -> PASS
+```
+
+`device const int* PRM` scalar passing works under `compile_shader`; the 2D threadgroup
+grid maps with no axis transposition (`threads=(gx*TG, gy, 1)` → `tg.x`/`tg.y` as
+expected). The GEMM's `threads=(gx*NSG*32, gy, 1), group_size=(NSG*32,1,1)` dispatch is
+confirmed correct.

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -123,3 +123,24 @@ the fallback path (grouped conv NOT routed to the kernel).
 
 Registered patch #18 in __init__.py (import list + install loop, after int8_linear_kernel_mps;
 docstring line 18). ruff clean on _patches/conv_im2col_mps.py + tests/test_conv_im2col.py.
+
+## Task B.9 — fused channel-major scatter (removes out_flat + permute copy)
+
+gemm_nt_bias_scatter: store epilogue decodes pix=p0+(m0+r) -> (n,od,oh,ow) and writes
+directly into channel-major OUT[N,Cout,(Dout,)Hout,Wout]; unified 2D/3D (Dout=1 for 2D).
+Drivers route through it when ASFP8_CONV_SCATTER (default "1") is on, allocating the final
+output ONCE (no out_flat staging, no permute().contiguous() copy).
+
+Tests:
+- test_scatter_matches_nonscatter: scatter output is torch.equal (BYTE-IDENTICAL) to the
+  out_flat+permute path (conv3d 1x16x5x24x24, w 12x16x3x3x3, bias). PASS.
+- test_scatter_drops_extra_buffer: DETERMINISTIC torch.empty spy (current_allocated is NOT
+  a high-watermark, so it cannot see the transient out_flat/copy -- earlier attempt showed
+  identical 16 MB current-alloc for both paths). Asserts the non-scatter path allocates the
+  [P,Cout] out_flat while the scatter path NEVER does and instead allocates [N,Cout,H,W]
+  directly. PASS.
+- B.4/B.6 correctness reused with scatter ON (default) and OFF: 5 passed each.
+
+conv3d bench with scatter default-on: im2col=41.320ms stock=69.689ms speedup=1.69x,
+correctness max|diff|=0.1247 OK -> no regression from the scatter epilogue (slightly faster
+than the 1.60-1.68x out_flat path). Full suite 20 passed, ruff clean.

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -69,3 +69,21 @@ achieved same-shape GEMM -> conv2d is ALREADY competitive; do NOT route conv2d. 
 conv3d achieves only 8% of the same-shape GEMM (~13x headroom) -> conv3d is the firm win.
 **Scope install to conv3d-only (`ASFP8_CONV_IM2COL=3d`).** conv2d path is still built and
 correctness-tested (B.4) but not installed by default.
+
+## Task B.5 — conv2d verify-first bench + deterministic tile-cap test
+
+conv2d bench (M5 Max, fp16, 1x256x512x512, w=256x256x3x3, pad=1):
+```
+  correctness: max|diff|=0.123 -> OK
+conv2d  im2col=24.118ms  stock=5.066ms  speedup=0.21x
+  current_allocated (NOT peak): 0.63GiB
+```
+Correctness OK (gate passes before timing). Speed 0.21x = ~4.7x SLOWER than stock conv2d,
+exactly as B.1 predicted (stock conv2d already at 111% of the achieved same-shape GEMM).
+DOCUMENTED non-ship outcome: conv2d is NOT installed by default (install gated to 3d-only).
+No regression shipped.
+
+Tests: `test_tile_buffer_capped` + `test_conv_alloc_smoke_nonpeak` -> 2 passed. The A_tile
+is deterministically <= 384 MB and tile_p < P (true tiling, not full 1.21 GB im2col); the
+non-peak alloc-smoke delta (0.63 GiB) stays well under the budget and under the full-im2col
+size.

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -103,3 +103,23 @@ conv3d im2col is FASTER than stock conv3d (1.6-1.7x) and correct -> firm win con
 Because the 64x64 baseline GEMM already beats stock conv3d, Task B.3b (register-tiling)
 is NOT required. current_alloc 0.21 GiB (NOT a high-watermark; the A_tile cap is the
 deterministic proof, B.8 the definitive OOM check).
+
+## Task B.7 — guarded install + __init__.py registration
+
+Full suite: `pytest tests/test_conv_im2col.py -v` -> 18 passed in 0.28s.
+Install/fallback tests (run everywhere, not just MPS): no-op-without-flag, per-mode
+idempotence (=2d then =3d installs {2,3}), grouped/dilated/CPU fallback, injected-kernel-
+exception fallback -> all pass.
+
+Flag-on grouped-fallback smoke:
+```
+[AppleSilicon-FP8/conv] conv im2col+matmul2d active on MPS (ranks=[2, 3], tile=384MB).
+grouped-fallback ok: (1, 8, 16, 16)
+```
+NOTE: the plan's smoke used w=[8,8,3,3] with groups=2 which is an INVALID grouped conv
+(groups=2 needs weight [8,4,3,3] for 8-ch input); the stock conv legitimately rejected it.
+Corrected to w=[8,4,3,3] -> fallback delegates to stock conv, output (1,8,16,16). Proves
+the fallback path (grouped conv NOT routed to the kernel).
+
+Registered patch #18 in __init__.py (import list + install loop, after int8_linear_kernel_mps;
+docstring line 18). ruff clean on _patches/conv_im2col_mps.py + tests/test_conv_im2col.py.

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -87,3 +87,19 @@ Tests: `test_tile_buffer_capped` + `test_conv_alloc_smoke_nonpeak` -> 2 passed. 
 is deterministically <= 384 MB and tile_p < P (true tiling, not full 1.21 GB im2col); the
 non-peak alloc-smoke delta (0.63 GiB) stays well under the budget and under the full-im2col
 size.
+
+## Task B.6 — conv3d variant (firm win + SeedVR2 OOM target)
+
+conv3d correctness (`test_conv3d_matches_reference`, spy active): 2 passed, max|diff| < 2e-1.
+
+conv3d bench (M5 Max, fp16, 1x128x5x256x256, w=128x128x3x3x3, pad=1):
+```
+  correctness: max|diff|=0.1248 -> OK
+conv3d  im2col=43.517ms  stock=69.472ms  speedup=1.60x  current_alloc_after_ours=0.21GiB (NOT peak)
+```
+(re-run standalone: conv3d im2col=44.675ms stock=75.019ms speedup=1.68x)
+
+conv3d im2col is FASTER than stock conv3d (1.6-1.7x) and correct -> firm win confirmed.
+Because the 64x64 baseline GEMM already beats stock conv3d, Task B.3b (register-tiling)
+is NOT required. current_alloc 0.21 GiB (NOT a high-watermark; the A_tile cap is the
+deterministic proof, B.8 the definitive OOM check).

--- a/docs/superpowers/results/B-results.md
+++ b/docs/superpowers/results/B-results.md
@@ -51,3 +51,21 @@ grid echo: [0, 100, 200, 1, 101, 201] expect [0, 100, 200, 1, 101, 201] -> PASS
 grid maps with no axis transposition (`threads=(gx*TG, gy, 1)` → `tg.x`/`tg.y` as
 expected). The GEMM's `threads=(gx*NSG*32, gy, 1), group_size=(NSG*32,1,1)` dispatch is
 confirmed correct.
+
+## Task B.1 — baseline stock conv vs measured same-shape GEMM (`dev/bench_mps_conv.py`)
+
+Device: Apple M5 Max, 18 cores (6 Super + 12 Performance), macOS 27.
+
+```
+conv2d 3x3 256ch 512x512: 5.115 ms  60458.8 GFLOP/s
+  measured GEMM @ M=262144,K=2304,N=256: 5.683 ms  54417.2 GFLOP/s (conv2d achieves 111% of achieved GEMM)
+conv3d 3x3x3 128ch 5x256x256: 69.926 ms  4146.0 GFLOP/s
+  measured GEMM @ M=327680,K=3456,N=128: 5.456 ms  53139.6 GFLOP/s (conv3d achieves 8% of achieved GEMM)
+driver_allocated (current, NOT peak): 4.32 GiB
+```
+
+DECISION (data-driven, Open Question #8): stock conv2d already achieves 111% of the
+achieved same-shape GEMM -> conv2d is ALREADY competitive; do NOT route conv2d. Stock
+conv3d achieves only 8% of the same-shape GEMM (~13x headroom) -> conv3d is the firm win.
+**Scope install to conv3d-only (`ASFP8_CONV_IM2COL=3d`).** conv2d path is still built and
+correctness-tested (B.4) but not installed by default.

--- a/docs/superpowers/results/D-results.md
+++ b/docs/superpowers/results/D-results.md
@@ -22,3 +22,34 @@ PROBE COMPLETE
   dropped from `_ACT`, store kernels (no `act==3u` branch), pybind docs, public Python contract,
   and A1/B1 parametrize lists. Supported acts: `{none:0, silu:1, gelu_tanh:2}`.
 - Therefore A1 parametrize = ["silu", "gelu_tanh"]; A6 expects 8 passed (2 acts x 2 bias x 2 M).
+
+## Phase A — point activation (SiLU / GELU-tanh)
+
+### Two empirical findings that shaped the implementation
+1. **Metal `precise::tanh` is low-accuracy.** With the plan's literal GELU-tanh formula
+   `0.5*x*(1+precise::tanh(z))`, the kernel diverged from `F.gelu(approximate='tanh')` by up to
+   **162 bf16 ulp** (14.7% of elements off by >1 ulp). `precise::exp`, by contrast, makes SiLU
+   bit-exact-to-1-ulp. Fix: compute GELU-tanh via the exp/sigmoid identity
+   `gelu(x) = x / (1 + exp(-2c(x + 0.044715 x^3)))`, `2c = 1.5957691216057308`. After this,
+   GELU-tanh matches torch in absolute terms (max|d| ~0.0156, near-zero epsilon ~7.6e-6 only).
+2. **The plan's `rtol=2e-3` is below bf16 precision.** One bf16 ulp is relative `2**-7 ~= 7.8e-3`.
+   The plan's rationale assumed outputs ~1.0, but this test data produces outputs up to ~15, where
+   one ulp = 0.0625. A *perfect* bf16 kernel (even SiLU, provably 1-ulp) cannot pass `rtol=2e-3`.
+   Tolerance therefore set to `atol=2e-3, rtol=8e-3` (= one bf16 ulp). This still rejects real bugs:
+   the buggy `precise::tanh` GELU had a 0.0156 absolute diff at small `ref`, which exceeds atol.
+
+### A6/A7 test run (ASFP8_INT8_EXT=1, real Metal kernel, spy guard active)
+`pytest -k "fused_activation or rejects_unknown_act or fallback_applies or bit_exact"` -> **11 passed**:
+- 8x `test_int8_linear_fused_activation_matches_reference` (silu/gelu_tanh x bias x M={1,256})
+  — spy guard (`_orig_int8_linear` -> raise) proves the REAL fused kernel ran. SiLU within 1 ulp;
+  GELU-tanh within atol/rtol.
+- `test_wrapper_fallback_applies_activation` (off-MPS fallback still applies silu).
+- `test_wrapper_rejects_unknown_act` (ValueError on typo).
+- `test_kernel_matches_original_bit_exact` (A7 regression guard, still `torch.equal` on no-act path).
+
+### A8 benchmark (dev/bench_fused_activation.py, M=4096 K=1536 N=6144)
+```
+correctness: max|d|=0.03125   (== 1 bf16 ulp; allclose atol=2e-3 rtol=8e-3 PASS)
+separate=1.035ms fused=0.824ms speedup=1.26x
+```
+Fused SiLU epilogue is 1.26x faster than (no-act kernel + torch.silu); no slowdown.

--- a/docs/superpowers/results/D-results.md
+++ b/docs/superpowers/results/D-results.md
@@ -53,3 +53,39 @@ correctness: max|d|=0.03125   (== 1 bf16 ulp; allclose atol=2e-3 rtol=8e-3 PASS)
 separate=1.035ms fused=0.824ms speedup=1.26x
 ```
 Fused SiLU epilogue is 1.26x faster than (no-act kernel + torch.silu); no slowdown.
+
+## Phase B — fused SwiGLU / GEGLU gate
+
+### Single-pass double-GEMM kernel
+`int8_matmul_swiglu[_small]` runs `w8a8_gemm_compute` twice for the SAME output tile
+(B=Wg then B=Wu) into two int32 register accumulators (64 int32 total on the large config),
+then one combined gated store. The second GEMM's tile coords are asserted to match the first
+(review MAJOR #6): `if (!ok2 || sc2 != sc || mb2 != m_base || nb2 != n_base) return;`.
+GELU-tanh uses the same exp identity as Phase A (precise::tanh is low-accuracy).
+
+### Reference subtlety (correctness contract)
+The fused gate keeps `act(gate)` in fp32 registers and multiplies by `up` in fp32, rounding to
+bf16 ONCE — that single-rounding is the entire point of fusion. The honest reference therefore
+computes torch's INDEPENDENT fp32 activation * up in fp32, rounded once. A naive reference that
+rounds `act(gate)` to bf16 first (as unfused eager does) double-rounds and diverges by up to
+half-a-gate-ulp * |up| (observed max|d|=0.25-1.0 at large `up`) — that is not a kernel bug. The
+kernel matches the fp32-fused reference to ~1 bf16 ulp; near-zero gelu epsilon * large up is
+bounded by atol=2e-3. (B1b's non-scalar-scale path genuinely routes through the per-branch
+fallback, which DOES double-round, so B1b keeps the bf16-intermediate reference.)
+
+### B6 test run (ASFP8_INT8_EXT=1, real Metal kernel, spy guard active)
+`pytest -k swiglu` -> **13 passed**:
+- 12x `test_int8_swiglu_matches_reference` (silu/gelu_tanh x bias x (M,K) in {(1,2560),(512,2560),
+  (512,2576)}). M=1 hits `int8_matmul_swiglu_small`; K=2576 exercises the remainder-K path;
+  spy guard (`_orig_int8_linear` -> raise) proves the REAL fused gate kernel ran.
+- 1x `test_int8_swiglu_nonscalar_scale_falls_back_correctly` (per-channel scales route through the
+  per-branch path, BLOCKER #3).
+Full file: **26 passed** (includes Phase A 11 + bit-exact regression + install/fallback unit tests).
+
+### B7 benchmark (dev/bench_fused_swiglu.py, M=4096 K=1536 N=6144)
+```
+correctness: max|d|=6.404e-33   (fp32-fused reference; allclose atol=2e-3 rtol=8e-3 PASS)
+unfused=2.188ms fused=1.742ms speedup=1.26x
+```
+The single-pass double-GEMM gate is 1.26x faster than (2 fused-no-act kernels + torch.silu + mul);
+no slowdown -> the experimental-fallback decision branch (Open Q #4) is NOT triggered.

--- a/docs/superpowers/results/D-results.md
+++ b/docs/superpowers/results/D-results.md
@@ -1,0 +1,24 @@
+# Issue D — empirical results
+
+## Environment
+- M5 Max, macOS 27, PyTorch 2.11.0 MPS, Metal 4.1 (MTLLanguageVersion4_1)
+- Python: /Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python (3.12.11)
+- torch.backends.mps.is_available() = True; hasattr(torch.mps,'compile_shader') = True
+
+## P0 — Metal transcendental compile probe (dev/probe_metal_transcendentals.py)
+Command: `PYTORCH_ENABLE_MPS_FALLBACK=1 python dev/probe_metal_transcendentals.py`
+
+```
+[precise.exp_tanh] COMPILE OK
+[fast.exp_tanh] COMPILE OK
+[erf.unqualified] COMPILE FAIL: SyntaxError: use of undeclared identifier 'erf'
+[erf.metal] COMPILE FAIL: SyntaxError: no member named 'erf' in namespace 'metal'
+PROBE COMPLETE
+```
+
+### Decision (per plan P0 decision rules)
+- `precise::exp` / `precise::tanh` COMPILE OK -> use `precise::` spelling in the store (default plan).
+- `erf` FAILS both unqualified and `metal::erf` -> **REMOVE `act=3` ("gelu", erf) ENTIRELY**:
+  dropped from `_ACT`, store kernels (no `act==3u` branch), pybind docs, public Python contract,
+  and A1/B1 parametrize lists. Supported acts: `{none:0, silu:1, gelu_tanh:2}`.
+- Therefore A1 parametrize = ["silu", "gelu_tanh"]; A6 expects 8 passed (2 acts x 2 bias x 2 M).

--- a/docs/superpowers/results/E-results.md
+++ b/docs/superpowers/results/E-results.md
@@ -1,0 +1,18 @@
+# Issue E — Fused RMSNorm+modulation+residual kernel — empirical results
+
+Environment: M5 Max, macOS 27, PyTorch 2.11.0, MPS available, `torch.mps.compile_shader` present.
+Python: `/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python`
+
+## Task 0 — compile_shader probes (`dev/probe_fused_norm.py`)
+
+```
+PROBE#1 grid.y=2^24 single-dim dispatch: PASS (checked [0, 8388608, 16777215] -> [0, 8388608, 16777215])
+PROBE#2 constant& scalar binding: PASS (simplification available)
+  -> design uses device-tensor meta/epsb regardless; this is informational only.
+PROBE#3 bfloat(y) cast compiles+runs: PASS (got 1.25)
+Task 0 probes done.
+```
+
+- PROBE#1 PASS: a single grid.y dimension of 2^24 dispatches correctly (z-tiling still used in production by design).
+- PROBE#2 PASS: scalar `constant&` binding works (informational; device-buffer design kept).
+- PROBE#3 PASS: `bfloat(literal)` compiles+runs => bf16 parametrization enabled in Task E.1.

--- a/docs/superpowers/results/E-results.md
+++ b/docs/superpowers/results/E-results.md
@@ -45,3 +45,19 @@ separate=198.572ms  fused=20.819ms  speedup=9.54x  fused~464 GB/s (BW estimate o
 ```
 
 Correctness + `_last_backend == "kernel"` asserted BEFORE timing. `fused < separate` holds (9.54x).
+
+TG tuning (Step 4) skipped: TG=128 kept; 9.54x already well above the ~2-4x target.
+
+## Task E.4 — registration (opt-in, never fatal)
+
+- `noop: False` with `ASFP8_FUSED_NORM` unset (install is a no-op).
+- `active: True rerouted: True` with `ASFP8_FUSED_NORM=1` (F.rms_norm rerouted to `_rms_norm`).
+- `bisection-name resolvable: fused_norm_mps` (matches `ASFP8_ENABLE_ONLY`/`ASFP8_DISABLE` filter).
+- Top-level package import + install: the package-internal `_patches.fused_norm_mps._installed`
+  is True and `F.rms_norm` is rerouted to the package module's `_rms_norm` (the active log line
+  prints). NOTE: the plan's verbatim Step-6 one-liner printed `installed via package import: False`
+  only because this worktree's directory name is the random `wf_*` slug (not
+  `ComfyUI-AppleSilicon-FP8`), which causes `from _patches import ...` to load a SECOND, distinct
+  copy of the module. Inspecting `sys.modules['<pkg>._patches.fused_norm_mps']` (the copy the
+  package actually installed) shows `_installed: True`. Wiring is correct.
+- Non-slow suite re-run after registration: 14 passed, 0 failed.

--- a/docs/superpowers/results/E-results.md
+++ b/docs/superpowers/results/E-results.md
@@ -28,6 +28,14 @@ Task 0 probes done.
   real 64-bit-indexed kernel handled the int32-offset overflow regime.
 - ruff check: All checks passed.
 
+Root-cause note (corrects an earlier overclaim): the kernel stays correct past ~2^21 rows
+PRIMARILY because it is a separate fp32-reduction implementation with correct Metal dispatch
+(z-tiled grid, fp32 simd_sum), NOT primarily because of the 64-bit ulong element offsets. The
+stock PyTorch MPS rms_norm bug manifests at ~2^21 rows (rows*D ≈ 537M at D=256, still well within
+int32 element range), so it is not an offset-overflow bug. The ulong offsets are valid
+defense-in-depth that only become load-bearing for genuinely enormous tensors (rows*D > 2^31,
+≈ >2^23 rows at D=256) — exactly what `test_overflow_rows_2pow24_kernel_path` exercises.
+
 Deviation from plan: `test_bad_optional_shape_falls_back` — the plan's verbatim body called the
 wrapper with a genuinely-malformed weight/residual then asserted `_last_backend == "fallback"`,
 but the torch fallback legitimately broadcast-raises on the invalid tensor before the assert runs.

--- a/docs/superpowers/results/E-results.md
+++ b/docs/superpowers/results/E-results.md
@@ -16,3 +16,32 @@ Task 0 probes done.
 - PROBE#1 PASS: a single grid.y dimension of 2^24 dispatches correctly (z-tiling still used in production by design).
 - PROBE#2 PASS: scalar `constant&` binding works (informational; device-buffer design kept).
 - PROBE#3 PASS: `bfloat(literal)` compiles+runs => bf16 parametrization enabled in Task E.1.
+
+## Task E.1/E.2 — correctness (kernel path proven via `_last_backend == "kernel"`)
+
+- 14 non-slow tests PASS (fp16/bf16/fp32 full path, tight bare-norm, optional-arg combos,
+  per-batch + mixed-group adaLN, multidim `F.rms_norm` reroute, forced-fallback group-equiv,
+  bad-optional-shape -> fallback, cpu fallback).
+- `test_stock_mps_broken_regime_2pow22` PASS (1<<22 rows, kernel path).
+- `test_overflow_rows_2pow24_kernel_path` PASS — rows*D = 1<<24 * 256 = 4.29e9 > 2**31;
+  `_reference` monkeypatched to raise so it CANNOT pass through the fallback => proves the
+  real 64-bit-indexed kernel handled the int32-offset overflow regime.
+- ruff check: All checks passed.
+
+Deviation from plan: `test_bad_optional_shape_falls_back` — the plan's verbatim body called the
+wrapper with a genuinely-malformed weight/residual then asserted `_last_backend == "fallback"`,
+but the torch fallback legitimately broadcast-raises on the invalid tensor before the assert runs.
+Verified empirically the kernel is NOT dispatched (flag set to "fallback" before the raise), so the
+test now wraps each malformed call in `pytest.raises(RuntimeError)` and asserts
+`_last_backend == "fallback"`. No kernel correctness contract loosened.
+
+## Task E.3 — benchmark (`dev/bench_fused_norm.py`, rows=1<<20, dim=1536, fp16)
+
+```
+correctness OK (max abs diff 0.0625, backend=kernel)
+first-call (compile_shader) latency: 517.3 ms
+rows=1048576 dim=1536 dtype=torch.float16
+separate=198.572ms  fused=20.819ms  speedup=9.54x  fused~464 GB/s (BW estimate only; no measured roofline)
+```
+
+Correctness + `_last_backend == "kernel"` asserted BEFORE timing. `fused < separate` holds (9.54x).

--- a/docs/superpowers/results/F-results.md
+++ b/docs/superpowers/results/F-results.md
@@ -1,0 +1,104 @@
+# Issue F — results: route fp8 Linear through native `fp8_matmul2d_nt` (half-act × fp8-weight)
+
+Branch: `impl/F-fp8-native-matmul` (off `main` @ `c0ff7cd`).
+Machine: M5 Max, macOS 27, PyTorch 2.11 MPS, repo venv.
+Status: **AUTONOMOUS portion GREEN. Feature ships DEFAULT OFF (`ASFP8_FP8_NATIVE` opt-in).
+Real-model gate (Task -1) and end-to-end gate (Task 6) are HUMAN-REQUIRED and still OPEN.**
+
+---
+
+## (A) Autonomous tasks — GREEN on this M5
+
+### Task 1 — loader build-gate
+`_patches/fp8_ext/loader.py` now builds when **`ASFP8_FP8_EXT=1` OR `ASFP8_FP8_NATIVE=1`**.
+Verified: `ASFP8_FP8_NATIVE=1` alone builds the Metal lib and exports `fp8_matmul2d_nt`.
+Reset-state tests pass.
+
+### Task 0 — SYNTHETIC numeric probe (`tests/probe_fp8_native_matmul.py`)
+Native `fp8_matmul2d_nt(half_act, fp8_e4m3_weight)` vs decoded-**fp32** ground truth, on
+Flux-2-Klein-class shapes. Gate: every shape `rel_native < 2e-2` AND `rel_native <= 2*rel_lut + eps`.
+
+| M | K | N | rel_native | rel_lut | mean_abs | p99.9_rel | act\|max\| | within_2x_lut |
+|---|---|---|---|---|---|---|---|---|
+| 4096 | 4096 | 4096 | 7.45e-07 | 2.04e-03 | 3.90e-07 | 2.33e-05 | 1.586 | ✅ |
+| 4096 | 4096 | 16384 | 9.25e-07 | 1.90e-03 | 3.91e-07 | 2.22e-05 | 1.547 | ✅ |
+| 4096 | 16384 | 4096 | 2.27e-06 | 2.07e-03 | 3.03e-06 | 9.29e-05 | 1.672 | ✅ |
+
+**WORST rel_native = 2.27e-06.** PROBE PASS. The native half-act path is ~1000× **more**
+accurate than the LUT→bf16 path it replaces (fp32 accumulate + half mantissa ≫ bf16), confirming
+the kernel math is correct. (Synthetic only — does NOT establish real activation range; that is Task -1.)
+
+### Tasks 2–4 — wrapper + unit + REAL spy tests (`tests/test_fp8_linear_kernel.py`)
+Wrapper module `_patches/fp8_linear_kernel_mps.py` (patch #20): shape/rank/dtype/eligibility
+guards, scalar **and** per-channel `[N]` scale support, `_self_check()` ordered AFTER all
+eligibility gates (never on an ineligible layer), never-fatal fallback.
+
+pytest counts:
+- **Flag OFF (`pytest tests/`):** `61 passed, 7 skipped` (kernel tests skip without the flag).
+- **Flag ON (`ASFP8_FP8_NATIVE=1 pytest tests/`):** `64 passed, 4 skipped` — the 3 native/spy tests run.
+- `tests/test_fp8_linear_kernel.py` alone, flag ON: **9 passed**.
+
+Spy/parity highlights (flag ON, real Metal kernel):
+- `test_native_matches_ground_truth` — native vs all-MPS fp32 ref, rel < 2e-2, output non-zero.
+- `test_native_per_channel_scale` — `[N]` scale branch exercised, rel < 2e-2.
+- `test_wrapper_dispatches_native_not_fallback` — **canonical SPY**: real fp8 `QuantizedTensor`
+  weight (`TensorCoreFP8Layout`, built on CPU then moved to MPS), `_fp8_linear_kernel` replaced by
+  a sentinel and the captured `orig_forward` set to **raise**. The wrapper returns the sentinel →
+  proves `Linear.forward` dispatched the NATIVE branch, not the fallback (a fallback would ERROR).
+- `test_self_check_not_run_on_ineligible` — BLOCKER-2 regression guard: self-check never runs on
+  an ineligible layer.
+
+> Note: this comfy_kitchen registers the e4m3 fp8 layout as **`TensorCoreFP8Layout`** (the eligibility
+> `str(...).startswith("TensorCoreFP8")` accepts it). Direct `QuantizedTensor.from_float(..., 'TensorCoreFP8Layout')`
+> on MPS raises (MPS can't cast bf16→fp8), so fp8 QTs are built on CPU then `.to('mps')` — which yields
+> MPS-resident `float8_e4m3fn` qdata. The spy fixture uses that path.
+
+### Task 5 — benchmark (`tests/bench_fp8_native_matmul.py`, verify-before-timing)
+Numerical match asserted (`rel < 2e-2`) **before** any timing. Native timing includes the per-call
+bf16→half cast; LUT timing reported with the per-call `decode_fp8` (the real per-step cost).
+
+| M | K | N | native_kernel | native_e2e | lut_gemm | lut_e2e(+decode) | speedup_e2e | rel |
+|---|---|---|---|---|---|---|---|---|
+| 4096 | 4096 | 4096 | 2.621 ms | 2.766 ms | 2.208 ms | 2.982 ms | **1.08×** | 8.30e-07 |
+| 4096 | 4096 | 16384 | 10.352 ms | 10.488 ms | 8.467 ms | 11.695 ms | **1.12×** | 8.30e-07 |
+| 4096 | 16384 | 4096 | 9.633 ms | 10.469 ms | 10.261 ms | 12.927 ms | **1.23×** | 1.98e-06 |
+
+`native_e2e` beats `lut_e2e` at every shape (1.08–1.23×) — the honest microbench win. The
+hypothesized ~3.6× is an **end-to-end per-step** claim (weight DRAM traffic halved, decode kernel
+removed across a 9B model) that **only Task 6 can confirm**; this microbench does not assert it.
+
+### Task 5.1 / 5.2 — registration + regression gate
+Patch #20 registered in `__init__.py` (after `int8_linear_kernel_mps`; fp8 check runs first, hands
+back to int8 on non-fp8 weights) and `_patches/__init__.py` `__all__`/docs tidied. Flag-OFF import
+smoke: `installed= False` (clean no-op). Full suite green both flag states (above).
+
+---
+
+## (B) HUMAN-REQUIRED gates — STILL OPEN (feature stays OFF until both pass)
+
+### Task -1 (HARD PRE-WIRE GATE) — real Flux-2-Klein seam/scale/range probe
+**NOT RUN** (needs Flux-2-Klein-9B loaded in ComfyUI; cannot be done in the isolated worktree).
+Runnable probe script written for the human: **`dev/probe_F_flux_seam.py`** — call
+`probe(model, run_one_step=<one sampler step>)` after launching ComfyUI with
+`ASFP8_FP8_NATIVE=1 ASFP8_PROFILE=1` and a Flux-2-Klein fp8 workflow.
+
+The human must confirm **all three** before patch #20 can be enabled for real renders:
+1. **Seam fires?** — the eligible fp8 Linear's MRO includes `comfy.ops…mixed_precision_ops…Linear`,
+   and its `FORWARD` logs **before** `torch._scaled_mm`. (If it's `fp8_ops.Linear` → re-point
+   `install()`. If `manual_cast.Linear` → out of scope. If forward never precedes scaled_mm → seam
+   wrong, stop.)
+2. **Scale shape?** — scalar `()`/`(1,)` vs per-channel `(N,)`. Wrapper already supports both;
+   the probe just records which is real (so a scalar-only assumption can't silently NO-OP every layer).
+3. **Activation range?** — per-layer `input.float().abs().amax()` vs fp16 max **65504**. If all
+   ≪ 65504, leave the range guard off and document the bound. If any ≳ 65504, enable
+   `ASFP8_FP8_NATIVE_RANGE_GUARD=1` and record outlier layers.
+
+### Task 6 — real Flux-2-Klein end-to-end validation
+**NOT RUN** (needs a real render). After Task -1 confirms the seam: A/B the `linear` profiler
+bucket (flag off vs on), confirm visual correctness (no NaN/black/garbage), and do the 3-way
+real-layer accuracy comparison (current quantized vs native half-act vs fp32 ground truth) to
+verify native is *closer to* fp32 than the current path. Record results here, then enable.
+
+> **Default state:** `ASFP8_FP8_NATIVE` is **OFF**. A wrong autonomous guess is safe (never-fatal
+> fallback) but is NOT validated. Enable only after Task -1 (seam/scale/range) and Task 6 (win +
+> no quality regression) sign-off.

--- a/docs/superpowers/results/G2-results.md
+++ b/docs/superpowers/results/G2-results.md
@@ -1,0 +1,109 @@
+# Issue G2 — M5 matmul2d operand dtype capability probe — RESULTS
+
+Branch: `impl/G2`
+Machine: M5 Max / macOS 27 (Darwin 27.0.0) / PyTorch 2.11.0 / Metal 4.1 (`MTLLanguageVersion4_1`)
+Python: `/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv/bin/python` (3.12.11), `torch.backends.mps.is_available() == True`
+Active SDK: `/Applications/Xcode-beta.app/.../MacOSX.sdk` (Metal toolchain MetalToolchain-v27.1.5194.15)
+GPUCompiler: Versions/32023
+Run date: 2026-06-30
+
+> Note: per the orchestrator hard rules these results are recorded HERE, not in
+> `INVESTIGATION_FACTS.md` (avoids cross-worktree merge conflicts). The probe scripts
+> still target `INVESTIGATION_FACTS.md` per the plan, but that file does not exist in
+> this worktree, so the scripts' existence-guard simply prints a "not appended" warning
+> and writes nothing — by design.
+
+## Prerequisites (Task 1)
+
+- `xcrun --find metal` → `/var/run/com.apple.security.cryptexd/mnt/.../Metal.xctoolchain/usr/bin/metal` OK
+- MPP header found under the ACTIVE SDK:
+  `.../MacOSX.sdk/System/Library/Frameworks/MetalPerformancePrimitives.framework/Versions/A/Headers/MetalPerformancePrimitives.h`
+- `ninja` available in the ComfyUI venv (`.venv/bin`)
+- MPS available: True
+
+## Task 0 — compile-only API facts (PASS = type/instantiation available under Metal 4.1)
+
+| fact | result |
+|------|--------|
+| matmul2d<half> + <half,half,float> accum compiles | PASS |
+| matmul2d<bfloat> + <bfloat,bfloat,float> accum compiles | PASS |
+| matmul2d<float> + <float,float,float> accum compiles | PASS |
+| matmul2d<signed char> + int accum compiles | PASS |
+| fp8 e4m3 type available under Metal 4.1 | PASS |
+| fp8 e5m2 type available under Metal 4.1 | PASS |
+
+All six Task-0 facts PASS. `signed_char` control compiles (mandatory gate). Both fp8
+macros (`__HAVE_METAL_FP8_E4M3_FORMAT_TYPE__`, `__HAVE_METAL_FP8_E5M2_FORMAT_TYPE__`)
+are defined on this SDK → no dtype is expected to surface COMPILE_SKIP.
+
+## Task 3 — one template fix required (compile failure, NOT a capability gap)
+
+The plan's fp8 kernel template cast the buffer pointer to `(device fp8_t*)`. The MPP
+`tensor<device fp8_t, …, tensor_inline>` constructor's `data_handle_type` is
+`device unsigned char*` (fp8 is addressed as bytes), so the cast was rejected:
+
+```
+error: no matching constructor ... no known conversion from 'device fp8_t *'
+       to '...data_handle_type' (aka 'device unsigned char *') for 1st argument
+```
+
+Fix: pass the raw `device uchar*` (`rawA+ulong(m0)*K`) directly, mirroring the
+production kernel `gemm_fp8_nt` (`_patches/fp8_ext/fp8_matmul2d.mm:96`). After the fix
+both fp8 dtypes compile, run, and match exactly. This was a generated-source bug, not a
+hardware/SDK limitation — Task 0 had already proven both fp8 types are available.
+
+## S-G2 — capability matrix (the keystone output for B/D/E)
+
+NT layout (A[M,K] @ Bᵀ, B[N,K]), BM=BN=64, NSG=4, M=N=64, K=128.
+Reference = torch fp32 matmul of DECODED stored operands. Each dtype compiled in its
+OWN MTLLibrary. Latency is INFORMATIONAL ONLY (launch-dominated; not a tensor-unit perf
+signal). SPY: every PASS row had C ≠ all-zero AND matched the reference — a no-op/fallback
+would leave C all-zero and fail.
+
+| dtype        | compile | run | max_err  | verdict | gate (issue B / FP8 only) |
+|--------------|---------|-----|----------|---------|---------------------------|
+| signed_char  | OK      | OK  | 0 (exact int32) | PASS | control / spy |
+| half         | OK      | OK  | 1.34e-05 | PASS | issue B conv GEMM can use fp16 operands on tensor units |
+| bfloat       | OK      | OK  | 7.63e-06 | PASS | issue B conv GEMM can use bf16 operands on tensor units |
+| float        | OK      | OK  | 0        | PASS | fp32 cooperative path legal (perf NOT proven here) |
+| fp8_e4m3     | OK      | OK  | 0        | PASS | FP8 e4m3 operand path viable (regresses existing fp8fp8_matmul2d_nt); NOT W4A8 |
+| fp8_e5m2     | OK      | OK  | 0        | PASS | FP8 e5m2 operand path viable (informational); NOT W4A8 |
+
+### Verdict for downstream issues
+
+- **half PASS and bfloat PASS** → issue B conv GEMM may use fp16 OR bf16 operands on the
+  M5 tensor units (cooperative `matmul2d` with a float accumulator). Both are bit-correct
+  vs the decoded-operand reference (max_err well under tolerance: half ≤ 0.5, bf16 ≤ 1.0).
+- **float PASS** → fp32 cooperative path is LEGAL on this M5/Metal 4.1. This proves
+  legality ONLY, not tensor-unit performance — a separate large-shape benchmark is needed.
+- **fp8_e4m3 PASS** → confirms/regresses the existing `fp8fp8_matmul2d_nt` path; FP8 e4m3
+  operands route through `matmul2d` correctly.
+- **fp8_e5m2 PASS** → e5m2 is available AND usable as a matmul2d operand under Metal 4.1
+  independently of e4m3 (its own macro is defined; the kernel compiles, runs, and matches).
+  Informational for now.
+- **W4A8 is NOT decided here.** Sub-byte int4b/uint4b/int2b operands are out of scope and
+  require a separate packing + correctness probe.
+
+## Tests (Task 4)
+
+`pytest tests/test_probe_matmul2d_dtypes.py -v` → **8 passed in 5.80s**
+
+- `test_signed_char_control_runs_exact` PASSED (control + spy: int8 kernel runs, matches
+  int32 reference exactly, C ≠ all-zero)
+- `test_every_candidate_produces_structured_row[*]` PASSED for all 6 candidates
+- `test_table_generation_covers_all_candidates` PASSED (one row per candidate; "NOT W4A8" present)
+
+No skips fired (MPS + xcrun both present). No tolerances were widened; all PASS rows are
+genuine real-kernel matches.
+
+## Caching (Task 5.2)
+
+First build ~30 s (JIT compile of the ObjC++ host). Second run: ~6 s total (host extension
+cached by `cpp_extension.load`; per-dtype Metal libraries recompiled each run, sub-ms each).
+
+## Tooling note
+
+`ruff` (the repo's documented linter) is not installed in the ComfyUI venv used here, nor
+is `pyflakes`. All three new files parse cleanly via `ast.parse`. The one unused local
+(`fp8_probe` lambda in `probe_matmul2d_task0.py`) is verbatim from the authoritative plan
+and was left as-is to avoid deviating from it.

--- a/docs/superpowers/results/ROPE-retarget-results.md
+++ b/docs/superpowers/results/ROPE-retarget-results.md
@@ -1,0 +1,103 @@
+# ROPE-retarget (patch #21b): fused RoPE retargeted onto the REAL comfy functions
+
+**Branch:** `impl/ROPE-retarget` (off `integration/asfp8-accel`)
+**File:** `_patches/rope_fast_mps.py` (extends patch #21)
+**Tests:** `tests/test_rope_fast_comfy.py` (new), `tests/test_rope_fast.py` (unchanged, still green)
+**Gate:** opt-in `ASFP8_ROPE_FAST=1`, default OFF, guarded, never fatal.
+
+## Problem
+
+Patch #21 only wrapped `comfy_kitchen.backends.eager.apply_rope{,1,_split_half,_split_half1}`.
+A live probe (2026-07-01) showed the real models bypass that path almost entirely — they call
+comfy's OWN rope functions:
+
+| model | function | fires |
+|---|---|---|
+| Flux-2-Klein DiT | `comfy.ldm.flux.math.apply_rope` | every layer |
+| Ideogram-4 DiT | `comfy.ldm.ideogram4.model.apply_rope` | every layer |
+| Ideogram-4 TE | `comfy.text_encoders.llama.apply_rope` | every layer |
+
+`comfy.ldm.ideogram4.model.apply_rope` **is** `comfy.text_encoders.llama.apply_rope` (same object,
+imported by alias — verified `is` identity). `comfy_kitchen.eager` fired at most once per model, so
+patch #21 was effectively inert on both.
+
+## Conventions (verified against source)
+
+Two **different** conventions — they are not interchangeable:
+
+- **`comfy.ldm.flux.math.apply_rope` — interleaved 2×2.** `freqs_cis` is a single fp32 tensor of
+  shape `(...,halfD,2,2)` (probe: `(1,1,8704,64,2,2)`). `_apply_rope1` reshapes `x` to
+  `(...,halfD,1,2)` (interleaved pairs `2p, 2p+1`) and applies the per-pair 2×2 matrix. This is the
+  **identical** convention to comfy_kitchen's `apply_rope`, so it maps onto the existing **split=0**
+  kernel with no new math. (Note: stock `flux.math.apply_rope` only forwards to
+  `comfy.quant_ops.ck.apply_rope` when not training — we intercept *above* that delegation.)
+
+- **`comfy.text_encoders.llama.apply_rope` — half-split rotate_half.** `freqs_cis` is a **3-tuple**
+  `(cos, sin, nsin)` (not a tensor): `cos` full-dim `D`, `sin`/`nsin` half-dim `halfD`
+  (`nsin = -sin`). The op is `q*cos` then `addcmul_` of the two halves:
+  `out[p] = cos[p]·x[p] + nsin[p]·x[p+halfD]`, `out[p+halfD] = sin[p]·x[p] + cos[p+halfD]·x[p+halfD]`.
+  This is expressible on the **split=1** kernel by building a per-pair 2×2 table
+  `[cos[:halfD], nsin, sin, cos[halfD:]]` → `[f00,f01,f10,f11]`. Bit-faithful (the real op also does
+  fp32 multiply/addcmul then casts back to input dtype).
+
+## What was done
+
+1. `install()` now also calls `_install_comfy()`: captures the real `flux.apply_rope`,
+   `flux.apply_rope1`, `llama.apply_rope` and replaces every reference to them **by object identity**
+   (mirroring `mps_profile._try_wrap_rope`) — so the ideogram4 alias is rerouted automatically.
+   Existing comfy_kitchen targets are untouched. Each comfy target's fallback is the **captured real
+   comfy function** (not eager), so any fallback is bit-identical to stock comfy.
+2. New table builder `_prep_table_llama` (tuple → fp32 `[L,halfD,4]`), new wrappers
+   `_flux_apply_rope{,1}_fused` and `_llama_apply_rope_fused`, sharing a refactored `_launch`.
+3. Safety: rank-4 MPS only, supported dtype, even D, fp32 table; llama requires batch/head broadcast
+   (cos rows == L) and `Lq == Lk == L`. Anything else → fall back to the real comfy fn (never wrong).
+
+## Retargeted functions
+
+| function | convention | kernel path | matched? | tolerance |
+|---|---|---|---|---|
+| `comfy.ldm.flux.math.apply_rope` | interleaved 2×2 | split=0 | ✅ | bf16 atol 2e-2 / fp32 2e-5 |
+| `comfy.ldm.flux.math.apply_rope1` | interleaved 2×2 | split=0 | ✅ | bf16 atol 2e-2 |
+| `comfy.text_encoders.llama.apply_rope` | half-split rotate_half (cos,sin,nsin) | split=1 + built table | ✅ | fp32 2e-5 / fp16 3e-3 / bf16 2e-2 |
+| `comfy.ldm.ideogram4.model.apply_rope` | (alias of llama) | split=1 | ✅ rerouted by identity | bf16 2e-2 |
+
+**Fallbacks (correct-by-construction, tested):** llama with a true batch>1 freqs table (cos rows =
+B·L ≠ L) and flux with non-broadcast (real B/H) leading table dims — both fall back to the real
+comfy fn and match it. No function required a permanent fall-back due to an unmatchable convention.
+
+## Correctness (oracle = captured REAL comfy fn; kernel proven via poison)
+
+Each kernel test computes the oracle from the real comfy function captured before patching, asserts
+allclose, and poisons the captured original so any silent fallback **raises** — proving the fused
+kernel actually ran. Observed max |fused − real|:
+
+- FLUX bf16: 1.56e-2 (≈1 bf16 ulp at magnitude ~5); fp32: 9.5e-7.
+- LLAMA bf16: 3.9e-3 – 1.56e-2; fp32: 4.8e-7.
+
+## Benchmark (verify-before-timing; kernel asserted to fire each row)
+
+| case | dtype | real ms/call | fused ms/call | speedup | maxdiff |
+|---|---|---|---|---|---|
+| FLUX L=8704 H=32 D=128 (probe) | bf16 | 6.852 | 1.459 | **4.70×** | 1.56e-2 |
+| FLUX L=4096 H=32 D=128 | bf16 | 3.312 | 0.692 | **4.79×** | 1.56e-2 |
+| FLUX L=8704 H=32 D=128 | fp32 | 5.739 | 2.213 | 2.59× | 9.5e-7 |
+| LLAMA seq=4096 H=16 hd=128 | bf16 | 1.008 | 0.392 | **2.57×** | 1.56e-2 |
+| LLAMA seq=256 H=16 hd=128 | bf16 | 0.200 | 0.058 | 3.45× | 3.9e-3 |
+| LLAMA seq=4096 H=16 hd=128 | fp32 | 0.952 | 0.571 | 1.67× | 4.8e-7 |
+
+## Test counts
+
+- `tests/test_rope_fast_comfy.py` (new): **14 passed** (flux pair/single + poison, llama param
+  dtype×shape + poison, ideogram4 alias reroute, two fallback regimes).
+- `tests/test_rope_fast.py` (patch #21, unchanged): **27 passed**.
+- Full suite: **186 passed, 40 skipped** — no regressions.
+
+## Environment note
+
+The repo venv (`/Volumes/IMPERIAL SPACE/AI/ComfyUI/.venv`) does not contain the `comfy` package;
+ComfyUI-desktop keeps the code tree at `/Users/pawelma/ComfyUI-Installs/ComfyUI/ComfyUI`
+(`basePath` in `~/Library/Application Support/ComfyUI/config.json`). Tests add that path (overridable
+via `ASFP8_COMFY_PATH`) and `importorskip` comfy, so they skip cleanly where comfy is absent. The
+comfy import pulls in `comfy.model_management`, whose `psutil.virtual_memory()` call fails under the
+build sandbox — runs need the sandbox-disabled path (the kernel/correctness logic itself is
+unaffected).

--- a/icon.svg
+++ b/icon.svg
@@ -1,37 +1,64 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" role="img" aria-label="AppleSilicon FP8">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#1d1f27"/>
-      <stop offset="1" stop-color="#0b0c10"/>
-    </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#7aa2ff"/>
-      <stop offset="1" stop-color="#b98cff"/>
-    </linearGradient>
-  </defs>
-
-  <rect width="400" height="400" rx="72" fill="url(#bg)"/>
-
-  <!-- chip pins -->
-  <g fill="url(#accent)" opacity="0.85">
-    <rect x="120" y="92"  width="14" height="26" rx="4"/>
-    <rect x="193" y="92"  width="14" height="26" rx="4"/>
-    <rect x="266" y="92"  width="14" height="26" rx="4"/>
-    <rect x="120" y="282" width="14" height="26" rx="4"/>
-    <rect x="193" y="282" width="14" height="26" rx="4"/>
-    <rect x="266" y="282" width="14" height="26" rx="4"/>
-    <rect x="92"  y="120" width="26" height="14" rx="4"/>
-    <rect x="92"  y="193" width="26" height="14" rx="4"/>
-    <rect x="92"  y="266" width="26" height="14" rx="4"/>
-    <rect x="282" y="120" width="26" height="14" rx="4"/>
-    <rect x="282" y="193" width="26" height="14" rx="4"/>
-    <rect x="282" y="266" width="26" height="14" rx="4"/>
-  </g>
-
-  <!-- chip die -->
-  <rect x="118" y="118" width="164" height="164" rx="30" fill="none" stroke="url(#accent)" stroke-width="6"/>
-
-  <!-- FP8 wordmark -->
-  <text x="200" y="196" text-anchor="middle" font-family="Menlo, monospace" font-size="72" font-weight="700" fill="#f4f5fb">FP8</text>
-  <text x="200" y="244" text-anchor="middle" font-family="Menlo, monospace" font-size="30" font-weight="600" fill="url(#accent)">INT8 · MPS</text>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 400 400" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <path d="M400,72L400,328C400,367.738 367.738,400 328,400L72,400C32.262,400 0,367.738 0,328L0,72C0,32.262 32.262,0 72,0L328,0C367.738,0 400,32.262 400,72Z" style="fill:url(#_Linear1);"/>
+    <g opacity="0.85">
+        <g transform="matrix(1,0,0,1,21,0)">
+            <path d="M134,96L134,114C134,116.208 132.208,118 130,118L124,118C121.792,118 120,116.208 120,114L120,96C120,93.792 121.792,92 124,92L130,92C132.208,92 134,93.792 134,96Z" style="fill:url(#_Linear2);"/>
+        </g>
+        <path d="M207,96L207,114C207,116.208 205.208,118 203,118L197,118C194.792,118 193,116.208 193,114L193,96C193,93.792 194.792,92 197,92L203,92C205.208,92 207,93.792 207,96Z" style="fill:url(#_Linear3);"/>
+        <g transform="matrix(1,0,0,1,-20,0)">
+            <path d="M280,96L280,114C280,116.208 278.208,118 276,118L270,118C267.792,118 266,116.208 266,114L266,96C266,93.792 267.792,92 270,92L276,92C278.208,92 280,93.792 280,96Z" style="fill:url(#_Linear4);"/>
+        </g>
+        <g transform="matrix(1,0,0,1,20,-2)">
+            <path d="M134,286L134,304C134,306.208 132.208,308 130,308L124,308C121.792,308 120,306.208 120,304L120,286C120,283.792 121.792,282 124,282L130,282C132.208,282 134,283.792 134,286Z" style="fill:url(#_Linear5);"/>
+        </g>
+        <path d="M207,286L207,304C207,306.208 205.208,308 203,308L197,308C194.792,308 193,306.208 193,304L193,286C193,283.792 194.792,282 197,282L203,282C205.208,282 207,283.792 207,286Z" style="fill:url(#_Linear6);"/>
+        <g transform="matrix(1,0,0,1,-19,-2)">
+            <path d="M280,286L280,304C280,306.208 278.208,308 276,308L270,308C267.792,308 266,306.208 266,304L266,286C266,283.792 267.792,282 270,282L276,282C278.208,282 280,283.792 280,286Z" style="fill:url(#_Linear7);"/>
+        </g>
+        <g transform="matrix(1,0,0,1,0,24)">
+            <path d="M118,124L118,130C118,132.208 116.208,134 114,134L96,134C93.792,134 92,132.208 92,130L92,124C92,121.792 93.792,120 96,120L114,120C116.208,120 118,121.792 118,124Z" style="fill:url(#_Linear8);"/>
+        </g>
+        <path d="M118,197L118,203C118,205.208 116.208,207 114,207L96,207C93.792,207 92,205.208 92,203L92,197C92,194.792 93.792,193 96,193L114,193C116.208,193 118,194.792 118,197Z" style="fill:url(#_Linear9);"/>
+        <g transform="matrix(1,0,0,1,1,-25)">
+            <path d="M118,270L118,276C118,278.208 116.208,280 114,280L96,280C93.792,280 92,278.208 92,276L92,270C92,267.792 93.792,266 96,266L114,266C116.208,266 118,267.792 118,270Z" style="fill:url(#_Linear10);"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1,22)">
+            <path d="M308,124L308,130C308,132.208 306.208,134 304,134L286,134C283.792,134 282,132.208 282,130L282,124C282,121.792 283.792,120 286,120L304,120C306.208,120 308,121.792 308,124Z" style="fill:url(#_Linear11);"/>
+        </g>
+        <path d="M308,197L308,203C308,205.208 306.208,207 304,207L286,207C283.792,207 282,205.208 282,203L282,197C282,194.792 283.792,193 286,193L304,193C306.208,193 308,194.792 308,197Z" style="fill:url(#_Linear12);"/>
+        <g transform="matrix(1,0,0,1,-1,-20)">
+            <path d="M308,270L308,276C308,278.208 306.208,280 304,280L286,280C283.792,280 282,278.208 282,276L282,270C282,267.792 283.792,266 286,266L304,266C306.208,266 308,267.792 308,270Z" style="fill:url(#_Linear13);"/>
+        </g>
+    </g>
+    <path d="M282,148L282,252C282,268.557 268.557,282 252,282L148,282C131.443,282 118,268.557 118,252L118,148C118,131.443 131.443,118 148,118L252,118C268.557,118 282,131.443 282,148Z" style="fill:none;stroke:url(#_Linear14);stroke-width:6px;"/>
+    <g transform="matrix(1,0,0,1,200,196)">
+        <text x="-65.021px" y="0px" style="font-family:'Menlo-Bold', 'Menlo', monospace;font-weight:700;font-size:72px;fill:rgb(244,245,251);">FP8</text>
+    </g>
+    <g transform="matrix(0.586824,0,0,0.586824,201.063092,65.814703)">
+        <g transform="matrix(72,0,0,72,281.759766,0)">
+        </g>
+        <text x="-281.76px" y="0px" style="font-family:'Menlo-Bold', 'Menlo', monospace;font-weight:700;font-size:72px;fill:rgb(244,245,251);">Apple Silicon</text>
+    </g>
+    <g transform="matrix(0.852519,0,0,0.852519,199.052929,240.716244)">
+        <text x="-90.308px" y="0px" style="font-family:'Menlo-Bold', 'Menlo', monospace;font-weight:700;font-size:30px;fill:url(#_Linear15);">INT8 · MPS</text>
+    </g>
+    <defs>
+        <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(400,400,-400,400,0,0)"><stop offset="0" style="stop-color:rgb(29,31,39);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(11,12,16);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,120,92)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear3" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,193,92)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear4" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,266,92)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear5" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,120,282)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear6" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,193,282)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear7" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(14,26,-26,14,266,282)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear8" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,92,120)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear9" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,92,193)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear10" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,92,266)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear11" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,282,120)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear12" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,282,193)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear13" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(26,14,-14,26,282,266)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear14" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(164,164,-164,164,118,118)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear15" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(180.615234,22.792969,-22.792969,180.615234,-90.307617,-22.792969)"><stop offset="0" style="stop-color:rgb(122,162,255);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(185,140,255);stop-opacity:1"/></linearGradient>
+    </defs>
 </svg>

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" role="img" aria-label="AppleSilicon FP8">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1d1f27"/>
+      <stop offset="1" stop-color="#0b0c10"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7aa2ff"/>
+      <stop offset="1" stop-color="#b98cff"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="400" height="400" rx="72" fill="url(#bg)"/>
+
+  <!-- chip pins -->
+  <g fill="url(#accent)" opacity="0.85">
+    <rect x="120" y="92"  width="14" height="26" rx="4"/>
+    <rect x="193" y="92"  width="14" height="26" rx="4"/>
+    <rect x="266" y="92"  width="14" height="26" rx="4"/>
+    <rect x="120" y="282" width="14" height="26" rx="4"/>
+    <rect x="193" y="282" width="14" height="26" rx="4"/>
+    <rect x="266" y="282" width="14" height="26" rx="4"/>
+    <rect x="92"  y="120" width="26" height="14" rx="4"/>
+    <rect x="92"  y="193" width="26" height="14" rx="4"/>
+    <rect x="92"  y="266" width="26" height="14" rx="4"/>
+    <rect x="282" y="120" width="26" height="14" rx="4"/>
+    <rect x="282" y="193" width="26" height="14" rx="4"/>
+    <rect x="282" y="266" width="26" height="14" rx="4"/>
+  </g>
+
+  <!-- chip die -->
+  <rect x="118" y="118" width="164" height="164" rx="30" fill="none" stroke="url(#accent)" stroke-width="6"/>
+
+  <!-- FP8 wordmark -->
+  <text x="200" y="196" text-anchor="middle" font-family="Menlo, monospace" font-size="72" font-weight="700" fill="#f4f5fb">FP8</text>
+  <text x="200" y="244" text-anchor="middle" font-family="Menlo, monospace" font-size="30" font-weight="600" fill="url(#accent)">INT8 · MPS</text>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-applesilicon-fp8"
 description = "Run FP8 and INT8 quantized models (FLUX, SD3.5, Ideogram 4, Krea2) on Apple Silicon / MPS — compatibility fixes plus bit-exact fp8/int8 Metal matmul kernels, plus a psutil fix for recent macOS betas."
-version = "1.1.0"
+version = "1.2.0"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"
@@ -11,9 +11,11 @@ Repository = "https://github.com/pawel-mazurkiewicz/ComfyUI-AppleSilicon-FP8"
 
 [project.optional-dependencies]
 mlx = ["mlx-vlm"]
-# Build toolchain for the opt-in Metal matmul kernels (fp8-native patch #3 via
-# ASFP8_FP8_EXT=1, int8 W8A8 patch #17 via ASFP8_INT8_EXT=1). torch's
-# cpp_extension needs the ninja build tool; install with the [kernels] extra.
+# Build toolchain for the ObjC++ Metal matmul kernels (fp8-native #3/#20, int8 W8A8
+# #17). These are DEFAULT ON but gated on M5/Metal-4.1 AND the presence of `ninja`
+# (torch's cpp_extension needs it to build). Without this extra the kernels simply
+# stay inert — nothing breaks — so install [kernels] to unlock them on an M5:
+#   pip install "comfyui-applesilicon-fp8[kernels]"
 kernels = ["ninja"]
 
 [tool.pytest.ini_options]
@@ -24,4 +26,4 @@ addopts = "--import-mode=importlib"
 [tool.comfy]
 PublisherId = "pawel-mazurkiewicz"
 DisplayName = "ComfyUI-AppleSilicon-FP8"
-Icon = ""
+Icon = "icon.svg"

--- a/tests/bench_fp8_native_matmul.py
+++ b/tests/bench_fp8_native_matmul.py
@@ -1,0 +1,49 @@
+"""Issue-F bench: native fp8 NT vs LUT->bf16, on Flux shapes. Verifies before timing.
+Reports: native(kernel-only), native(end-to-end incl bf16->half cast),
+         lut(GEMM-only, weight pre-decoded), lut(end-to-end incl per-call decode_fp8)."""
+import os, sys, time, torch
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ["ASFP8_FP8_NATIVE"] = "1"
+from _patches._common import decode_fp8
+from _patches.fp8_ext import loader
+
+mod = loader.module(); assert mod is not None; mod.warmup()
+dev = "mps"
+SHAPES = [(4096, 4096, 4096), (4096, 4096, 16384), (4096, 16384, 4096)]
+ITERS = 30
+
+def sync(): torch.mps.synchronize()
+def timed(fn):
+    for _ in range(5): fn()
+    sync(); t0 = time.perf_counter()
+    for _ in range(ITERS): fn()
+    sync(); return (time.perf_counter() - t0) / ITERS * 1e3
+
+for (M, K, N) in SHAPES:
+    g = torch.Generator().manual_seed(1)
+    act = (torch.randn(M, K, generator=g) * 0.3).to(torch.bfloat16).to(dev)
+    w   = (torch.randn(N, K, generator=g) * 0.3).to(torch.float8_e4m3fn).to(dev)
+    w_u8_pre = w.contiguous().view(torch.uint8)
+    a_half_pre = act.to(torch.float16).contiguous()
+
+    native_kernel_only = lambda: mod.fp8_matmul2d_nt(a_half_pre, w_u8_pre, N)
+    # end-to-end: cast happens every call, as in _fp8_linear_kernel
+    native_e2e = lambda: mod.fp8_matmul2d_nt(act.to(torch.float16).contiguous(), w_u8_pre, N)
+    w_bf16_pre = decode_fp8(w, torch.bfloat16)
+    lut_gemm_only = lambda: (act @ w_bf16_pre.t())
+    lut_e2e = lambda: (act @ decode_fp8(w, torch.bfloat16).t())  # decode every call (real model)
+
+    # VERIFY FIRST (gate the whole bench).
+    gt = (act.float() @ decode_fp8(w, torch.float32).t())
+    rel_n = ((native_kernel_only().float() - gt).abs().max() / (gt.abs().max() + 1e-9)).item()
+    assert rel_n < 2e-2, f"native rel={rel_n} too high; refusing to time"
+
+    tk  = timed(native_kernel_only)
+    tne = timed(native_e2e)
+    tlg = timed(lut_gemm_only)
+    tle = timed(lut_e2e)
+    print(f"M={M} K={K} N={N}: native_kernel={tk:.3f}ms native_e2e={tne:.3f}ms "
+          f"lut_gemm={tlg:.3f}ms lut_e2e(+decode)={tle:.3f}ms "
+          f"speedup_e2e={tle/tne:.2f}x  rel={rel_n:.2e}")
+# Honest comparison: the model-relevant number is native_e2e vs lut_e2e (both include their
+# real per-call costs). native_kernel vs lut_gemm is the kernel-only ceiling.

--- a/tests/probe_fp8_native_matmul.py
+++ b/tests/probe_fp8_native_matmul.py
@@ -1,0 +1,63 @@
+"""Issue-F Task 0 probe (run on M5, ASFP8_FP8_NATIVE=1).
+
+SYNTHETIC ONLY. Confirms the existing native fp8 NT kernel (half activation x fp8
+e4m3 weight) matches the decoded-fp32 ground truth on real Flux-2-Klein linear
+shapes, and that the current LUT->bf16 path is not dramatically more accurate.
+Cannot establish real activation range (see Task -1). Lifts the layout/spy
+approach from docs/superpowers/results/G2-results.md.
+"""
+import os, sys, torch
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _patches._common import decode_fp8
+from _patches.fp8_ext import loader
+
+assert torch.backends.mps.is_available(), "need MPS"
+os.environ["ASFP8_FP8_NATIVE"] = "1"
+mod = loader.module()
+assert mod is not None, "fp8_ext failed to build"
+mod.warmup()
+assert hasattr(mod, "fp8_matmul2d_nt"), "fp8_matmul2d_nt export missing"
+
+# Flux-2-Klein-9B-class linear shapes: M=tokens(1024^2 -> ~4096), K/N in {4096,16384}.
+SHAPES = [(4096, 4096, 4096), (4096, 4096, 16384), (4096, 16384, 4096)]
+g = torch.Generator().manual_seed(0)
+worst = 0.0
+ok = True
+for (M, K, N) in SHAPES:
+    act_bf16 = (torch.randn(M, K, generator=g) * 0.3).to(torch.bfloat16)        # activation
+    w_fp8    = (torch.randn(N, K, generator=g) * 0.3).to(torch.float8_e4m3fn)   # weight [N,K]
+
+    # Ground truth: decode both to fp32, fp32 matmul.
+    gt = (act_bf16.float() @ decode_fp8(w_fp8.to("mps"), torch.float32).cpu().t()).to("mps")
+
+    # NATIVE: half activation x fp8 weight bytes.
+    a_half = act_bf16.to("mps").to(torch.float16).contiguous()
+    w_u8   = w_fp8.to("mps").contiguous().view(torch.uint8)
+    native = mod.fp8_matmul2d_nt(a_half, w_u8, N)            # [M,N] f32
+
+    # CURRENT (LUT->bf16): decode weight to bf16, bf16 matmul (what we replace).
+    a_bf16 = act_bf16.to("mps")
+    w_bf16 = decode_fp8(w_fp8.to("mps"), torch.bfloat16)
+    lut    = (a_bf16 @ w_bf16.t()).float()
+
+    assert native.abs().max() > 0, "SPY: native C is all-zero -> kernel no-op"
+    diff = (native - gt).abs()
+    den  = gt.abs().max() + 1e-9
+    rel_native = (diff.max() / den).item()
+    rel_lut    = ((lut - gt).abs().max() / den).item()
+    # Distribution-aware stats (MAJOR 10): worst-element relative is not enough over K<=16384.
+    rel_elt = (diff / (gt.abs() + 1e-6))
+    mean_abs = diff.mean().item()
+    p999     = torch.quantile(rel_elt.flatten().float()[:: max(1, rel_elt.numel()//1_000_000)], 0.999).item()
+    actmax   = act_bf16.float().abs().max().item()
+    worst = max(worst, rel_native)
+    # Decision rule (MAJOR 10): native must be within ~2x of the LUT path it replaces.
+    within_lut = rel_native <= 2 * rel_lut + 1e-4
+    ok = ok and (rel_native < 2e-2) and within_lut
+    print(f"M={M} K={K} N={N}: rel_native={rel_native:.4e} rel_lut={rel_lut:.4e} "
+          f"mean_abs={mean_abs:.4e} p99.9_rel={p999:.4e} act|max|={actmax:.3f} "
+          f"within_2x_lut={within_lut} (fp16 max 65504)")
+
+print(f"WORST rel_native={worst:.4e}  (gate: < 2e-2 AND rel_native <= 2*rel_lut+eps)")
+assert ok, "native path failed the tolerance/decision gate vs fp32 ground truth"
+print("PROBE PASS (synthetic; real range/scale still gated on Task -1)")

--- a/tests/test_caps.py
+++ b/tests/test_caps.py
@@ -12,8 +12,8 @@ from _patches import _caps
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
+    # Setup-only: monkeypatch auto-reverts, so no teardown/yield is needed.
     monkeypatch.delenv("ASFP8_CAPS_TEST", raising=False)
-    yield
 
 
 def _cap(value):
@@ -80,4 +80,6 @@ def test_tier_b_requires_both_probe_and_ninja(monkeypatch):
 
 def test_summary_is_a_string():
     s = _caps.summary()
-    assert isinstance(s, str) and "mps=" in s and "ninja=" in s
+    assert isinstance(s, str)
+    assert "mps=" in s
+    assert "ninja=" in s

--- a/tests/test_caps.py
+++ b/tests/test_caps.py
@@ -1,0 +1,83 @@
+"""Contract tests for the three-state capability gate (_patches/_caps.py).
+
+These are pure/host-side: they exercise the env-resolution logic with a stubbed
+capability predicate, so they run identically on CI (no MPS) and on an M5 box.
+The gate is the mechanism every default-on perf patch now shares, so its contract
+is worth pinning independently of any one kernel.
+"""
+import pytest
+
+from _patches import _caps
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("ASFP8_CAPS_TEST", raising=False)
+    yield
+
+
+def _cap(value):
+    """A zero-arg predicate that also records whether it was called."""
+    calls = []
+
+    def probe():
+        calls.append(True)
+        return value
+
+    probe.calls = calls
+    return probe
+
+
+# --- unset: defers to default_on AND the capability probe -------------------
+def test_unset_default_on_cap_true_installs():
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(True)) is True
+
+
+def test_unset_default_on_cap_false_skips():
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(False)) is False
+
+
+def test_unset_default_off_never_installs_even_if_capable():
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=False, cap=_cap(True)) is False
+
+
+# --- explicit values win over the probe, and skip it entirely ---------------
+@pytest.mark.parametrize("tok", _caps.ON_TOKENS)
+def test_explicit_on_forces_install_without_probing(monkeypatch, tok):
+    monkeypatch.setenv("ASFP8_CAPS_TEST", tok)
+    probe = _cap(False)  # probe says "unsupported"; explicit ON must still win
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=probe) is True
+    assert probe.calls == [], "explicit ON must not pay for a capability probe"
+
+
+@pytest.mark.parametrize("tok", _caps.OFF_TOKENS)
+def test_explicit_off_forces_skip_without_probing(monkeypatch, tok):
+    monkeypatch.setenv("ASFP8_CAPS_TEST", tok)
+    probe = _cap(True)  # probe says "supported"; explicit OFF must still win
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=probe) is False
+    assert probe.calls == [], "explicit OFF must not pay for a capability probe"
+
+
+def test_case_and_whitespace_insensitive(monkeypatch):
+    monkeypatch.setenv("ASFP8_CAPS_TEST", "  OFF  ")
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(True)) is False
+
+
+def test_unrecognised_value_falls_through_to_default(monkeypatch):
+    monkeypatch.setenv("ASFP8_CAPS_TEST", "maybe")
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(True)) is True
+    assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(False)) is False
+
+
+# --- tier B implies both the tensor-ops probe AND ninja ---------------------
+def test_tier_b_requires_both_probe_and_ninja(monkeypatch):
+    monkeypatch.setattr(_caps, "has_tensor_ops_matmul2d", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: False)
+    assert _caps.tier_b_ready() is False
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    assert _caps.tier_b_ready() is True
+
+
+def test_summary_is_a_string():
+    s = _caps.summary()
+    assert isinstance(s, str) and "mps=" in s and "ninja=" in s

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -215,15 +215,181 @@ def test_wrapper_falls_back_on_kernel_exception(monkeypatch):
     assert out is sentinel
 
 
+def _boom_fallback(*a, **k):
+    raise AssertionError("fell back to stock conv instead of running the Metal kernel")
+
+
+@requires_mps
+def test_fallback_after_install_no_recursion(monkeypatch):
+    """[MAJOR #1] After install() swaps F.conv2d for the wrapper, a kernel failure inside
+    conv_im2col must fall back to the captured ORIGINAL conv -- not re-enter the wrapper.
+    Before the fix _fallback_conv called F.conv2d (= the wrapper) -> wrapper -> conv_im2col
+    -> kernel raises -> _fallback_conv -> wrapper -> ... infinite recursion. We force the
+    kernel to raise and assert exactly ONE kernel attempt (no re-entry) + a correct result."""
+    import torch.nn.functional as F
+    import _patches.conv_im2col_mps as cm
+    saved2, saved3 = F.conv2d, F.conv3d
+    try:
+        # fresh install state, pretend MPS is installable, install conv2d wrapper
+        monkeypatch.setattr(cm, "_installed_ranks", set(), raising=False)
+        monkeypatch.setattr(cm, "_orig_conv2d", None, raising=False)
+        monkeypatch.setattr(cm, "_orig_conv3d", None, raising=False)
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
+        monkeypatch.setenv("ASFP8_CONV_IM2COL", "2d")
+        cm.install()
+        assert cm._installed_ranks == {2}
+        assert F.conv2d is not saved2, "install() did not replace F.conv2d with the wrapper"
+
+        # force the kernel to raise so conv_im2col hits its INTERNAL fallback seam
+        calls = {"checked": 0}
+
+        def boom_checked(*a, **k):
+            calls["checked"] += 1
+            raise RuntimeError("forced kernel failure")
+        monkeypatch.setattr(cm, "_conv2d_im2col_checked", boom_checked)
+
+        x = torch.randn(1, 4, 8, 8, device="mps", dtype=torch.float16)
+        w = torch.randn(8, 4, 3, 3, device="mps", dtype=torch.float16)
+        ref = saved2(x, w, None, 1, 1).float()           # stock conv via TRUE original
+        # call THROUGH the installed wrapper (what real callers hit after install)
+        out = F.conv2d(x, w, None, 1, 1).float()
+        torch.mps.synchronize()
+        # with the recursion bug this is re-entered many times (or RecursionError); the
+        # fix makes the fallback use the captured original -> exactly ONE kernel attempt.
+        assert calls["checked"] == 1, calls
+        assert out.shape == ref.shape
+        assert (out - ref).abs().max().item() < 1e-2
+    finally:
+        F.conv2d, F.conv3d = saved2, saved3
+
+
+@requires_mps
+def test_conv3d_multitile_matches_reference(monkeypatch):
+    """[MAJOR #2] Force tiny tiles so the conv3d tiling loop runs MANY tiles, and compare
+    against the F.conv3d fp32 reference. All other correctness tests are single-tile
+    (tile_p >= P); this is the only test that exercises the p0/rows tiling loop for real."""
+    import math
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    N, Cin, Cout, D, H, W = 1, 8, 12, 4, 12, 12
+    x = torch.randn(N, Cin, D, H, W, device="mps", dtype=torch.float16)
+    w = torch.randn(Cout, Cin, 3, 3, 3, device="mps", dtype=torch.float16)
+    b = torch.randn(Cout, device="mps", dtype=torch.float16)
+    P = N * D * H * W                       # 576 output pixels (pad=1, stride=1)
+    K = Cin * 3 * 3 * 3                      # 216
+    # cap A_tile to ~8 rows -> ~72 tiles, deep into the tiling loop
+    tile_p_target = 8
+    monkeypatch.setattr(cm, "_TILE_BYTES", tile_p_target * K * 2, raising=False)
+    tile_p = max(1, min(P, cm._TILE_BYTES // (K * 2)))
+    expected_tiles = math.ceil(P / tile_p)
+    assert tile_p < P and expected_tiles > 1, (tile_p, P, expected_tiles)
+
+    # count tiling-loop iterations to PROVE many tiles really ran
+    n_tiles = {"n": 0}
+    orig_tile = cm._im2col_3d_tile
+
+    def spy_tile(*a, **k):
+        n_tiles["n"] += 1
+        return orig_tile(*a, **k)
+    monkeypatch.setattr(cm, "_im2col_3d_tile", spy_tile)
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
+
+    ref = torch.nn.functional.conv3d(x.float(), w.float(), b.float(), padding=1)
+    out = conv_im2col(x, w, b, stride=1, padding=1).float()
+    torch.mps.synchronize()
+    assert n_tiles["n"] == expected_tiles, (n_tiles, expected_tiles)
+    assert out.shape == ref.shape
+    assert (out - ref).abs().max().item() < 2e-1
+
+
+@requires_mps
+@pytest.mark.parametrize("rank", [2, 3])
+def test_conv_batch_n_gt_1(rank, monkeypatch):
+    """[MINOR #5] N>1 batch: the pixel decode n = pix/(...) must place batches correctly."""
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
+    if rank == 2:
+        x = torch.randn(3, 8, 16, 16, device="mps", dtype=torch.float16)
+        w = torch.randn(12, 8, 3, 3, device="mps", dtype=torch.float16)
+        ref = torch.nn.functional.conv2d(x.float(), w.float(), padding=1)
+    else:
+        x = torch.randn(2, 6, 4, 12, 12, device="mps", dtype=torch.float16)
+        w = torch.randn(10, 6, 3, 3, 3, device="mps", dtype=torch.float16)
+        ref = torch.nn.functional.conv3d(x.float(), w.float(), padding=1)
+    out = conv_im2col(x, w, None, stride=1, padding=1).float()
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert (out - ref).abs().max().item() < 2e-1
+
+
+@requires_mps
+def test_conv3d_stride2_matches_reference(monkeypatch):
+    """[MINOR #6] conv3d with stride>1 (sD/sH/sW used independently in the gather)."""
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
+    x = torch.randn(1, 8, 7, 17, 15, device="mps", dtype=torch.float16)
+    w = torch.randn(10, 8, 3, 3, 3, device="mps", dtype=torch.float16)
+    b = torch.randn(10, device="mps", dtype=torch.float16)
+    ref = torch.nn.functional.conv3d(x.float(), w.float(), b.float(), stride=2, padding=1)
+    out = conv_im2col(x, w, b, stride=2, padding=1).float()
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert (out - ref).abs().max().item() < 2e-1
+
+
+@requires_mps
+def test_conv3d_bf16_end_to_end(monkeypatch):
+    """[MINOR #4] bf16 end-to-end conv (all other conv tests are fp16). Result must be no
+    worse than the stock bf16 conv against the fp32 reference."""
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    x = torch.randn(1, 6, 4, 12, 12, device="mps", dtype=torch.bfloat16)
+    w = torch.randn(8, 6, 3, 3, 3, device="mps", dtype=torch.bfloat16)
+    b = torch.randn(8, device="mps", dtype=torch.bfloat16)
+    ref = torch.nn.functional.conv3d(x.float(), w.float(), b.float(), padding=1)
+    stock = torch.nn.functional.conv3d(x, w, b, padding=1).float()  # capture BEFORE spy
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
+    out = conv_im2col(x, w, b, stride=1, padding=1).float()
+    torch.mps.synchronize()
+    assert out.dtype == torch.float32 and ref.shape == out.shape
+    # no worse than stock bf16 conv against the fp32 reference (+ small slack)
+    assert (out - ref).abs().max().item() <= (stock - ref).abs().max().item() + 5e-2
+
+
+def test_supported_rejects_dtype_mismatch():
+    """[MINOR #7] _supported must reject weight.dtype != x.dtype (kernel is compiled for the
+    input dtype and would read the weight buffer's bytes as the wrong type -> garbage)."""
+    import _patches.conv_im2col_mps as cm
+
+    class _FakeT:
+        def __init__(self, dt):
+            self.dtype = dt
+            self.device = type("D", (), {"type": "mps"})()
+    x = _FakeT(torch.float16)
+    w_ok = _FakeT(torch.float16)
+    w_bad = _FakeT(torch.float32)
+    assert cm._supported(x, w_ok, 1, 1, x.dtype) is True
+    assert cm._supported(x, w_bad, 1, 1, x.dtype) is False
+
+
 @requires_mps
 def test_scatter_matches_nonscatter(monkeypatch):
     """The fused channel-major scatter epilogue must produce byte-identical output to the
     out_flat+permute path (same kernel math, different store)."""
+    import _patches.conv_im2col_mps as cm
     from _patches.conv_im2col_mps import conv_im2col
     torch.manual_seed(0)
     x = torch.randn(1, 16, 5, 24, 24, device="mps", dtype=torch.float16)
     w = torch.randn(12, 16, 3, 3, 3, device="mps", dtype=torch.float16)
     b = torch.randn(12, device="mps", dtype=torch.float16)
+    # [MINOR #3] defense-in-depth: a silent fallback would make scatter==nonscatter trivially
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
     monkeypatch.setenv("ASFP8_CONV_SCATTER", "0")
     ref = conv_im2col(x, w, b, stride=1, padding=1)
     monkeypatch.setenv("ASFP8_CONV_SCATTER", "1")
@@ -239,7 +405,11 @@ def test_scatter_drops_extra_buffer(monkeypatch):
     the transient out_flat/copy that scatter removes). We spy torch.empty: the scatter path
     must allocate ONLY the channel-major final output [N,Cout,H,W] + the [tile_p,K] A_tile,
     and NEVER the [P,Cout] out_flat staging buffer the non-scatter path allocates."""
+    import _patches.conv_im2col_mps as cm
     from _patches.conv_im2col_mps import conv_im2col
+    # [MINOR #3] defense-in-depth: stock fallback doesn't allocate [P,Cout] either, so a
+    # silent fallback could mask a broken scatter path -- make it explode instead.
+    monkeypatch.setattr(cm, "_fallback_conv", _boom_fallback, raising=True)
     N, Cin, H, W, Cout = 1, 64, 256, 256, 128
     P = N * H * W  # pad=1, stride=1 -> Hout=H, Wout=W
     x = torch.randn(N, Cin, H, W, device="mps", dtype=torch.float16)

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -130,3 +130,25 @@ def test_conv_alloc_smoke_nonpeak():
     full_im2col_bytes = (512 * 512) * (256 * 9) * 2       # 1.21 GB
     assert delta < budget, (delta, budget)
     assert delta < full_im2col_bytes, (delta, full_im2col_bytes)
+
+
+@requires_mps
+@pytest.mark.parametrize("D,H,W,Cin,Cout,bias", [(5, 32, 32, 16, 16, False),
+                                                 (4, 24, 24, 8, 12, True)])
+def test_conv3d_matches_reference(D, H, W, Cin, Cout, bias, monkeypatch):
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    x = torch.randn(1, Cin, D, H, W, device="mps", dtype=torch.float16)
+    w = torch.randn(Cout, Cin, 3, 3, 3, device="mps", dtype=torch.float16)
+    b = torch.randn(Cout, device="mps", dtype=torch.float16) if bias else None
+    ref = torch.nn.functional.conv3d(x.float(), w.float(),
+                                     b.float() if bias else None, padding=1)
+    # SPY: stock fallback must not be how this test passes.
+    def boom(*a, **k):
+        raise AssertionError("conv3d fell back to stock conv instead of running the kernel")
+    monkeypatch.setattr(cm, "_fallback_conv", boom, raising=True)
+    out = conv_im2col(x, w, b, stride=1, padding=1).float()
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert (out - ref).abs().max().item() < 2e-1

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -19,3 +19,48 @@ def test_im2col_2d_matches_unfold(H, W, Cin, kh, kw, s, p):
     torch.mps.synchronize()
     assert A.shape == ref.shape, (A.shape, ref.shape)
     assert (A - ref).abs().max().item() < 1e-2
+
+
+@requires_mps
+@pytest.mark.parametrize("M,K,N,bias", [(130, 96, 72, False), (64, 256, 64, True),
+                                        (300, 1152, 128, True)])
+def test_gemm_nt_bias_matches_reference(M, K, N, bias, monkeypatch):
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import _gemm_nt_bias
+    torch.manual_seed(0)
+    # SPY: wrap the compiled lib so the test proves the real Metal entry point ran.
+    # NOTE: torch.mps compiled-shader objects route attribute access to kernel-function
+    # lookup (you cannot set/get arbitrary attrs on them), so we wrap the lib in a thin
+    # delegating proxy that counts gemm_nt_bias invocations and forwards everything else.
+    calls = {"gemm_nt_bias": 0}
+    real_lib = cm._lib
+
+    class _SpyLib:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def gemm_nt_bias(self, *a, **k):
+            calls["gemm_nt_bias"] += 1
+            return self._inner.gemm_nt_bias(*a, **k)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    def spy_lib(dtype):
+        return _SpyLib(real_lib(dtype))
+    monkeypatch.setattr(cm, "_lib", spy_lib)
+
+    A = torch.randn(M, K, device="mps", dtype=torch.float16)
+    Bw = torch.randn(N, K, device="mps", dtype=torch.float16)
+    b = torch.randn(N, device="mps", dtype=torch.float32) if bias else None
+    out = torch.empty(M, N, device="mps", dtype=torch.float16)
+    ref = A.float() @ Bw.float().t()
+    if bias:
+        ref = ref + b
+    _gemm_nt_bias(A, Bw, b, out)          # writes directly into `out` (no per-call alloc)
+    torch.mps.synchronize()
+    out = out.float()
+    assert calls["gemm_nt_bias"] == 1, "Metal gemm_nt_bias kernel did not run"
+    assert out.shape == (M, N)
+    # fp16 operands, fp32 accumulate: error is operand rounding only
+    assert (out - ref).abs().max().item() < 2e-1

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -98,7 +98,7 @@ def test_tile_buffer_capped():
     and for a large conv it actually tiles (tile_p < P) rather than materializing full im2col."""
     import _patches.conv_im2col_mps as cm
     # 512x512, Cin=256, 3x3 -> full im2col is 1.21 GB, well above the 384 MB default cap.
-    N, Cin, H, W, kh, kw = 1, 256, 512, 512, 3, 3
+    N, Cin, kh, kw = 1, 256, 3, 3  # H = W = 512
     Hout = Wout = 512  # pad=1, stride=1
     P, K = N * Hout * Wout, Cin * kh * kw
     elsize = 2  # fp16
@@ -152,3 +152,64 @@ def test_conv3d_matches_reference(D, H, W, Cin, Cout, bias, monkeypatch):
     torch.mps.synchronize()
     assert out.shape == ref.shape
     assert (out - ref).abs().max().item() < 2e-1
+
+
+def test_install_noop_without_flag(monkeypatch):
+    import _patches.conv_im2col_mps as cm
+    monkeypatch.delenv("ASFP8_CONV_IM2COL", raising=False)
+    monkeypatch.setattr(cm, "_installed_ranks", set(), raising=False)
+    monkeypatch.setattr(cm, "_orig_conv2d", None, raising=False)
+    cm.install()
+    assert cm._installed_ranks == set()
+
+
+def test_install_idempotent_per_mode(monkeypatch):
+    """=2d then =3d in one process must install BOTH ranks."""
+    import torch.nn.functional as F
+    import _patches.conv_im2col_mps as cm
+    monkeypatch.setattr(cm, "_installed_ranks", set(), raising=False)
+    monkeypatch.setattr(cm, "_orig_conv2d", None, raising=False)
+    monkeypatch.setattr(cm, "_orig_conv3d", None, raising=False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
+    monkeypatch.setenv("ASFP8_CONV_IM2COL", "2d")
+    cm.install()
+    assert cm._installed_ranks == {2}
+    monkeypatch.setenv("ASFP8_CONV_IM2COL", "3d")
+    cm.install()
+    assert cm._installed_ranks == {2, 3}
+    # restore F.conv2d/conv3d to the captured originals so we don't leak the wrap.
+    F.conv2d, F.conv3d = cm._orig_conv2d, cm._orig_conv3d
+
+
+@pytest.mark.parametrize("kwargs", [{"groups": 2}, {"dilation": 2}])
+def test_wrapper_falls_back_unsupported(kwargs):
+    """Grouped / dilated convs must delegate to the captured original, not the kernel."""
+    import _patches.conv_im2col_mps as cm
+    sentinel = object()
+    called = {}
+
+    def fake_orig(x, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        called["hit"] = True
+        return sentinel
+    conv2 = cm._make_wrap(fake_orig, 2)  # module-level wrapper factory (no MPS/install needed)
+    x = torch.zeros(1, 4, 8, 8)          # CPU tensor, also unsupported device
+    w = torch.zeros(8, 4, 3, 3)
+    out = conv2(x, w, padding=1, **kwargs)
+    assert out is sentinel and called.get("hit") is True
+
+
+def test_wrapper_falls_back_on_kernel_exception(monkeypatch):
+    """If the kernel raises, the wrapper must still return the original's result."""
+    import _patches.conv_im2col_mps as cm
+    sentinel = object()
+
+    def fake_orig(x, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        return sentinel
+
+    def boom(*a, **k):
+        raise RuntimeError("kernel blew up")
+    monkeypatch.setattr(cm, "_supported", lambda *a, **k: True)
+    monkeypatch.setattr(cm, "conv_im2col", boom)
+    conv2 = cm._make_wrap(fake_orig, 2)
+    out = conv2(torch.zeros(1, 4, 8, 8), torch.zeros(8, 4, 3, 3), padding=1)
+    assert out is sentinel

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -213,3 +213,63 @@ def test_wrapper_falls_back_on_kernel_exception(monkeypatch):
     conv2 = cm._make_wrap(fake_orig, 2)
     out = conv2(torch.zeros(1, 4, 8, 8), torch.zeros(8, 4, 3, 3), padding=1)
     assert out is sentinel
+
+
+@requires_mps
+def test_scatter_matches_nonscatter(monkeypatch):
+    """The fused channel-major scatter epilogue must produce byte-identical output to the
+    out_flat+permute path (same kernel math, different store)."""
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    x = torch.randn(1, 16, 5, 24, 24, device="mps", dtype=torch.float16)
+    w = torch.randn(12, 16, 3, 3, 3, device="mps", dtype=torch.float16)
+    b = torch.randn(12, device="mps", dtype=torch.float16)
+    monkeypatch.setenv("ASFP8_CONV_SCATTER", "0")
+    ref = conv_im2col(x, w, b, stride=1, padding=1)
+    monkeypatch.setenv("ASFP8_CONV_SCATTER", "1")
+    got = conv_im2col(x, w, b, stride=1, padding=1)
+    torch.mps.synchronize()
+    assert got.shape == ref.shape
+    assert torch.equal(got, ref), (got - ref).abs().max().item()
+
+
+@requires_mps
+def test_scatter_drops_extra_buffer(monkeypatch):
+    """DETERMINISTIC proof (current_allocated is NOT a high-watermark, so it cannot observe
+    the transient out_flat/copy that scatter removes). We spy torch.empty: the scatter path
+    must allocate ONLY the channel-major final output [N,Cout,H,W] + the [tile_p,K] A_tile,
+    and NEVER the [P,Cout] out_flat staging buffer the non-scatter path allocates."""
+    from _patches.conv_im2col_mps import conv_im2col
+    N, Cin, H, W, Cout = 1, 64, 256, 256, 128
+    P = N * H * W  # pad=1, stride=1 -> Hout=H, Wout=W
+    x = torch.randn(N, Cin, H, W, device="mps", dtype=torch.float16)
+    w = torch.randn(Cout, Cin, 3, 3, device="mps", dtype=torch.float16)
+
+    real_empty = torch.empty
+
+    def run_and_capture(scatter):
+        shapes = []
+
+        def spy_empty(*size, **kw):
+            # torch.empty(*sizes) or torch.empty((sizes,))
+            s = size[0] if len(size) == 1 and isinstance(size[0], (tuple, list, torch.Size)) else size
+            shapes.append(tuple(int(d) for d in s))
+            return real_empty(*size, **kw)
+        monkeypatch.setenv("ASFP8_CONV_SCATTER", "1" if scatter else "0")
+        monkeypatch.setattr(torch, "empty", spy_empty)
+        out = conv_im2col(x, w, None, 1, 1)
+        torch.mps.synchronize()
+        monkeypatch.setattr(torch, "empty", real_empty)
+        return shapes, out
+
+    s_scatter, out = run_and_capture(True)
+    s_nonscatter, _ = run_and_capture(False)
+
+    out_flat_shape = (P, Cout)
+    final_shape = (N, Cout, H, W)
+    # non-scatter allocates the [P,Cout] out_flat staging buffer ...
+    assert out_flat_shape in s_nonscatter, s_nonscatter
+    # ... scatter NEVER does; it allocates the channel-major output directly.
+    assert out_flat_shape not in s_scatter, s_scatter
+    assert final_shape in s_scatter, s_scatter
+    assert out.shape == final_shape

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -1,0 +1,21 @@
+import pytest
+import torch
+
+from conftest import requires_mps  # repo-provided marker (tests/conftest.py)
+
+
+@requires_mps
+@pytest.mark.parametrize("H,W,Cin,kh,kw,s,p", [(16, 16, 8, 3, 3, 1, 1),
+                                               (15, 17, 6, 3, 3, 2, 1),
+                                               (8, 8, 4, 1, 1, 1, 0)])
+def test_im2col_2d_matches_unfold(H, W, Cin, kh, kw, s, p):
+    from _patches.conv_im2col_mps import _im2col_2d_full  # test helper: full (untiled) im2col
+    torch.manual_seed(0)
+    x = torch.randn(1, Cin, H, W, device="mps", dtype=torch.float16)
+    # F.unfold gives [N, Cin*kh*kw, L] with the SAME (c,ki,kj) ordering as our K index.
+    ref = torch.nn.functional.unfold(x.float(), (kh, kw), stride=s, padding=p)  # [1, K, P]
+    ref = ref[0].t().contiguous()  # [P, K]
+    A = _im2col_2d_full(x, kh, kw, s, p).float()  # [P, K]
+    torch.mps.synchronize()
+    assert A.shape == ref.shape, (A.shape, ref.shape)
+    assert (A - ref).abs().max().item() < 1e-2

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -154,11 +154,31 @@ def test_conv3d_matches_reference(D, H, W, Cin, Cout, bias, monkeypatch):
     assert (out - ref).abs().max().item() < 2e-1
 
 
-def test_install_noop_without_flag(monkeypatch):
+def test_install_default_on_routes_conv3d_only(monkeypatch):
+    """Default (no env) routes conv3d (the measured ~2.7x win) but NOT conv2d
+    (stock conv2d is at-roofline; im2col loses there)."""
+    import torch.nn.functional as F
     import _patches.conv_im2col_mps as cm
     monkeypatch.delenv("ASFP8_CONV_IM2COL", raising=False)
     monkeypatch.setattr(cm, "_installed_ranks", set(), raising=False)
     monkeypatch.setattr(cm, "_orig_conv2d", None, raising=False)
+    monkeypatch.setattr(cm, "_orig_conv3d", None, raising=False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
+    try:
+        cm.install()
+        assert cm._installed_ranks == {3}
+    finally:
+        if cm._orig_conv2d is not None:
+            F.conv2d, F.conv3d = cm._orig_conv2d, cm._orig_conv3d
+
+
+def test_install_off_disables(monkeypatch):
+    """ASFP8_CONV_IM2COL=off is the kill switch -- nothing is installed."""
+    import _patches.conv_im2col_mps as cm
+    monkeypatch.setenv("ASFP8_CONV_IM2COL", "off")
+    monkeypatch.setattr(cm, "_installed_ranks", set(), raising=False)
+    monkeypatch.setattr(cm, "_orig_conv2d", None, raising=False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
     cm.install()
     assert cm._installed_ranks == set()
 

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -90,3 +90,43 @@ def test_conv2d_matches_reference(H, W, Cin, Cout, s, p, bias, monkeypatch):
     assert (out - ref).abs().max().item() < 2e-1
     # must be no worse than stock fp16 conv
     assert (out - ref).abs().max().item() <= (stock - ref).abs().max().item() + 1e-2
+
+
+@requires_mps
+def test_tile_buffer_capped():
+    """DETERMINISTIC OOM proof: the A_tile the driver allocates is provably <= _TILE_BYTES,
+    and for a large conv it actually tiles (tile_p < P) rather than materializing full im2col."""
+    import _patches.conv_im2col_mps as cm
+    # 512x512, Cin=256, 3x3 -> full im2col is 1.21 GB, well above the 384 MB default cap.
+    N, Cin, H, W, kh, kw = 1, 256, 512, 512, 3, 3
+    Hout = Wout = 512  # pad=1, stride=1
+    P, K = N * Hout * Wout, Cin * kh * kw
+    elsize = 2  # fp16
+    tile_p = max(1, min(P, cm._TILE_BYTES // (K * elsize)))
+    a_tile_bytes = tile_p * K * elsize
+    full_im2col_bytes = P * K * elsize          # = 262144*2304*2 = 1.21 GB
+    assert a_tile_bytes <= cm._TILE_BYTES, (a_tile_bytes, cm._TILE_BYTES)
+    assert tile_p < P, "must tile, not materialize full im2col"
+    assert a_tile_bytes < full_im2col_bytes / 3   # tile is a small fraction of full im2col
+
+
+@requires_mps
+def test_conv_alloc_smoke_nonpeak():
+    """NON-PEAK smoke: current_allocated delta with the output held live stays under an explicit
+    budget = _TILE_BYTES + out_flat + contiguous-copy + weight + slack. (current_allocated is NOT
+    a high-watermark; the deterministic guarantee is test_tile_buffer_capped above.)"""
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.mps.empty_cache()
+    x = torch.randn(1, 256, 512, 512, device="mps", dtype=torch.float16)
+    w = torch.randn(256, 256, 3, 3, device="mps", dtype=torch.float16)
+    base = torch.mps.current_allocated_memory()
+    out = conv_im2col(x, w, None, 1, 1)       # keep `out` live so its bytes are counted
+    torch.mps.synchronize()
+    delta = torch.mps.current_allocated_memory() - base
+    out_bytes = out.numel() * out.element_size()          # P*Cout*2
+    weight_bytes = w.numel() * w.element_size()
+    budget = cm._TILE_BYTES + 2 * out_bytes + weight_bytes + 64 * 1024 * 1024  # +64MB slack
+    full_im2col_bytes = (512 * 512) * (256 * 9) * 2       # 1.21 GB
+    assert delta < budget, (delta, budget)
+    assert delta < full_im2col_bytes, (delta, full_im2col_bytes)

--- a/tests/test_conv_im2col.py
+++ b/tests/test_conv_im2col.py
@@ -64,3 +64,29 @@ def test_gemm_nt_bias_matches_reference(M, K, N, bias, monkeypatch):
     assert out.shape == (M, N)
     # fp16 operands, fp32 accumulate: error is operand rounding only
     assert (out - ref).abs().max().item() < 2e-1
+
+
+@requires_mps
+@pytest.mark.parametrize("H,W,Cin,Cout,s,p,bias", [(64, 64, 32, 32, 1, 1, False),
+                                                   (128, 128, 64, 128, 1, 1, True),
+                                                   (65, 63, 16, 24, 2, 1, True)])
+def test_conv2d_matches_reference(H, W, Cin, Cout, s, p, bias, monkeypatch):
+    import _patches.conv_im2col_mps as cm
+    from _patches.conv_im2col_mps import conv_im2col
+    torch.manual_seed(0)
+    x = torch.randn(1, Cin, H, W, device="mps", dtype=torch.float16)
+    w = torch.randn(Cout, Cin, 3, 3, device="mps", dtype=torch.float16)
+    b = torch.randn(Cout, device="mps", dtype=torch.float16) if bias else None
+    ref = torch.nn.functional.conv2d(x.float(), w.float(),
+                                     b.float() if bias else None, stride=s, padding=p)
+    stock = torch.nn.functional.conv2d(x, w, b, stride=s, padding=p).float()  # capture BEFORE spy
+    # SPY: make the in-module stock fallback explode so a silent fallback fails the test.
+    def boom(*a, **k):
+        raise AssertionError("conv_im2col fell back to stock conv instead of running the kernel")
+    monkeypatch.setattr(cm, "_fallback_conv", boom, raising=True)
+    out = conv_im2col(x, w, b, stride=s, padding=p).float()
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert (out - ref).abs().max().item() < 2e-1
+    # must be no worse than stock fp16 conv
+    assert (out - ref).abs().max().item() <= (stock - ref).abs().max().item() + 1e-2

--- a/tests/test_fp8_linear_kernel.py
+++ b/tests/test_fp8_linear_kernel.py
@@ -29,3 +29,41 @@ def test_loader_memo_resets_between_flag_states(monkeypatch):
     # On non-MPS/no-toolchain CI this returns None via a *different* branch (xcrun/build),
     # NOT the env gate; that is still correct. On this M5 it builds and returns a module.
     _ = loader.module()  # must not raise; value depends on host
+
+
+# --- Task 3: unit guards (no kernel needed; run everywhere) ---------------------
+from _patches import fp8_linear_kernel_mps as patch
+
+
+def test_install_noop_without_flag(monkeypatch):
+    monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+    patch.install()
+    assert patch._installed is False
+
+
+def test_eligibility_returns_none_no_kernel(monkeypatch):
+    monkeypatch.setattr(patch, "_kernel", None, raising=False)
+    class FakeLinear: weight = torch.zeros(8, 8, dtype=torch.float8_e4m3fn)
+    assert patch._try_fp8_kernel_forward(FakeLinear(), torch.zeros(4, 8)) is None
+
+
+def test_eligibility_rejects_non_fp8_weight(monkeypatch):
+    # Kernel present but weight isn't a fp8 QuantizedTensor -> None (FAST handback to int8/orig).
+    monkeypatch.setattr(patch, "_kernel", object(), raising=False)
+    class FakeLinear: weight = torch.zeros(8, 8)   # plain, not QuantizedTensor
+    assert patch._try_fp8_kernel_forward(FakeLinear(), torch.zeros(4, 8, device="cpu")) is None
+
+
+def test_self_check_not_run_on_ineligible(monkeypatch):
+    # BLOCKER 2 regression guard: a non-MPS/non-fp8 layer must NOT trigger the self-check.
+    monkeypatch.setattr(patch, "_kernel", object(), raising=False)
+    monkeypatch.setattr(patch, "_self_checked", False, raising=False)
+    calls = {"n": 0}
+    def boom():
+        calls["n"] += 1
+        return True
+    monkeypatch.setattr(patch, "_self_check", boom, raising=False)
+    class FakeLinear: weight = torch.zeros(8, 8)   # ineligible
+    assert patch._try_fp8_kernel_forward(FakeLinear(), torch.zeros(4, 8, device="cpu")) is None
+    assert calls["n"] == 0, "self-check ran on an ineligible layer (BLOCKER 2 regression)"

--- a/tests/test_fp8_linear_kernel.py
+++ b/tests/test_fp8_linear_kernel.py
@@ -11,15 +11,30 @@ def _reset_loader(monkeypatch):
     monkeypatch.setattr(loader, "_mod", None, raising=False)
 
 
-def test_loader_gated_off_without_any_flag(monkeypatch):
+def test_loader_gated_off_when_unsupported(monkeypatch):
+    # DEFAULT ON but capability-gated: flags unset + unsupported HW -> no build.
+    from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    _reset_loader(monkeypatch)
+    assert loader.module() is None
+
+
+def test_loader_forced_off_beats_capability(monkeypatch):
+    # Explicit off on both flags wins even on capable HW -> no build.
+    from _patches import _caps
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setenv("ASFP8_FP8_EXT", "off")
+    monkeypatch.setenv("ASFP8_FP8_NATIVE", "off")
     _reset_loader(monkeypatch)
     assert loader.module() is None
 
 
 def test_loader_memo_resets_between_flag_states(monkeypatch):
     # Off -> None, then flip NATIVE on with a fresh reset; the gate must re-evaluate.
+    from _patches import _caps
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
     _reset_loader(monkeypatch)
@@ -35,8 +50,21 @@ def test_loader_memo_resets_between_flag_states(monkeypatch):
 from _patches import fp8_linear_kernel_mps as patch
 
 
-def test_install_noop_without_flag(monkeypatch):
+def test_install_noop_when_explicitly_off(monkeypatch):
+    # ASFP8_FP8_NATIVE=off force-disables even on capable hardware.
+    from _patches import _caps
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setenv("ASFP8_FP8_NATIVE", "off")
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+    patch.install()
+    assert patch._installed is False
+
+
+def test_install_noop_when_not_capable(monkeypatch):
+    # DEFAULT ON but Tier-B gated: unsupported hardware -> no build, stays inert.
+    from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
     assert patch._installed is False

--- a/tests/test_fp8_linear_kernel.py
+++ b/tests/test_fp8_linear_kernel.py
@@ -1,0 +1,31 @@
+import os
+
+import pytest
+import torch
+
+from _patches.fp8_ext import loader
+
+
+def _reset_loader(monkeypatch):
+    monkeypatch.setattr(loader, "_tried", False, raising=False)
+    monkeypatch.setattr(loader, "_mod", None, raising=False)
+
+
+def test_loader_gated_off_without_any_flag(monkeypatch):
+    monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
+    monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
+    _reset_loader(monkeypatch)
+    assert loader.module() is None
+
+
+def test_loader_memo_resets_between_flag_states(monkeypatch):
+    # Off -> None, then flip NATIVE on with a fresh reset; the gate must re-evaluate.
+    monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
+    monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
+    _reset_loader(monkeypatch)
+    assert loader.module() is None
+    monkeypatch.setenv("ASFP8_FP8_NATIVE", "1")
+    _reset_loader(monkeypatch)
+    # On non-MPS/no-toolchain CI this returns None via a *different* branch (xcrun/build),
+    # NOT the env gate; that is still correct. On this M5 it builds and returns a module.
+    _ = loader.module()  # must not raise; value depends on host

--- a/tests/test_fp8_linear_kernel.py
+++ b/tests/test_fp8_linear_kernel.py
@@ -67,3 +67,103 @@ def test_self_check_not_run_on_ineligible(monkeypatch):
     class FakeLinear: weight = torch.zeros(8, 8)   # ineligible
     assert patch._try_fp8_kernel_forward(FakeLinear(), torch.zeros(4, 8, device="cpu")) is None
     assert calls["n"] == 0, "self-check ran on an ineligible layer (BLOCKER 2 regression)"
+
+
+# --- Task 4: REAL spy tests (kernel really ran AND wrapper dispatched native) -----
+# Gated on ASFP8_FP8_NATIVE=1 + MPS (builds the Metal lib).
+_run = os.environ.get("ASFP8_FP8_NATIVE") == "1"
+requires_fp8_native = pytest.mark.skipif(
+    not (_run and torch.backends.mps.is_available()),
+    reason="set ASFP8_FP8_NATIVE=1 on an MPS device to build + test the fp8 kernel")
+
+# MPS cannot cast bf16->fp8, so real fp8 QuantizedTensors are built on CPU then moved.
+# This comfy_kitchen registers the e4m3 layout as "TensorCoreFP8Layout".
+_FP8_LAYOUT = "TensorCoreFP8Layout"
+
+
+@requires_fp8_native
+def test_native_matches_ground_truth(monkeypatch):
+    from _patches.fp8_ext import loader
+    from _patches._common import decode_fp8
+    mod = loader.module(); assert mod is not None; mod.warmup()
+    monkeypatch.setattr(patch, "_kernel", mod, raising=False)
+
+    M, K, N = 64, 8192, 8192
+    g = torch.Generator().manual_seed(3)
+    act = (torch.randn(M, K, generator=g) * 0.3).to(torch.bfloat16).to("mps")
+    w_fp8 = (torch.randn(N, K, generator=g) * 0.3).to(torch.float8_e4m3fn).to("mps")
+    scale = torch.tensor(1.0)
+
+    out = patch._fp8_linear_kernel(act, w_fp8, scale, None)
+    gt = (act.float() @ decode_fp8(w_fp8, torch.float32).t()).to(torch.bfloat16)  # all-MPS fp32 ref
+    assert out.dtype == torch.bfloat16
+    rel = ((out.float() - gt.float()).abs().max() / (gt.float().abs().max() + 1e-9)).item()
+    assert rel < 2e-2, f"native vs ground-truth rel={rel}"
+    assert out.abs().max() > 0  # SPY: not all-zero
+
+
+@requires_fp8_native
+def test_native_per_channel_scale(monkeypatch):
+    # Exercise the [N] scale branch (resolves OQ#1 in code regardless of Task -1 finding).
+    from _patches.fp8_ext import loader
+    from _patches._common import decode_fp8
+    mod = loader.module(); assert mod is not None; mod.warmup()
+    monkeypatch.setattr(patch, "_kernel", mod, raising=False)
+    M, K, N = 64, 8192, 8192
+    g = torch.Generator().manual_seed(5)
+    act = (torch.randn(M, K, generator=g) * 0.3).to(torch.bfloat16).to("mps")
+    w_fp8 = (torch.randn(N, K, generator=g) * 0.3).to(torch.float8_e4m3fn).to("mps")
+    scale = (torch.rand(N, generator=g) * 0.5 + 0.5)  # [N]
+    out = patch._fp8_linear_kernel(act, w_fp8, scale, None)
+    gt = (act.float() @ decode_fp8(w_fp8, torch.float32).t()) * scale.to("mps").reshape(1, N)
+    rel = ((out.float() - gt.float()).abs().max() / (gt.abs().max() + 1e-9)).item()
+    assert rel < 2e-2, f"per-channel native rel={rel}"
+
+
+@requires_fp8_native
+def test_wrapper_dispatches_native_not_fallback(monkeypatch):
+    """End-to-end SPY: build a REAL QuantizedTensor fp8 weight, monkeypatch
+    _fp8_linear_kernel to a sentinel AND the captured orig_forward to RAISE.
+    If Linear.forward returns the sentinel, the native path dispatched; if the fallback
+    ran, the test ERRORS (orig_forward raises) instead of silently passing."""
+    from comfy_kitchen.tensor import QuantizedTensor
+    from _patches.fp8_ext import loader
+    mod = loader.module(); assert mod is not None
+    monkeypatch.setattr(patch, "_kernel", mod, raising=False)
+    monkeypatch.setattr(patch, "_self_checked", True, raising=False)
+    monkeypatch.setattr(patch, "_self_ok", True, raising=False)
+
+    SENTINEL = torch.full((1,), 1234.0)
+    monkeypatch.setattr(patch, "_fp8_linear_kernel",
+                        lambda *a, **k: SENTINEL, raising=False)
+
+    # Build a real fp8 QuantizedTensor weight on CPU (MPS can't cast bf16->fp8), then
+    # move to MPS so _qdata is MPS-resident fp8 e4m3 (layout_cls starts "TensorCoreFP8").
+    N, K = 8192, 8192
+    wf = (torch.randn(N, K) * 0.3).to(torch.bfloat16)
+    qw = QuantizedTensor.from_float(wf, _FP8_LAYOUT, scale=torch.tensor(1.0))
+    qw = qw.to("mps")
+    assert qw._qdata.is_mps and qw._qdata.dtype == torch.float8_e4m3fn
+    assert str(qw._layout_cls).startswith("TensorCoreFP8")
+
+    # Minimal Linear-like holder matching the attributes the eligibility reads.
+    class Holder:
+        weight = qw
+        bias = None
+        _full_precision_mm = False
+        comfy_force_cast_weights = False
+        weight_function = []
+        bias_function = []
+    holder = Holder()
+
+    # Construct the patched forward exactly as install() does, with a RAISING orig_forward.
+    def orig_forward(self, input, *a, **k):
+        raise AssertionError("fallback orig_forward ran; native path did NOT dispatch")
+
+    def forward(self, input, *a, **k):
+        res = patch._try_fp8_kernel_forward(self, input)
+        return res if res is not None else orig_forward(self, input, *a, **k)
+
+    inp = (torch.randn(64, K) * 0.3).to(torch.bfloat16).to("mps")
+    out = forward(holder, inp)
+    assert torch.equal(out, SENTINEL), "wrapper did not dispatch the native sentinel path"

--- a/tests/test_fused_norm.py
+++ b/tests/test_fused_norm.py
@@ -164,11 +164,17 @@ def test_bad_optional_shape_falls_back():
     rows, dim = 256, 128
     x = torch.randn(rows, dim, device="mps", dtype=torch.float16)
     bad_w = torch.randn(dim - 1, device="mps", dtype=torch.float16)   # wrong length
-    out = fused_rmsnorm_modulate(x, bad_w, 1e-6)
+    # the validation must route to the fallback (no kernel dispatch / no OOB buffer read); the
+    # torch fallback then legitimately broadcast-fails on the genuinely-malformed tensor. The
+    # load-bearing assertion is that we did NOT dispatch the kernel (backend == "fallback").
+    m._last_backend = "kernel"
+    with pytest.raises(RuntimeError):
+        fused_rmsnorm_modulate(x, bad_w, 1e-6)
     assert m._last_backend == "fallback"
-    # the fallback itself will broadcast-fail or mismatch; here we only assert it did not dispatch
     bad_res = torch.randn(rows, dim + 1, device="mps", dtype=torch.float16)
-    out2 = fused_rmsnorm_modulate(x, None, 1e-6, None, None, bad_res)
+    m._last_backend = "kernel"
+    with pytest.raises(RuntimeError):
+        fused_rmsnorm_modulate(x, None, 1e-6, None, None, bad_res)
     assert m._last_backend == "fallback"
 
 

--- a/tests/test_fused_norm.py
+++ b/tests/test_fused_norm.py
@@ -228,3 +228,39 @@ def test_cpu_falls_back():
     ref = m._reference(x, w, 1e-6, None, None, None)
     assert m._last_backend == "fallback"
     assert torch.allclose(out, ref, atol=1e-6)
+
+
+@mps
+@pytest.mark.parametrize("D", [17, 31])
+def test_direct_kernel_D_not_multiple_of_32(D):
+    """Verify #4 MINOR: exercise the kernel's fp32 simd_sum reduction at D < 32 / not a multiple
+    of 32 against an INDEPENDENT hand-computed fp32 oracle (no m._reference) so a subtle bug in the
+    module's own reference could not mask a partial-simdgroup reduction error."""
+    torch.manual_seed(D)
+    rows = 257                                            # not a multiple of TG either
+    x = torch.randn(rows, D, device="mps", dtype=torch.float16)
+    w = torch.randn(D, device="mps", dtype=torch.float16)
+    out = fused_rmsnorm_modulate(x, w, 1e-6)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    # hand-computed fp32 oracle: rmsnorm(x) * weight, eps inside sqrt (LLaMA formulation)
+    xf = x.float()
+    oracle = (xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + 1e-6)) * w.float()
+    assert torch.allclose(out.float(), oracle, atol=5e-2, rtol=5e-2)
+
+
+def test_reroute_bypass_sets_fallback_backend():
+    """Verify #3 MAJOR: when the F.rms_norm reroute bypasses the kernel on an outer guard (here a
+    non-MPS device), it must set _last_backend = 'fallback' so a stale 'kernel' value from a previous
+    successful call cannot create a false-positive kernel-path test. Uses a CPU tensor with a VALID
+    normalized_shape so the bypass reaches the real stock rms_norm (which then succeeds)."""
+    m.install_for_test()
+    try:
+        m._last_backend = "kernel"                        # simulate a stale spy from a prior kernel run
+        x = torch.randn(4, 16)                            # CPU tensor -> device.type != "mps" outer bypass
+        w = torch.randn(16)
+        out = torch.nn.functional.rms_norm(x, (16,), w, 1e-6)
+        assert m._last_backend == "fallback", "outer reroute bypass must reset the spy to 'fallback'"
+        assert out.shape == x.shape
+    finally:
+        m.uninstall_for_test()

--- a/tests/test_fused_norm.py
+++ b/tests/test_fused_norm.py
@@ -1,0 +1,224 @@
+# tests/test_fused_norm.py
+"""Issue E: fused RMSNorm + affine + adaLN(scale,shift) + residual kernel.
+
+Correctness oracle = exact, GROUP-AWARE torch composition in fp32 (the same formula the
+wrapper falls back to). Every MPS test asserts the real Metal kernel ran (m._last_backend
+== 'kernel') so it cannot pass silently through the torch fallback. Includes the int32
+row*D overflow regime (rows*D > 2**31) since this kernel supersedes rmsnorm_mps_large.py."""
+import pytest
+import torch
+
+from _patches import fused_norm_mps as m
+from _patches.fused_norm_mps import fused_rmsnorm_modulate
+
+mps = pytest.mark.skipif(not torch.backends.mps.is_available(), reason="needs MPS")
+
+
+def _reference(x, weight, eps, scale, shift, residual):
+    # mirror the module's group-aware reference for tests that pre-expand inputs
+    return m._reference(x, weight, eps, scale, shift, residual)
+
+
+@mps
+@pytest.mark.parametrize("dtype,atol,rtol", [
+    (torch.float16, 5e-2, 5e-2),
+    (torch.bfloat16, 8e-2, 8e-2),
+    (torch.float32, 2e-4, 2e-4),
+])
+def test_full_path_matches_reference(dtype, atol, rtol):
+    torch.manual_seed(0)
+    rows, dim = 4096, 256
+    x = torch.randn(rows, dim, device="mps", dtype=dtype)
+    w = torch.randn(dim, device="mps", dtype=dtype)
+    sc = torch.randn(dim, device="mps", dtype=dtype)
+    sh = torch.randn(dim, device="mps", dtype=dtype)
+    res = torch.randn(rows, dim, device="mps", dtype=dtype)
+    ref = _reference(x, w, 1e-6, sc, sh, res)
+    out = fused_rmsnorm_modulate(x, w, 1e-6, sc, sh, res)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel", "fell back to torch composition instead of running the kernel"
+    assert out.dtype == dtype and out.shape == ref.shape
+    assert torch.allclose(out.float(), ref.float(), atol=atol, rtol=rtol)
+
+
+@mps
+def test_bare_rmsnorm_tight_tolerance():
+    """Deterministic low-dynamic-range case: x in [-1,1], weight=ones, no modulation/residual.
+    Expected error is final-store rounding only, so use a tight fp16 tolerance (Codex MINOR #10)."""
+    torch.manual_seed(7)
+    rows, dim = 1024, 64
+    x = (torch.rand(rows, dim, device="mps", dtype=torch.float16) * 2.0 - 1.0)
+    w = torch.ones(dim, device="mps", dtype=torch.float16)
+    ref = _reference(x, w, 1e-6, None, None, None)
+    out = fused_rmsnorm_modulate(x, w, 1e-6)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    assert torch.allclose(out.float(), ref.float(), atol=3e-3, rtol=3e-3)
+
+
+@mps
+@pytest.mark.parametrize("use_scale,use_shift,use_res,use_w", [
+    (False, False, False, True),    # bare rmsnorm + weight
+    (True, False, False, True),     # + scale only
+    (False, True, True, True),      # shift + residual, no scale
+    (True, True, True, False),      # modulation + residual, no weight (weight=None)
+])
+def test_optional_args(use_scale, use_shift, use_res, use_w):
+    torch.manual_seed(1)
+    rows, dim = 2048, 320
+    x = torch.randn(rows, dim, device="mps", dtype=torch.float16)
+    w = torch.randn(dim, device="mps", dtype=torch.float16) if use_w else None
+    sc = torch.randn(dim, device="mps", dtype=torch.float16) if use_scale else None
+    sh = torch.randn(dim, device="mps", dtype=torch.float16) if use_shift else None
+    res = torch.randn(rows, dim, device="mps", dtype=torch.float16) if use_res else None
+    ref = _reference(x, w, 1e-6, sc, sh, res)
+    out = fused_rmsnorm_modulate(x, w, 1e-6, sc, sh, res)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    assert torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2)
+
+
+@mps
+def test_per_batch_modulation_grouping():
+    """adaLN case: x flattened from [B, L, D], scale/shift are [B, D] (one group per batch)."""
+    torch.manual_seed(2)
+    B, L, D = 3, 512, 256
+    x = torch.randn(B * L, D, device="mps", dtype=torch.float16)
+    w = torch.randn(D, device="mps", dtype=torch.float16)
+    sc = torch.randn(B, D, device="mps", dtype=torch.float16)
+    sh = torch.randn(B, D, device="mps", dtype=torch.float16)
+    res = torch.randn(B * L, D, device="mps", dtype=torch.float16)
+    # group-aware reference expands [B,D] -> [B*L,D] exactly as the kernel maps row->group
+    ref = _reference(x, w, 1e-6, sc, sh, res)
+    out = fused_rmsnorm_modulate(x, w, 1e-6, sc, sh, res)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    assert torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2)
+
+
+@mps
+def test_mixed_group_counts():
+    """Open question #5/#6: scale=[B,D], shift=[1,D] (different group counts) must work."""
+    torch.manual_seed(8)
+    B, L, D = 4, 256, 256
+    x = torch.randn(B * L, D, device="mps", dtype=torch.float16)
+    sc = torch.randn(B, D, device="mps", dtype=torch.float16)   # G=B
+    sh = torch.randn(1, D, device="mps", dtype=torch.float16)   # G=1
+    ref = _reference(x, None, 1e-6, sc, sh, None)
+    out = fused_rmsnorm_modulate(x, None, 1e-6, sc, sh, None)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    assert torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2)
+    # reversed roles
+    ref2 = _reference(x, None, 1e-6, sh, sc, None)
+    out2 = fused_rmsnorm_modulate(x, None, 1e-6, sh, sc, None)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    assert torch.allclose(out2.float(), ref2.float(), atol=5e-2, rtol=5e-2)
+
+
+@mps
+def test_multidim_normalized_shape_reroute():
+    """Codex BLOCKER #2: F.rms_norm reroute must reduce over ALL normalized dims
+    (D = prod(normalized_shape)), not just the last one, and must read a multi-dim weight."""
+    m.install_for_test()                       # force the F.rms_norm reroute regardless of env flag
+    try:
+        torch.manual_seed(9)
+        x = torch.randn(2, 3, 4, device="mps", dtype=torch.float16)
+        w = torch.randn(3, 4, device="mps", dtype=torch.float16)
+        # manual fp32 multi-dim rms_norm oracle (same formula as rmsnorm_mps_large.py)
+        xf = x.float()
+        dims = (1, 2)
+        ref = (xf * torch.rsqrt(xf.pow(2).mean(dims, keepdim=True) + 1e-6)).to(x.dtype) * w
+        out = torch.nn.functional.rms_norm(x, (3, 4), w, 1e-6)
+        torch.mps.synchronize()
+        assert m._last_backend == "kernel"
+        assert out.shape == x.shape
+        assert torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2)
+    finally:
+        m.uninstall_for_test()
+
+
+@mps
+def test_grouped_modulation_fallback_equiv(monkeypatch):
+    """Codex MAJOR #3: forcing the fallback with grouped [B,D] scale/shift must NOT raise and
+    must match the kernel result (group-aware reference). Plain broadcasting would crash here."""
+    torch.manual_seed(10)
+    B, L, D = 3, 128, 256
+    x = torch.randn(B * L, D, device="mps", dtype=torch.float16)
+    sc = torch.randn(B, D, device="mps", dtype=torch.float16)
+    sh = torch.randn(B, D, device="mps", dtype=torch.float16)
+    ref = m._reference(x, None, 1e-6, sc, sh, None)        # group-aware oracle
+    # force the kernel to fail so the wrapper takes the fallback
+    monkeypatch.setattr(m, "_get_lib", lambda dtype: (_ for _ in ()).throw(RuntimeError("forced")))
+    out = fused_rmsnorm_modulate(x, None, 1e-6, sc, sh, None)
+    assert m._last_backend == "fallback", "expected the forced fallback path"
+    assert torch.allclose(out.float(), ref.float(), atol=5e-2, rtol=5e-2)
+
+
+@mps
+def test_bad_optional_shape_falls_back():
+    """Codex MAJOR #4: a short weight / mismatched residual must route to the fallback, not
+    dispatch undefined memory reads."""
+    torch.manual_seed(11)
+    rows, dim = 256, 128
+    x = torch.randn(rows, dim, device="mps", dtype=torch.float16)
+    bad_w = torch.randn(dim - 1, device="mps", dtype=torch.float16)   # wrong length
+    out = fused_rmsnorm_modulate(x, bad_w, 1e-6)
+    assert m._last_backend == "fallback"
+    # the fallback itself will broadcast-fail or mismatch; here we only assert it did not dispatch
+    bad_res = torch.randn(rows, dim + 1, device="mps", dtype=torch.float16)
+    out2 = fused_rmsnorm_modulate(x, None, 1e-6, None, None, bad_res)
+    assert m._last_backend == "fallback"
+
+
+@mps
+@pytest.mark.slow
+def test_overflow_rows_2pow24_kernel_path(monkeypatch):
+    """THE int32-offset overflow proof (Codex MAJOR #5): rows*D = 1<<24 * 256 = 4.29e9 > 2**31.
+    Monkeypatch _reference to raise so this CANNOT pass through the fallback — it must be the
+    real 64-bit-indexed kernel. ~8.6 GiB fp16; needs the 128 GB box."""
+    monkeypatch.setattr(m, "_reference",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not fall back")))
+    torch.manual_seed(4)
+    rows, dim = 1 << 24, 256
+    x = torch.randn(rows, dim, device="mps", dtype=torch.float16)
+    w = torch.randn(dim, device="mps", dtype=torch.float16)
+    out = fused_rmsnorm_modulate(x, w, 1e-6)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    idx = torch.tensor([0, rows // 3, rows - 1], device="mps")
+    xr = x.index_select(0, idx).float()
+    ref = (xr * torch.rsqrt(xr.pow(2).mean(-1, keepdim=True) + 1e-6)) * w.float()
+    assert torch.isfinite(out.index_select(0, idx).float()).all()
+    assert torch.allclose(out.index_select(0, idx).float(), ref.float(), atol=5e-2, rtol=5e-2)
+
+
+@mps
+@pytest.mark.slow
+def test_stock_mps_broken_regime_2pow22():
+    """rows=1<<22 (4.19M). This is BELOW int32 element max (1.07e9 < 2.147e9) so it does NOT
+    prove offset overflow; it reproduces the *stock PyTorch* MPS row-count bug regime. Our kernel
+    must stay correct here (fp32 + kernel path)."""
+    torch.manual_seed(3)
+    rows, dim = 1 << 22, 256
+    x = torch.randn(rows, dim, device="mps", dtype=torch.float16)
+    w = torch.randn(dim, device="mps", dtype=torch.float16)
+    out = fused_rmsnorm_modulate(x, w, 1e-6)
+    torch.mps.synchronize()
+    assert m._last_backend == "kernel"
+    idx = torch.tensor([0, 1, rows // 2, rows - 2, rows - 1], device="mps")
+    xr = x.index_select(0, idx).float()
+    ref = (xr * torch.rsqrt(xr.pow(2).mean(-1, keepdim=True) + 1e-6)) * w.float()
+    assert torch.isfinite(out.index_select(0, idx).float()).all()
+    assert torch.allclose(out.index_select(0, idx).float(), ref.float(), atol=5e-2, rtol=5e-2)
+
+
+def test_cpu_falls_back():
+    """Off-MPS input must hit the torch-composition fallback, not the kernel."""
+    x = torch.randn(8, 16)            # CPU tensor
+    w = torch.randn(16)
+    out = m.fused_rmsnorm_modulate(x, w, 1e-6)
+    ref = m._reference(x, w, 1e-6, None, None, None)
+    assert m._last_backend == "fallback"
+    assert torch.allclose(out, ref, atol=1e-6)

--- a/tests/test_int4_linear.py
+++ b/tests/test_int4_linear.py
@@ -1,0 +1,143 @@
+"""Tests for _patches/int4_linear_mps.py (ConvRot W4A4 fast path on MPS).
+
+Requires comfy-kitchen >= 0.2.13 (ConvRot W4A4 layout). Skips otherwise —
+run with PYTHONPATH pointing at a new-enough kitchen if the env has an old one.
+"""
+
+import pytest
+import torch
+
+from conftest import requires_mps
+
+ck_eager = pytest.importorskip("comfy_kitchen.backends.eager.convrot_w4a4")
+
+from _patches import int4_linear_mps  # noqa: E402
+
+M, K, N = 128, 1024, 512  # K divisible by 256 (convrot) and 64 (quant group)
+
+
+def _quantized_weight(seed=0):
+    torch.manual_seed(seed)
+    w = torch.randn(N, K, dtype=torch.float32) * 0.02
+    qdata, wscales = ck_eager.quantize_convrot_w4a4_weight(w, convrot_groupsize=256)
+    return w, qdata, wscales
+
+
+def test_unpack_bit_exact_cpu():
+    p = torch.randint(-128, 128, (64, 128), dtype=torch.int8)
+    ref = ck_eager._unpack_int4_row_major(p).to(torch.int8)
+    got = int4_linear_mps._unpack_int4_signed_fast(p, torch.int8)
+    assert torch.equal(ref, got)
+
+
+@requires_mps
+def test_unpack_bit_exact_mps():
+    p = torch.randint(-128, 128, (64, 128), dtype=torch.int8, device="mps")
+    ref = ck_eager._unpack_int4_row_major(p.cpu()).to(torch.int8)
+    got = int4_linear_mps._unpack_int4_signed_fast(p, torch.int8).cpu()
+    assert torch.equal(ref, got)
+
+
+@requires_mps
+def test_w4a16_more_accurate_than_eager():
+    w, qdata, wscales = _quantized_weight()
+    torch.manual_seed(1)
+    x = torch.randn(M, K, dtype=torch.float32)
+    ref = torch.nn.functional.linear(x, w)
+
+    y_eager = ck_eager.convrot_w4a4_linear(x.to("mps", torch.bfloat16), qdata.to("mps"),
+                                           wscales.to("mps"), convrot_groupsize=256)
+    y_fast = int4_linear_mps._w4a16_linear_mps(x.to("mps", torch.bfloat16), qdata.to("mps"),
+                                               wscales.to("mps"), None, 256, ck_eager)
+
+    err_eager = (y_eager.float().cpu() - ref).abs().mean() / ref.abs().mean()
+    err_fast = (y_fast.float().cpu() - ref).abs().mean() / ref.abs().mean()
+    assert err_fast < err_eager, f"fast path err {err_fast} not < eager err {err_eager}"
+    assert err_fast < 0.25  # int4 weight-only on random gaussian data
+
+
+@requires_mps
+def test_w4a16_bias_and_3d_input():
+    w, qdata, wscales = _quantized_weight()
+    bias = torch.randn(N, dtype=torch.float32)
+    x = torch.randn(2, 64, K, dtype=torch.bfloat16, device="mps")
+    y = int4_linear_mps._w4a16_linear_mps(x, qdata.to("mps"), wscales.to("mps"),
+                                          bias.to("mps"), 256, ck_eager)
+    assert y.shape == (2, 64, N)
+    ref = torch.nn.functional.linear(
+        x.float().cpu().reshape(-1, K), w, bias).reshape(2, 64, N)
+    err = (y.float().cpu() - ref).abs().mean() / ref.abs().mean()
+    assert err < 0.25
+
+
+def _kernel_or_skip():
+    import os
+    os.environ.setdefault("ASFP8_INT4_EXT", "1")
+    from _patches.int4_ext import loader
+    mod = loader.module()
+    if mod is None:
+        pytest.skip("int4 Metal extension unavailable (build failed or no toolchain)")
+    return mod
+
+
+@requires_mps
+def test_w4a8_kernel_bit_exact_vs_emulation():
+    kernel = _kernel_or_skip()
+    torch.manual_seed(2)
+    Mk = 200  # non-multiple of tile to exercise bounds
+    _, qdata, wscales = _quantized_weight()
+    x_rot = torch.randn(Mk, K, dtype=torch.bfloat16, device="mps")
+    bias = torch.randn(N, dtype=torch.bfloat16, device="mps")
+
+    from _patches import int4_linear_mps
+    y = int4_linear_mps._w4a8_kernel_linear(x_rot, qdata.to("mps"), wscales.to("mps"),
+                                            bias, kernel)
+
+    # emulate: same act quant, int32 matmul on unpacked weight, same epilogue
+    absmax = x_rot.float().abs().amax(dim=-1).clamp(min=1e-10)
+    x_scale = absmax / 127.0
+    qx = torch.round(x_rot.float() / x_scale.unsqueeze(-1)).clamp(-127, 127).to(torch.int8)
+    w_int = ck_eager._unpack_int4_row_major(qdata).to(torch.int32)
+    acc = qx.cpu().to(torch.int32) @ w_int.T
+    ref = (acc.float() * x_scale.cpu().unsqueeze(-1) * wscales.reshape(1, -1)).to(torch.bfloat16)
+    ref = ref + bias.cpu()
+    assert torch.equal(y.cpu(), ref), \
+        f"kernel mismatch: maxdiff={(y.cpu().float() - ref.float()).abs().max()}"
+
+
+@requires_mps
+def test_w4a8_kernel_no_bias():
+    kernel = _kernel_or_skip()
+    torch.manual_seed(3)
+    _, qdata, wscales = _quantized_weight()
+    x_rot = torch.randn(64, K, dtype=torch.bfloat16, device="mps")
+    from _patches import int4_linear_mps
+    y = int4_linear_mps._w4a8_kernel_linear(x_rot, qdata.to("mps"), wscales.to("mps"),
+                                            None, kernel)
+    assert y.shape == (64, N)
+    assert torch.isfinite(y.float()).all()
+
+
+@requires_mps
+def test_install_routes_mps_only():
+    import comfy_kitchen.tensor.convrot_w4a4 as ck_tensor
+
+    int4_linear_mps.install()
+    try:
+        assert int4_linear_mps._patched
+        w, qdata, wscales = _quantized_weight()
+        x = torch.randn(M, K, dtype=torch.bfloat16)
+
+        # CPU falls through to the original eager path (identical result)
+        y_cpu = ck_tensor.convrot_w4a4_linear(x, qdata, wscales, convrot_groupsize=256)
+        y_orig = int4_linear_mps._orig(x, qdata, wscales, convrot_groupsize=256)
+        assert torch.equal(y_cpu, y_orig)
+
+        # MPS goes through the fast path (matches direct call)
+        y_mps = ck_tensor.convrot_w4a4_linear(x.to("mps"), qdata.to("mps"),
+                                              wscales.to("mps"), convrot_groupsize=256)
+        y_fast = int4_linear_mps._w4a16_linear_mps(x.to("mps"), qdata.to("mps"),
+                                                   wscales.to("mps"), None, 256, ck_eager)
+        assert torch.equal(y_mps.cpu(), y_fast.cpu())
+    finally:
+        int4_linear_mps.uninstall()

--- a/tests/test_int4_linear.py
+++ b/tests/test_int4_linear.py
@@ -72,8 +72,12 @@ def test_w4a16_bias_and_3d_input():
 
 def _kernel_or_skip():
     import os
-    os.environ.setdefault("ASFP8_INT4_EXT", "1")
+    os.environ["ASFP8_INT4_EXT"] = "1"
     from _patches.int4_ext import loader
+    # Earlier default-off W4A16 tests call loader.module() and permanently cache None;
+    # clear that cache so the W4A8 build is actually attempted (and tested) on capable HW.
+    loader._tried = False
+    loader._mod = None
     mod = loader.module()
     if mod is None:
         pytest.skip("int4 Metal extension unavailable (build failed or no toolchain)")

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -105,3 +105,85 @@ def test_kernel_matches_original_bit_exact():
     run(512, 6144, 6144, convrot=True, bias=True, three_d=False)
     run(188, 4096, 2560, convrot=True, bias=True, three_d=True)
     run(1, 6144, 6144, convrot=True, bias=False, three_d=False)
+
+
+# P0 verdict: Metal `erf` is unavailable under MTLLanguageVersion4_1, so act=3
+# ("gelu", erf) is dropped entirely; only {silu, gelu_tanh} are supported.
+@requires_int8_ext
+@pytest.mark.parametrize("act", ["silu", "gelu_tanh"])
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("M", [1, 256])
+def test_int8_linear_fused_activation_matches_reference(M, bias, act):
+    """Fused-epilogue activation == torch activation of the unfused kernel output."""
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    from _patches.int8_ext import loader
+    from comfy_kitchen.backends.eager.quantization import int8_linear as orig_int8_linear
+    mod = loader.module()
+    assert mod is not None and hasattr(mod, "i8_matmul2d_nt_fused")
+    mod.warmup()
+    patch._kernel = mod
+    patch._orig_int8_linear = orig_int8_linear
+
+    dev = "mps"
+    g = torch.Generator().manual_seed(11)
+    K, N = 2560, 1024
+    x = (torch.randn(M, K, generator=g, dtype=torch.bfloat16) * 0.5).to(dev)
+    w = torch.randint(-128, 128, (N, K), generator=g, dtype=torch.int8).to(dev)
+    ws = (torch.rand(1, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)
+    b = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
+
+    lin = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, False, 256, act="none")
+    if act == "silu":
+        ref = torch.nn.functional.silu(lin)
+    else:
+        ref = torch.nn.functional.gelu(lin, approximate="tanh")
+
+    # Spy guard: the fused activation path must be the real kernel, not the torch fallback.
+    def _boom(*a, **k):
+        raise AssertionError("fell back to _orig_int8_linear; fused kernel did not run")
+    saved = patch._orig_int8_linear
+    patch._orig_int8_linear = _boom
+    try:
+        out = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, False, 256, act=act)
+    finally:
+        patch._orig_int8_linear = saved
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    # The fused epilogue rounds the activation to bf16; torch rounds its own bf16
+    # activation too, so the honest correctness bound is ONE bf16 ulp (relative
+    # 2**-7 ~= 7.8e-3). The plan's rtol=2e-3 sits *below* bf16 precision and is
+    # unsatisfiable for these magnitude-~15 outputs even by a perfect kernel
+    # (the plan's rationale assumed outputs ~1.0; this data reaches ~15). rtol=8e-3
+    # admits a 1-ulp-correct kernel; atol=2e-3 bounds the near-zero regime. This
+    # still rejects real bugs: the original precise::tanh GELU (~160 ulp) had an
+    # absolute diff of 0.0156 at small ref, which exceeds atol and fails here.
+    # See docs/superpowers/results/D-results.md.
+    d = (out.float() - ref.float()).abs()
+    assert torch.allclose(out, ref, atol=2e-3, rtol=8e-3), \
+        f"M={M} bias={bias} {act}: max|d|={d.max().item():.4g}"
+
+
+def test_wrapper_fallback_applies_activation(monkeypatch):
+    """Off-MPS / no-kernel fallback must still apply the requested activation, not drop it."""
+    monkeypatch.setattr(patch, "_kernel", None)  # force the early fallback branch
+
+    captured = {}
+    def fake_orig(x, w, ws, bias, out_dtype, convrot, gs):
+        captured["called"] = True
+        return torch.full((x.shape[0], w.shape[0]), 2.0, dtype=torch.float32)
+    monkeypatch.setattr(patch, "_orig_int8_linear", fake_orig)
+
+    x = torch.randn(4, 8)
+    w = torch.randint(-128, 128, (3, 8), dtype=torch.int8)
+    ws = torch.tensor([0.01])
+    out = patch._int8_linear_kernel(x, w, ws, None, torch.float32, False, 256, act="silu")
+    assert captured.get("called"), "fallback path was not taken"
+    # silu(2.0) ≈ 1.7616, not the raw 2.0 — proves the activation was applied post-fallback.
+    assert torch.allclose(out, torch.nn.functional.silu(torch.full_like(out, 2.0)))
+
+
+def test_wrapper_rejects_unknown_act():
+    with pytest.raises(ValueError):
+        patch._int8_linear_kernel(torch.randn(2, 4), torch.randint(-1, 2, (3, 4),
+                                  dtype=torch.int8), torch.tensor([0.01]), None,
+                                  torch.float32, False, 256, act="sillu")

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -187,3 +187,91 @@ def test_wrapper_rejects_unknown_act():
         patch._int8_linear_kernel(torch.randn(2, 4), torch.randint(-1, 2, (3, 4),
                                   dtype=torch.int8), torch.tensor([0.01]), None,
                                   torch.float32, False, 256, act="sillu")
+
+
+# tolerance: one bf16 ulp (rtol=8e-3) + atol=2e-3 near zero — see the point-activation
+# test rationale above and docs/superpowers/results/D-results.md. act=3 (gelu-erf) dropped.
+@requires_int8_ext
+@pytest.mark.parametrize("act", ["silu", "gelu_tanh"])
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("M,K", [(1, 2560), (512, 2560), (512, 2576)])  # 2576 = remainder-K
+def test_int8_swiglu_matches_reference(M, K, bias, act):
+    """Fused gate == act(int8_linear(x,Wg)) * int8_linear(x,Wu)."""
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    from _patches.int8_ext import loader
+    from comfy_kitchen.backends.eager.quantization import int8_linear as orig_int8_linear
+    mod = loader.module()
+    assert mod is not None and hasattr(mod, "i8_matmul2d_nt_swiglu")
+    mod.warmup()
+    patch._kernel = mod
+    patch._orig_int8_linear = orig_int8_linear
+
+    dev = "mps"
+    g = torch.Generator().manual_seed(5)
+    N = 1024
+    x  = (torch.randn(M, K, generator=g, dtype=torch.bfloat16) * 0.5).to(dev)
+    wg = torch.randint(-128, 128, (N, K), generator=g, dtype=torch.int8).to(dev)
+    wu = torch.randint(-128, 128, (N, K), generator=g, dtype=torch.int8).to(dev)
+    sg = (torch.rand(1, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)
+    su = (torch.rand(1, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)
+    bg = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
+    bu = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
+
+    lin_g = patch._int8_linear_kernel(x, wg, sg, bg, torch.bfloat16, False, 256, act="none")
+    lin_u = patch._int8_linear_kernel(x, wu, su, bu, torch.bfloat16, False, 256, act="none")
+    # The fused gate keeps act(gate) in fp32 registers and multiplies by up in fp32,
+    # rounding to bf16 ONCE (that single-rounding is the whole point of fusion). The
+    # reference must do the same: torch's INDEPENDENT fp32 activation (not the kernel's
+    # exp identity) * up in fp32, rounded once. A bf16-rounded intermediate gate would
+    # double-round and diverge by up to half-a-gate-ulp * |up| — that is not a kernel
+    # bug. The kernel matches this fp32-fused reference to ~1 bf16 ulp; near-zero gelu
+    # epsilon * large up is bounded by atol=2e-3. See docs/superpowers/results/D-results.md.
+    gfp = lin_g.float()
+    gate = torch.nn.functional.silu(gfp) if act == "silu" \
+           else torch.nn.functional.gelu(gfp, approximate="tanh")
+    ref = (gate * lin_u.float()).to(torch.bfloat16)
+
+    # Spy guard: prove the fused gated kernel ran, not the per-branch fallback.
+    def _boom(*a, **k):
+        raise AssertionError("SwiGLU fell back to _orig_int8_linear; fused gate did not run")
+    saved = patch._orig_int8_linear
+    patch._orig_int8_linear = _boom
+    try:
+        out = patch._int8_swiglu_kernel(x, wg, wu, sg, su, bg, bu, False, 256, act=act)
+    finally:
+        patch._orig_int8_linear = saved
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert torch.allclose(out, ref, atol=2e-3, rtol=8e-3), \
+        f"M={M} K={K} {act} bias={bias}: max|d|={(out.float()-ref.float()).abs().max().item():.4g}"
+
+
+@requires_int8_ext
+def test_int8_swiglu_nonscalar_scale_falls_back_correctly():
+    """Length-N weight scales must route through the per-branch path, not the fused gate kernel."""
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    from _patches.int8_ext import loader
+    from comfy_kitchen.backends.eager.quantization import int8_linear as orig_int8_linear
+    mod = loader.module()
+    assert mod is not None
+    mod.warmup()
+    patch._kernel = mod
+    patch._orig_int8_linear = orig_int8_linear
+
+    dev = "mps"
+    g = torch.Generator().manual_seed(7)
+    M, K, N = 64, 2560, 1024
+    x  = (torch.randn(M, K, generator=g, dtype=torch.bfloat16) * 0.5).to(dev)
+    wg = torch.randint(-128, 128, (N, K), generator=g, dtype=torch.int8).to(dev)
+    wu = torch.randint(-128, 128, (N, K), generator=g, dtype=torch.int8).to(dev)
+    sg = (torch.rand(N, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)  # per-channel
+    su = (torch.rand(N, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)
+
+    lin_g = patch._int8_linear_kernel(x, wg, sg, None, torch.bfloat16, False, 256, act="none")
+    lin_u = patch._int8_linear_kernel(x, wu, su, None, torch.bfloat16, False, 256, act="none")
+    ref = torch.nn.functional.silu(lin_g) * lin_u
+    out = patch._int8_swiglu_kernel(x, wg, wu, sg, su, None, None, False, 256, act="silu")
+    torch.mps.synchronize()
+    assert out.shape == ref.shape
+    assert torch.allclose(out, ref, atol=2e-3, rtol=8e-3), \
+        f"nonscalar: max|d|={(out.float()-ref.float()).abs().max().item():.4g}"

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -20,10 +20,21 @@ requires_int8_ext = pytest.mark.skipif(
 )
 
 
-def test_install_noop_without_flag(monkeypatch):
-    """install() must be a no-op unless ASFP8_INT8_EXT=1 (opt-in build)."""
+def test_install_noop_when_explicitly_off(monkeypatch):
+    """ASFP8_INT8_EXT=off force-disables even on capable hardware."""
+    from _patches import _caps
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setenv("ASFP8_INT8_EXT", "off")
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+    patch.install()
+    assert patch._installed is False
+
+
+def test_install_noop_when_not_capable(monkeypatch):
+    """DEFAULT ON but gated: unsupported hardware -> no build attempt, stays inert."""
+    from _patches import _caps
     monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
-    # Reset module state so a prior install() in-session doesn't mask this.
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
     assert patch._installed is False

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -48,6 +48,18 @@ def test_wrapper_falls_back_off_mps(monkeypatch):
     assert out is sentinel and called.get("hit") is True
 
 
+def test_fallback_without_install_raises_clean_error(monkeypatch):
+    """Direct call before install() (both _kernel and _orig are None) must raise a
+    clear RuntimeError, not an opaque AttributeError from calling None(...)."""
+    monkeypatch.setattr(patch, "_kernel", None, raising=False)
+    monkeypatch.setattr(patch, "_orig_int8_linear", None, raising=False)
+    x = torch.zeros(4, 8)
+    w = torch.zeros(8, 8, dtype=torch.int8)
+    ws = torch.ones(1)
+    with pytest.raises(RuntimeError):
+        patch._int8_linear_kernel(x, w, ws)
+
+
 @requires_int8_ext
 def test_kernel_matches_original_bit_exact():
     """Kernel-backed int8_linear == comfy_kitchen original (bit-identical bf16)."""
@@ -112,9 +124,15 @@ def test_kernel_matches_original_bit_exact():
 @requires_int8_ext
 @pytest.mark.parametrize("act", ["silu", "gelu_tanh"])
 @pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("convrot", [False, True])  # rotation shifts the activation magnitude dist
 @pytest.mark.parametrize("M", [1, 256])
-def test_int8_linear_fused_activation_matches_reference(M, bias, act):
-    """Fused-epilogue activation == torch activation of the unfused kernel output."""
+def test_int8_linear_fused_activation_matches_reference(M, convrot, bias, act):
+    """Fused-epilogue activation == torch activation of the unfused kernel output.
+
+    convrot=True exercises the Hadamard-rotate -> requant path feeding the fused
+    activation epilogue: rotation reshapes the magnitude distribution (GELU x^3,
+    SiLU saturation, quant edges), so the activation must stay correct there too.
+    """
     os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
     from _patches.int8_ext import loader
     from comfy_kitchen.backends.eager.quantization import int8_linear as orig_int8_linear
@@ -132,7 +150,7 @@ def test_int8_linear_fused_activation_matches_reference(M, bias, act):
     ws = (torch.rand(1, generator=g, dtype=torch.float32) * 0.01 + 0.001).to(dev)
     b = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
 
-    lin = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, False, 256, act="none")
+    lin = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, convrot, 256, act="none")
     if act == "silu":
         ref = torch.nn.functional.silu(lin)
     else:
@@ -144,7 +162,7 @@ def test_int8_linear_fused_activation_matches_reference(M, bias, act):
     saved = patch._orig_int8_linear
     patch._orig_int8_linear = _boom
     try:
-        out = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, False, 256, act=act)
+        out = patch._int8_linear_kernel(x, w, ws, b, torch.bfloat16, convrot, 256, act=act)
     finally:
         patch._orig_int8_linear = saved
     torch.mps.synchronize()
@@ -160,7 +178,7 @@ def test_int8_linear_fused_activation_matches_reference(M, bias, act):
     # See docs/superpowers/results/D-results.md.
     d = (out.float() - ref.float()).abs()
     assert torch.allclose(out, ref, atol=2e-3, rtol=8e-3), \
-        f"M={M} bias={bias} {act}: max|d|={d.max().item():.4g}"
+        f"M={M} convrot={convrot} bias={bias} {act}: max|d|={d.max().item():.4g}"
 
 
 def test_wrapper_fallback_applies_activation(monkeypatch):
@@ -189,13 +207,39 @@ def test_wrapper_rejects_unknown_act():
                                   torch.float32, False, 256, act="sillu")
 
 
+def test_swiglu_rejects_unknown_act():
+    """Mirror of test_wrapper_rejects_unknown_act for the gated kernel: a typo'd
+    activation must raise before any dispatch (CPU tensors, no kernel needed)."""
+    w = torch.randint(-1, 2, (3, 4), dtype=torch.int8)
+    s = torch.tensor([0.01])
+    with pytest.raises(ValueError):
+        patch._int8_swiglu_kernel(torch.randn(2, 4), w, w, s, s,
+                                  None, None, False, 256, act="sillu")
+
+
+def test_swiglu_rejects_none_act():
+    """'none' is a *valid* activation name but meaningless for a gate — it must be
+    rejected (the gate would degenerate to a plain elementwise product)."""
+    w = torch.randint(-1, 2, (3, 4), dtype=torch.int8)
+    s = torch.tensor([0.01])
+    with pytest.raises(ValueError):
+        patch._int8_swiglu_kernel(torch.randn(2, 4), w, w, s, s,
+                                  None, None, False, 256, act="none")
+
+
 # tolerance: one bf16 ulp (rtol=8e-3) + atol=2e-3 near zero — see the point-activation
 # test rationale above and docs/superpowers/results/D-results.md. act=3 (gelu-erf) dropped.
+# 2576 = remainder-K; the (256,2560,convrot=True) case exercises the Hadamard-rotate ->
+# requant path through the fused gate kernel (rotation reshapes the gate magnitude dist,
+# which is where SwiGLU/GEGLU saturation + quant edges live) and keeps its spy guard.
 @requires_int8_ext
 @pytest.mark.parametrize("act", ["silu", "gelu_tanh"])
 @pytest.mark.parametrize("bias", [False, True])
-@pytest.mark.parametrize("M,K", [(1, 2560), (512, 2560), (512, 2576)])  # 2576 = remainder-K
-def test_int8_swiglu_matches_reference(M, K, bias, act):
+@pytest.mark.parametrize(
+    "M,K,convrot",
+    [(1, 2560, False), (512, 2560, False), (512, 2576, False), (256, 2560, True)],
+)
+def test_int8_swiglu_matches_reference(M, K, convrot, bias, act):
     """Fused gate == act(int8_linear(x,Wg)) * int8_linear(x,Wu)."""
     os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
     from _patches.int8_ext import loader
@@ -217,8 +261,8 @@ def test_int8_swiglu_matches_reference(M, K, bias, act):
     bg = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
     bu = torch.randn(N, generator=g, dtype=torch.bfloat16).to(dev) if bias else None
 
-    lin_g = patch._int8_linear_kernel(x, wg, sg, bg, torch.bfloat16, False, 256, act="none")
-    lin_u = patch._int8_linear_kernel(x, wu, su, bu, torch.bfloat16, False, 256, act="none")
+    lin_g = patch._int8_linear_kernel(x, wg, sg, bg, torch.bfloat16, convrot, 256, act="none")
+    lin_u = patch._int8_linear_kernel(x, wu, su, bu, torch.bfloat16, convrot, 256, act="none")
     # The fused gate keeps act(gate) in fp32 registers and multiplies by up in fp32,
     # rounding to bf16 ONCE (that single-rounding is the whole point of fusion). The
     # reference must do the same: torch's INDEPENDENT fp32 activation (not the kernel's
@@ -237,13 +281,13 @@ def test_int8_swiglu_matches_reference(M, K, bias, act):
     saved = patch._orig_int8_linear
     patch._orig_int8_linear = _boom
     try:
-        out = patch._int8_swiglu_kernel(x, wg, wu, sg, su, bg, bu, False, 256, act=act)
+        out = patch._int8_swiglu_kernel(x, wg, wu, sg, su, bg, bu, convrot, 256, act=act)
     finally:
         patch._orig_int8_linear = saved
     torch.mps.synchronize()
     assert out.shape == ref.shape
     assert torch.allclose(out, ref, atol=2e-3, rtol=8e-3), \
-        f"M={M} K={K} {act} bias={bias}: max|d|={(out.float()-ref.float()).abs().max().item():.4g}"
+        f"M={M} K={K} convrot={convrot} {act} bias={bias}: max|d|={(out.float()-ref.float()).abs().max().item():.4g}"
 
 
 @requires_int8_ext

--- a/tests/test_mps_profile_seams.py
+++ b/tests/test_mps_profile_seams.py
@@ -126,18 +126,29 @@ def test_install_wraps_activation_globals(monkeypatch):
     monkeypatch.setenv("ASFP8_PROFILE", "1")
     monkeypatch.setattr(mps_profile, "_installed", False)
 
-    orig_silu = F.silu
-    orig_gelu = F.gelu
-    orig_glu = F.glu
+    # install() globally rebinds the full set of profiled seams (matmul, linear,
+    # sdpa, conv2d/3d, layer_norm, rms_norm, bmm, silu/gelu/glu). Snapshot and
+    # restore *all* of them — restoring only the activations leaks Python timing
+    # wrappers onto torch.matmul/F.linear into later test files, which then makes
+    # torch.compile graph-break and fall back to the CPU C++ inductor backend.
+    _saved_torch = {name: getattr(torch, name) for name in ("matmul", "bmm")}
+    _f_names = [
+        "scaled_dot_product_attention", "linear", "conv2d", "conv3d",
+        "layer_norm", "silu", "gelu", "glu",
+    ]
+    if hasattr(F, "rms_norm"):
+        _f_names.append("rms_norm")
+    _saved_F = {name: getattr(F, name) for name in _f_names}
     try:
         mps_profile.install()
         assert getattr(F.silu, "_asfp8_timed", False), "F.silu not wrapped by install()"
         assert getattr(F.gelu, "_asfp8_timed", False), "F.gelu not wrapped by install()"
         assert getattr(F.glu, "_asfp8_timed", False), "F.glu not wrapped by install()"
     finally:
-        F.silu = orig_silu
-        F.gelu = orig_gelu
-        F.glu = orig_glu
+        for name, fn in _saved_torch.items():
+            setattr(torch, name, fn)
+        for name, fn in _saved_F.items():
+            setattr(F, name, fn)
         monkeypatch.setattr(mps_profile, "_installed", False)
 
 

--- a/tests/test_mps_profile_seams.py
+++ b/tests/test_mps_profile_seams.py
@@ -1,0 +1,379 @@
+# tests/test_mps_profile_seams.py
+"""Unit tests for the G1 additions to mps_profile.py.
+
+Covers:
+  - F.silu / F.gelu / F.glu accumulate into 'activation' bucket on MPS tensors
+  - CPU tensors pass through unwrapped (no stats recorded — _is_mps guard)
+  - install() with ASFP8_PROFILE=1 marks F.silu/F.gelu/F.glu as _asfp8_timed
+  - _try_wrap_rope() finds and wraps module-level RoPE functions by canonical name
+  - _try_wrap_rope() wraps _ideogram4_apply_rope_lowp (KJNodes Ideogram4 path)
+  - _try_wrap_rope() patches alias occurrences by object identity (Pass 2)
+  - Functions whose id() is in _rope_wrapped_ids are not re-wrapped
+  - Already-wrapped functions (_asfp8_timed=True) are not double-wrapped
+  - Callables without __code__ (builtins, partials) are skipped safely
+  - *args-only functions (co_argcount == 0) with __code__ ARE wrapped
+  - No-target scan: _rope_wrapped_ids stays empty when no rope names found
+  - install() is a no-op when ASFP8_PROFILE != 1
+
+All tests are MPS-conditional where required; lazy-scanner tests are CPU-safe.
+"""
+import sys
+import time
+import types
+import functools
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from _patches import mps_profile
+
+requires_mps = pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="requires MPS"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _reset(monkeypatch):
+    """Bring mps_profile back to a clean pre-install state for isolated tests.
+    Suppresses the periodic dump by setting _t_last_dump far in the future."""
+    monkeypatch.setattr(mps_profile, "_stats", {})
+    monkeypatch.setattr(mps_profile, "_rope_wrapped_ids", set())
+    monkeypatch.setattr(mps_profile, "_gguf_wrapped", False)
+    monkeypatch.setattr(mps_profile, "_t_start", time.perf_counter())
+    monkeypatch.setattr(mps_profile, "_t_last_dump", time.perf_counter() + 9999.0)
+
+
+# ---------------------------------------------------------------------------
+# 1. Activation seam — numerics unchanged after wrapping
+# ---------------------------------------------------------------------------
+@requires_mps
+def test_activation_silu_value_unchanged(monkeypatch):
+    _reset(monkeypatch)
+    x = torch.randn(64, 128, device="mps")
+    ref = F.silu(x.clone())
+    wrapped = mps_profile._timed("activation", F.silu)
+    out = wrapped(x)
+    torch.mps.synchronize()
+    assert torch.allclose(out, ref, atol=1e-5), "silu values changed after profiling wrap"
+
+
+@requires_mps
+def test_activation_gelu_value_unchanged(monkeypatch):
+    _reset(monkeypatch)
+    x = torch.randn(64, 128, device="mps")
+    ref = F.gelu(x.clone())
+    wrapped = mps_profile._timed("activation", F.gelu)
+    out = wrapped(x)
+    torch.mps.synchronize()
+    assert torch.allclose(out, ref, atol=1e-5), "gelu values changed after profiling wrap"
+
+
+@requires_mps
+def test_activation_glu_value_unchanged(monkeypatch):
+    _reset(monkeypatch)
+    # F.glu requires last dim to be even; default dim=-1
+    x = torch.randn(64, 128, device="mps")
+    ref = F.glu(x.clone())
+    wrapped = mps_profile._timed("activation", F.glu)
+    out = wrapped(x)
+    torch.mps.synchronize()
+    assert torch.allclose(out, ref, atol=1e-5), "glu values changed after profiling wrap"
+
+
+# ---------------------------------------------------------------------------
+# 2. Activation seam — stats accumulate on MPS, silent on CPU
+# ---------------------------------------------------------------------------
+@requires_mps
+def test_activation_stats_accumulate_on_mps(monkeypatch):
+    _reset(monkeypatch)
+    x = torch.randn(32, 64, device="mps")
+    ws = mps_profile._timed("activation", F.silu)
+    wg = mps_profile._timed("activation", F.gelu)
+    ws(x)
+    wg(x)
+    ws(x)
+    torch.mps.synchronize()
+    assert "activation" in mps_profile._stats, "activation bucket not created"
+    calls, total = mps_profile._stats["activation"]
+    assert calls == 3, f"expected 3 activation calls, got {calls}"
+    assert total > 0.0, "total GPU time should be > 0"
+
+
+def test_activation_cpu_tensor_no_stats(monkeypatch):
+    """Off-MPS tensors must pass through unchanged with no stats recorded."""
+    _reset(monkeypatch)
+    x = torch.randn(16, 32)  # CPU — _is_mps returns False
+    wrapped = mps_profile._timed("activation", F.silu)
+    out = wrapped(x)
+    assert out.shape == x.shape, "shape must be preserved on CPU passthrough"
+    assert "activation" not in mps_profile._stats, "CPU tensor must not record stats"
+
+
+# ---------------------------------------------------------------------------
+# 3. install() seam — F.silu/F.gelu/F.glu are marked _asfp8_timed after install
+# ---------------------------------------------------------------------------
+@requires_mps
+def test_install_wraps_activation_globals(monkeypatch):
+    """install() with ASFP8_PROFILE=1 must mark F.silu/F.gelu/F.glu as _asfp8_timed.
+
+    This test exercises Change 5 (install seam) independently of the _timed tests
+    above. It would fail if the F.* wrapping lines were accidentally omitted from
+    install() even though _timed itself works correctly.
+    """
+    monkeypatch.setenv("ASFP8_PROFILE", "1")
+    monkeypatch.setattr(mps_profile, "_installed", False)
+
+    orig_silu = F.silu
+    orig_gelu = F.gelu
+    orig_glu = F.glu
+    try:
+        mps_profile.install()
+        assert getattr(F.silu, "_asfp8_timed", False), "F.silu not wrapped by install()"
+        assert getattr(F.gelu, "_asfp8_timed", False), "F.gelu not wrapped by install()"
+        assert getattr(F.glu, "_asfp8_timed", False), "F.glu not wrapped by install()"
+    finally:
+        F.silu = orig_silu
+        F.gelu = orig_gelu
+        F.glu = orig_glu
+        monkeypatch.setattr(mps_profile, "_installed", False)
+
+
+# ---------------------------------------------------------------------------
+# 4. Lazy RoPE scanner — canonical names
+# ---------------------------------------------------------------------------
+def test_try_wrap_rope_finds_rope_apply(monkeypatch):
+    """_try_wrap_rope finds rope_apply in a freshly injected module."""
+    _reset(monkeypatch)
+
+    def fake_rope_apply(x, grid_sizes, freqs):
+        return x
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_a")
+    fake_mod.rope_apply = fake_rope_apply
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_a", fake_mod)
+
+    mps_profile._try_wrap_rope()
+
+    assert getattr(fake_mod.rope_apply, "_asfp8_timed", False), (
+        "rope_apply should have been replaced with a _timed('rotary', ...) wrapper"
+    )
+    assert len(mps_profile._rope_wrapped_ids) > 0, (
+        "_rope_wrapped_ids should be non-empty after wrapping rope_apply"
+    )
+
+
+def test_try_wrap_rope_finds_apply_rope(monkeypatch):
+    """Scanner finds apply_rope (Flux / Chroma / Ideogram naming convention)."""
+    _reset(monkeypatch)
+
+    def fake_apply_rope(xq, xk, freqs_cis):
+        return xq, xk
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_b")
+    fake_mod.apply_rope = fake_apply_rope
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_b", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert getattr(fake_mod.apply_rope, "_asfp8_timed", False), (
+        "apply_rope should have been replaced with a _timed wrapper"
+    )
+
+
+def test_try_wrap_rope_finds_apply_rotary_emb(monkeypatch):
+    """Scanner finds apply_rotary_emb (HunyuanVideo / LTX naming)."""
+    _reset(monkeypatch)
+
+    def fake_are(x, freqs_cis):
+        return x
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_c")
+    fake_mod.apply_rotary_emb = fake_are
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_c", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert getattr(fake_mod.apply_rotary_emb, "_asfp8_timed", False)
+
+
+def test_try_wrap_rope_finds_ideogram4_apply_rope_lowp(monkeypatch):
+    """Scanner finds _ideogram4_apply_rope_lowp (KJNodes Ideogram4 RoPE path).
+
+    Without this name in _ROPE_FN_NAMES, the Ideogram4 convrot run would
+    report rotary = 0% even though RoPE ran inside the KJNodes kernel.
+    """
+    _reset(monkeypatch)
+
+    def fake_ideogram4_rope(xq, xk, freqs, rope_2d):
+        return xq, xk
+
+    fake_mod = types.ModuleType("_test_fake_rope_kjnodes")
+    fake_mod._ideogram4_apply_rope_lowp = fake_ideogram4_rope
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_kjnodes", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert getattr(fake_mod._ideogram4_apply_rope_lowp, "_asfp8_timed", False), (
+        "_ideogram4_apply_rope_lowp must be wrapped (KJNodes Ideogram4 RoPE path)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Lazy RoPE scanner — alias/identity scanning (Pass 2)
+# ---------------------------------------------------------------------------
+def test_try_wrap_rope_patches_aliases_by_identity(monkeypatch):
+    """Pass 2 patches all modules holding the same function under an alias name.
+
+    Simulates: wanvideo/modules/model.py does
+        from ... import rope_apply as apply_rope_comfy1
+    then calls apply_rope_comfy1 at lines 441-451.
+    Name-only scanning would leave apply_rope_comfy1 unwrapped.
+    Identity scanning (Pass 2) must patch it too.
+    """
+    _reset(monkeypatch)
+
+    def fake_rope_apply(x, freqs):
+        return x
+
+    source_mod = types.ModuleType("_test_rope_source")
+    source_mod.rope_apply = fake_rope_apply
+    monkeypatch.setitem(sys.modules, "_test_rope_source", source_mod)
+
+    caller_mod = types.ModuleType("_test_rope_caller")
+    caller_mod.apply_rope_comfy1 = fake_rope_apply  # same object, alias name
+    monkeypatch.setitem(sys.modules, "_test_rope_caller", caller_mod)
+
+    mps_profile._try_wrap_rope()
+
+    assert getattr(source_mod.rope_apply, "_asfp8_timed", False), (
+        "source module: rope_apply must be wrapped (Pass 1)"
+    )
+    assert getattr(caller_mod.apply_rope_comfy1, "_asfp8_timed", False), (
+        "caller module: alias apply_rope_comfy1 must be wrapped by identity (Pass 2)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Lazy RoPE scanner — deduplication and edge cases
+# ---------------------------------------------------------------------------
+def test_try_wrap_rope_skips_known_id(monkeypatch):
+    """A function whose id() is in _rope_wrapped_ids is not re-wrapped."""
+    _reset(monkeypatch)
+
+    def fake_rope(x, freqs):
+        return x
+
+    original_fn = fake_rope
+    monkeypatch.setattr(mps_profile, "_rope_wrapped_ids", {id(fake_rope)})
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_d")
+    fake_mod.rope_apply = fake_rope
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_d", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert fake_mod.rope_apply is original_fn, (
+        "function whose id is in _rope_wrapped_ids must not be re-wrapped"
+    )
+
+
+def test_try_wrap_rope_no_double_wrap(monkeypatch):
+    """A function already carrying _asfp8_timed=True must not be re-wrapped."""
+    _reset(monkeypatch)
+
+    def fake_rope(x, freqs):
+        return x
+
+    fake_rope._asfp8_timed = True
+    original_fn = fake_rope
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_e")
+    fake_mod.rope_apply = fake_rope
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_e", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert fake_mod.rope_apply is original_fn, (
+        "already-wrapped function must not be replaced"
+    )
+
+
+def test_try_wrap_rope_skips_callable_without_code(monkeypatch):
+    """A callable without __code__ (functools.partial, builtin) must be skipped."""
+    _reset(monkeypatch)
+
+    fake_rope = functools.partial(lambda x: x)
+    assert not hasattr(fake_rope, "__code__"), "precondition: partial has no __code__"
+
+    fake_mod = types.ModuleType("_test_fake_rope_mod_f")
+    fake_mod.rope_apply = fake_rope
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_mod_f", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert not getattr(fake_mod.rope_apply, "_asfp8_timed", False), (
+        "functools.partial should be skipped (no __code__)"
+    )
+    assert len(mps_profile._rope_wrapped_ids) == 0, (
+        "_rope_wrapped_ids must remain empty when only unqualified callables found"
+    )
+
+
+def test_try_wrap_rope_handles_varargs_function(monkeypatch):
+    """*args-only functions (co_argcount == 0) with __code__ must be wrapped.
+
+    The original co_argcount < 1 guard was wrong: valid RoPE wrappers that
+    use only *args have co_argcount == 0 but have __code__. The correct guard
+    is __code__ is None (builtins/C-extensions), not co_argcount.
+    """
+    _reset(monkeypatch)
+
+    def fake_rope_varargs(*args):
+        return args[0] if args else None
+
+    assert fake_rope_varargs.__code__.co_argcount == 0, (
+        "precondition: *args-only function has co_argcount == 0"
+    )
+
+    fake_mod = types.ModuleType("_test_fake_rope_varargs")
+    fake_mod.rope_apply = fake_rope_varargs
+    monkeypatch.setitem(sys.modules, "_test_fake_rope_varargs", fake_mod)
+
+    mps_profile._try_wrap_rope()
+    assert getattr(fake_mod.rope_apply, "_asfp8_timed", False), (
+        "*args-only function with __code__ should be wrapped (co_argcount guard removed)"
+    )
+
+
+def test_try_wrap_rope_does_not_wrap_when_no_targets(monkeypatch):
+    """_rope_wrapped_ids does not grow when no rope-named callables exist.
+
+    Injects a decoy module with non-rope attribute names, then asserts that
+    neither the decoy function nor its id appears in _rope_wrapped_ids.
+    """
+    _reset(monkeypatch)
+
+    original_fn = lambda x: x  # noqa: E731
+    decoy_mod = types.ModuleType("_test_decoy_no_rope_xyz")
+    decoy_mod.unrelated_function = original_fn
+    monkeypatch.setitem(sys.modules, "_test_decoy_no_rope_xyz", decoy_mod)
+
+    mps_profile._try_wrap_rope()
+
+    # Decoy must be untouched
+    assert decoy_mod.unrelated_function is original_fn, (
+        "non-rope-named function must not be wrapped"
+    )
+    assert id(original_fn) not in mps_profile._rope_wrapped_ids, (
+        "non-target function id must not appear in _rope_wrapped_ids"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. install() guard — no-op without ASFP8_PROFILE=1
+# ---------------------------------------------------------------------------
+def test_install_noop_without_env(monkeypatch):
+    """install() must be a no-op when ASFP8_PROFILE env var is absent or not '1'."""
+    monkeypatch.delenv("ASFP8_PROFILE", raising=False)
+    monkeypatch.setattr(mps_profile, "_installed", False)
+    mps_profile.install()
+    assert mps_profile._installed is False, (
+        "install() should not set _installed without ASFP8_PROFILE=1"
+    )

--- a/tests/test_probe_matmul2d_dtypes.py
+++ b/tests/test_probe_matmul2d_dtypes.py
@@ -16,12 +16,16 @@ _probe = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_probe)
 
 import shutil
+from _patches import _caps
 _NO_MPS = not torch.backends.mps.is_available()
 _NO_TOOLCHAIN = shutil.which("xcrun") is None
 
 pytestmark = [
     pytest.mark.skipif(_NO_MPS, reason="needs MPS device"),
     pytest.mark.skipif(_NO_TOOLCHAIN, reason="needs Xcode CLI tools (xcrun)"),
+    # Match the docstring: a missing ninja toolchain is a legitimate skip, not a build
+    # failure (build_extension() would return None and fail the probe_mod assertion).
+    pytest.mark.skipif(not _caps.ninja_available(), reason="needs ninja to build the ObjC++ extension"),
 ]
 
 

--- a/tests/test_probe_matmul2d_dtypes.py
+++ b/tests/test_probe_matmul2d_dtypes.py
@@ -1,0 +1,68 @@
+"""Pytest for the G2 matmul2d dtype probe.
+
+The probe's table generation is the unit under test. We do NOT skip the suite when a
+candidate fails to compile — a candidate compile failure is a recorded capability finding,
+asserted as a structured row. The ONLY legitimate skips are: no MPS device, or no Xcode/
+ninja toolchain. signed_char is the control + spy: it must compile, run, and match the
+int32 reference EXACTLY (a silent fallback would leave C all-zero and fail this).
+"""
+import pytest
+import torch
+
+import importlib.util, pathlib
+_probe_path = pathlib.Path(__file__).parent.parent / "dev" / "probe_matmul2d_dtypes.py"
+_spec = importlib.util.spec_from_file_location("probe_matmul2d_dtypes", _probe_path)
+_probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_probe)
+
+import shutil
+_NO_MPS = not torch.backends.mps.is_available()
+_NO_TOOLCHAIN = shutil.which("xcrun") is None
+
+pytestmark = [
+    pytest.mark.skipif(_NO_MPS, reason="needs MPS device"),
+    pytest.mark.skipif(_NO_TOOLCHAIN, reason="needs Xcode CLI tools (xcrun)"),
+]
+
+
+@pytest.fixture(scope="module")
+def probe_mod():
+    mod = _probe.build_extension()
+    # Extension build failure is a TEST FAILURE (toolchain/MPS already skip above).
+    assert mod is not None, "ObjC++ host extension failed to build (see stderr)"
+    return mod
+
+
+def test_signed_char_control_runs_exact(probe_mod):
+    """SPY/CONTROL: real int8 kernel must run and match int32 reference exactly."""
+    r = _probe.run_probe(probe_mod, "signed_char")
+    assert r["compile_ok"], f"signed_char compile failed: {r['detail']}"
+    assert r["has_fn"], "signed_char kernel absent — host/template broken"
+    assert r["run_ok"], f"signed_char run failed: {r['detail']}"
+    assert r["exact"], f"signed_char not bit-exact (kernel did not really run?): {r['detail']}"
+    assert r["verdict"] == "PASS", r["detail"]
+
+
+@pytest.mark.parametrize("dtype", _probe.CANDIDATES)
+def test_every_candidate_produces_structured_row(probe_mod, dtype):
+    """Every candidate yields a structured row; verdict is one of the known states."""
+    r = _probe.run_probe(probe_mod, dtype)
+    assert r["verdict"] in {
+        "PASS", "FAIL", "COMPILE_FAIL", "COMPILE_SKIP", "RUN_FAIL"
+    }, f"{dtype}: unexpected verdict {r['verdict']!r}"
+    # If it ran, the spy already enforced C != all-zero inside run_probe before PASS.
+    if r["verdict"] == "PASS":
+        assert r["run_ok"] and r["has_fn"] and r["compile_ok"]
+    # A FAIL/COMPILE_FAIL/RUN_FAIL must carry a non-empty diagnostic.
+    if r["verdict"] in {"FAIL", "COMPILE_FAIL", "RUN_FAIL"}:
+        assert r["detail"], f"{dtype}: {r['verdict']} with no detail"
+
+
+def test_table_generation_covers_all_candidates(probe_mod):
+    """The INVESTIGATION_FACTS section must contain a row for every candidate."""
+    rows = [{"name": d, "res": _probe.run_probe(probe_mod, d)} for d in _probe.CANDIDATES]
+    section = _probe.build_section(rows)
+    for d in _probe.CANDIDATES:
+        assert f"| {d:<12} |" in section, f"missing row for {d}"
+    # W4A8 must NOT be claimed from this matrix (Codex MAJOR 6).
+    assert "NOT W4A8" in section

--- a/tests/test_rope_fast.py
+++ b/tests/test_rope_fast.py
@@ -1,0 +1,250 @@
+import pytest, torch
+from _patches import rope_fast_mps as m
+
+mps = pytest.mark.skipif(not torch.backends.mps.is_available(), reason="needs MPS")
+
+
+@pytest.fixture(autouse=True)
+def _install_rope_fast():
+    m.install_for_test()                  # captures real eager originals into m._orig
+    m._backend_events.clear()
+    try:
+        yield
+    finally:
+        m.uninstall_for_test()
+
+
+def _orig_interleaved(x, fr):
+    """PRIMARY oracle: the captured REAL eager apply_rope1 (computed before any poisoning)."""
+    return m._orig["apply_rope1"](x, fr)
+
+
+def _orig_split_half(x, fr):
+    return m._orig["apply_rope_split_half1"](x, fr)
+
+
+def _shapes():
+    return [(1, 24, 4608, 128), (2, 16, 1024, 64), (1, 1, 37, 16)]   # all rank-4 [B,H,L,D]
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — interleaved kernel vs REAL eager
+# ---------------------------------------------------------------------------
+@mps
+@pytest.mark.parametrize("B,H,L,D", _shapes())
+@pytest.mark.parametrize("dtype,atol,rtol", [
+    (torch.float32, 2e-5, 2e-5),
+    (torch.float16, 3e-3, 3e-3),
+    (torch.bfloat16, 2e-2, 2e-2),
+])
+def test_interleaved_matches_real_eager(B, H, L, D, dtype, atol, rtol):
+    torch.manual_seed(0)
+    x = torch.randn(B, H, L, D, device="mps", dtype=dtype)
+    fr = torch.randn(1, 1, L, D // 2, 2, 2, device="mps", dtype=torch.float32)
+    ref = _orig_interleaved(x, fr)                      # PRIMARY oracle (real eager)
+    m._backend_events.clear()
+    out = m.apply_rope1_fused(x, fr)
+    torch.mps.synchronize()
+    assert m._last_backend() == "kernel", "fell back instead of running the kernel"
+    assert out.dtype == dtype and out.shape == x.shape
+    assert torch.allclose(out.float(), ref.float(), atol=atol, rtol=rtol)
+    # secondary diagnostic vs the formula helper:
+    assert torch.allclose(out.float(), m._reference_interleaved(x, fr).float(), atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — split-half kernel vs REAL eager
+# ---------------------------------------------------------------------------
+@mps
+@pytest.mark.parametrize("B,H,L,D", _shapes())
+@pytest.mark.parametrize("dtype,atol,rtol", [
+    (torch.float32, 2e-5, 2e-5),
+    (torch.bfloat16, 2e-2, 2e-2),
+])
+def test_split_half_matches_real_eager(B, H, L, D, dtype, atol, rtol):
+    torch.manual_seed(1)
+    x = torch.randn(B, H, L, D, device="mps", dtype=dtype)
+    fr = torch.randn(1, 1, L, D // 2, 2, 2, device="mps", dtype=torch.float32)
+    ref = _orig_split_half(x, fr)                       # PRIMARY oracle (real eager)
+    m._backend_events.clear()
+    out = m.apply_rope_split_half1_fused(x, fr)
+    torch.mps.synchronize()
+    assert m._last_backend() == "kernel"
+    assert torch.allclose(out.float(), ref.float(), atol=atol, rtol=rtol)
+    assert torch.allclose(out.float(), m._reference_split_half(x, fr).float(), atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — pair wrappers, cross-length, real public-API dispatch proof
+# ---------------------------------------------------------------------------
+@mps
+def test_pair_cross_length():
+    """xq (Lq) and xk (Lk) share one table; each slices its own prefix (real-eager parity).
+    Per-call trace must show BOTH single-tensor calls took the kernel (MAJOR 5)."""
+    torch.manual_seed(2)
+    B, H, D = 1, 8, 64
+    Lq, Lk = 4096, 512
+    fr = torch.randn(1, 1, Lq, D // 2, 2, 2, device="mps", dtype=torch.float32)
+    xq = torch.randn(B, H, Lq, D, device="mps", dtype=torch.bfloat16)
+    xk = torch.randn(B, H, Lk, D, device="mps", dtype=torch.bfloat16)
+    ref_q = _orig_interleaved(xq, fr)
+    ref_k = _orig_interleaved(xk, fr)                   # real eager, pre-poison
+    m._backend_events.clear()
+    oq, ok = m.apply_rope_fused_pair(xq, xk, fr)
+    torch.mps.synchronize()
+    kinds = [ev[1] for ev in m._backend_events]
+    assert kinds == ["kernel", "kernel"], f"both calls must be kernel, got {kinds}"
+    assert torch.allclose(oq.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
+    assert torch.allclose(ok.float(), ref_k.float(), atol=2e-2, rtol=2e-2)
+
+
+@mps
+@pytest.mark.parametrize("public_name", ["apply_rope1", "apply_rope",
+                                         "apply_rope_split_half1", "apply_rope_split_half"])
+def test_real_public_dispatch_hits_kernel(public_name):
+    """BLOCKER 2: call the REAL comfy_kitchen public API (-> torch.ops -> custom op ->
+    registry.get_implementation -> getattr(eager, name)) and prove our kernel fires. Poison the
+    captured originals so any silent fallback RAISES. Assert kernel for all four ops."""
+    import comfy_kitchen as ck
+    torch.manual_seed(3)
+    x = torch.randn(1, 4, 256, 64, device="mps", dtype=torch.bfloat16)
+    fr = torch.randn(1, 1, 256, 32, 2, 2, device="mps", dtype=torch.float32)
+    poison = lambda *a, **k: (_ for _ in ()).throw(AssertionError("fell back: kernel did not fire"))
+    saved = dict(m._orig)
+    for nm in m._orig:                          # poison ALL single-tensor + pair originals
+        m._orig[nm] = poison
+    m._backend_events.clear()
+    try:
+        if public_name == "apply_rope1":
+            _ = ck.apply_rope1(x, fr)
+        elif public_name == "apply_rope":
+            _ = ck.apply_rope(x, x, fr)
+        elif public_name == "apply_rope_split_half1":
+            _ = ck.apply_rope_split_half1(x, fr)
+        else:
+            _ = ck.apply_rope_split_half(x, x, fr)
+        torch.mps.synchronize()
+    finally:
+        m._orig.update(saved)
+    kinds = [ev[1] for ev in m._backend_events]
+    assert kinds and all(k == "kernel" for k in kinds), \
+        f"{public_name}: expected kernel via real dispatch, got {kinds}"
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — fallback regimes, dtype, cache spy
+# ---------------------------------------------------------------------------
+# (1) VALID-eager but UNSUPPORTED-kernel -> fallback SUCCEEDS and matches real eager.
+@mps
+def test_non_broadcast_table_falls_back_and_matches():
+    """Non-broadcast leading table dims (real B/H) are valid eager but unsupported by the kernel
+    (Open Q #2). Must fall back and produce the SAME result as real eager."""
+    torch.manual_seed(7)
+    B, H, L, D = 2, 4, 128, 64
+    x = torch.randn(B, H, L, D, device="mps", dtype=torch.bfloat16)
+    fr = torch.randn(B, H, L, D // 2, 2, 2, device="mps", dtype=torch.float32)   # leading dims != 1
+    ref = _orig_interleaved(x, fr)               # real eager broadcasts B/H fine
+    m._backend_events.clear()
+    out = m.apply_rope1_fused(x, fr)
+    assert m._last_backend() == "fallback"
+    assert torch.allclose(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+
+
+@mps
+def test_non_fp32_table_falls_back_and_matches():
+    """MAJOR 8: a bf16 freqs_cis table is valid eager but routed to fallback (kernel is fp32-only).
+    Output must match real eager (which multiplies in the table dtype)."""
+    torch.manual_seed(8)
+    x = torch.randn(1, 8, 128, 64, device="mps", dtype=torch.bfloat16)
+    fr = torch.randn(1, 1, 128, 32, 2, 2, device="mps", dtype=torch.bfloat16)
+    ref = _orig_interleaved(x, fr)
+    m._backend_events.clear()
+    out = m.apply_rope1_fused(x, fr)
+    assert m._last_backend() == "fallback"
+    assert torch.allclose(out.float(), ref.float(), atol=3e-2, rtol=3e-2)
+
+
+# (2) GENUINELY MALFORMED -> kernel must NOT dispatch; real eager then legitimately RAISES.
+@mps
+def test_malformed_table_does_not_dispatch_and_raises():
+    """BLOCKER 3 / fused-norm pattern: a wrong-shaped freqs_cis (halfD=16 vs D/2=32) cannot
+    broadcast in real eager. The load-bearing assertion is that we did NOT dispatch the kernel
+    (backend == 'fallback') and that the real eager fallback RAISES -- NOT an allclose."""
+    torch.manual_seed(6)
+    x = torch.randn(1, 8, 128, 64, device="mps", dtype=torch.bfloat16)   # D/2 = 32
+    bad = torch.randn(1, 1, 128, 16, 2, 2, device="mps", dtype=torch.float32)  # halfD = 16 (malformed)
+    m._backend_events.clear()
+    m._backend_events.append(("stale", "kernel", ()))   # stale spy must be overwritten
+    with pytest.raises(Exception):
+        m.apply_rope1_fused(x, bad)                      # validation -> fallback -> real eager raises
+    assert m._last_backend() == "fallback"
+
+
+@mps
+def test_per_call_trace_distinguishes_kernel_then_fallback():
+    """MAJOR 5: the per-call trace must distinguish a kernel call from a fallback call -- a scalar
+    `_last_backend` would only reflect the LAST and could mask an earlier mixed result.
+
+    Note: a genuine [kernel, fallback] mix is NOT reachable through a single pair-wrapper call with
+    a shared table, because the kernel's per-tensor rejections (rank!=4, odd-D, numel==0) are
+    exactly the cases real eager also rejects, and the table-based rejections (non-fp32,
+    non-broadcast) are shared by both tensors. So we drive the two paths with two sequential
+    single-tensor calls: an fp32-table call (kernel) then a bf16-table call (valid eager, kernel
+    fp32-only -> fallback). Both originals stay real so the fallback succeeds."""
+    torch.manual_seed(9)
+    x = torch.randn(1, 8, 256, 64, device="mps", dtype=torch.bfloat16)
+    fr_fp32 = torch.randn(1, 1, 256, 32, 2, 2, device="mps", dtype=torch.float32)   # -> kernel
+    fr_bf16 = torch.randn(1, 1, 256, 32, 2, 2, device="mps", dtype=torch.bfloat16)  # -> fallback
+    m._backend_events.clear()
+    _ = m.apply_rope1_fused(x, fr_fp32)
+    _ = m.apply_rope1_fused(x, fr_bf16)
+    kinds = [ev[1] for ev in m._backend_events]
+    assert kinds == ["kernel", "fallback"], f"per-call trace must catch the split: {kinds}"
+    # a scalar would only show the last ("fallback"); the list preserves both.
+    assert m._last_backend() == "fallback"
+
+
+@mps
+def test_pair_wrapper_records_both_calls():
+    """MAJOR 5 (pair form): a pair-wrapper call must append ONE event per tensor (two total), so a
+    first-call fallback can never be masked by the second. Drive both to fallback with a bf16 table
+    (shared) -> two 'fallback' events; combined with test_pair_cross_length's two 'kernel' events,
+    this proves the trace is per-call, not a scalar."""
+    torch.manual_seed(11)
+    xq = torch.randn(1, 8, 256, 64, device="mps", dtype=torch.bfloat16)
+    xk = torch.randn(1, 8, 128, 64, device="mps", dtype=torch.bfloat16)
+    fr_bf16 = torch.randn(1, 1, 256, 32, 2, 2, device="mps", dtype=torch.bfloat16)
+    ref_q = _orig_interleaved(xq, fr_bf16)
+    ref_k = _orig_interleaved(xk, fr_bf16)
+    m._backend_events.clear()
+    oq, ok = m.apply_rope_fused_pair(xq, xk, fr_bf16)
+    kinds = [ev[1] for ev in m._backend_events]
+    assert kinds == ["fallback", "fallback"], f"pair must record one event per tensor: {kinds}"
+    assert torch.allclose(oq.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
+    assert torch.allclose(ok.float(), ref_k.float(), atol=2e-2, rtol=2e-2)
+
+
+# (3) CPU input -> fallback (valid eager, no MPS dispatch).
+def test_cpu_falls_back():
+    x = torch.randn(1, 2, 8, 16)                   # CPU
+    fr = torch.randn(1, 1, 8, 8, 2, 2)
+    ref = m._orig["apply_rope1"](x, fr)
+    m._backend_events.clear()
+    out = m.apply_rope1_fused(x, fr)
+    assert m._last_backend() == "fallback"
+    assert torch.allclose(out.float(), ref.float(), atol=1e-5)
+
+
+# (4) cache invalidation on in-place table mutation (MAJOR 9).
+@mps
+def test_table_mutation_invalidates_cache():
+    """Mutating the table in place must change the output (no stale id()-keyed data)."""
+    torch.manual_seed(10)
+    x = torch.randn(1, 4, 128, 64, device="mps", dtype=torch.float32)
+    fr = torch.randn(1, 1, 128, 32, 2, 2, device="mps", dtype=torch.float32)
+    out1 = m.apply_rope1_fused(x, fr).clone()
+    fr.mul_(2.0)                                         # in-place mutation bumps _version
+    out2 = m.apply_rope1_fused(x, fr)
+    ref2 = _orig_interleaved(x, fr)
+    assert not torch.allclose(out1.float(), out2.float()), "cache returned stale table"
+    assert torch.allclose(out2.float(), ref2.float(), atol=2e-5, rtol=2e-5)

--- a/tests/test_rope_fast_comfy.py
+++ b/tests/test_rope_fast_comfy.py
@@ -228,3 +228,28 @@ def test_flux_non_broadcast_table_falls_back_and_matches(comfy_patched):
     assert [e[1] for e in _events("flux.apply_rope")] == ["fallback"]
     assert torch.allclose(out_q.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
     assert torch.allclose(out_k.float(), ref_k.float(), atol=2e-2, rtol=2e-2)
+
+
+# --- patch #21b install-gate: the comfy retarget is OPT-IN (default OFF) --------------------
+@mps
+def test_comfy_retarget_off_by_default(monkeypatch):
+    """install() must NOT retarget the real comfy functions unless ASFP8_ROPE_COMFY_RETARGET=1."""
+    monkeypatch.delenv("ASFP8_ROPE_COMFY_RETARGET", raising=False)
+    monkeypatch.delenv("ASFP8_ROPE_FAST", raising=False)  # master gate defaults on
+    hits = []
+    monkeypatch.setattr(m, "_do_install", lambda: True)              # skip the eager reroute
+    monkeypatch.setattr(m, "_install_comfy", lambda: hits.append(1))
+    m.install()
+    assert hits == [], "comfy retarget fired without the opt-in flag"
+
+
+@mps
+def test_comfy_retarget_on_with_flag(monkeypatch):
+    """ASFP8_ROPE_COMFY_RETARGET=1 opts the real-comfy retarget in."""
+    monkeypatch.setenv("ASFP8_ROPE_COMFY_RETARGET", "1")
+    monkeypatch.delenv("ASFP8_ROPE_FAST", raising=False)
+    hits = []
+    monkeypatch.setattr(m, "_do_install", lambda: True)
+    monkeypatch.setattr(m, "_install_comfy", lambda: hits.append(1))
+    m.install()
+    assert hits == [1], "comfy retarget did not fire despite the opt-in flag"

--- a/tests/test_rope_fast_comfy.py
+++ b/tests/test_rope_fast_comfy.py
@@ -1,0 +1,230 @@
+"""Patch #21b spy tests: the fused RoPE kernel retargeted onto the REAL comfy functions the live
+models call (probe 2026-07-01):
+
+  comfy.ldm.flux.math.apply_rope / apply_rope1      -- interleaved 2x2 (split=0)
+  comfy.text_encoders.llama.apply_rope              -- half-split rotate_half, (cos,sin,nsin) tuple
+  comfy.ldm.ideogram4.model.apply_rope              -- SAME object as llama's (alias import)
+
+Oracle = the captured REAL comfy function (m._orig_comfy[...]), computed before the kernel runs.
+Each kernel test also POISONS the captured original so a silent fallback would RAISE -- proving the
+fused kernel actually fired. Requires comfy on sys.path; otherwise the whole module is skipped."""
+import os
+import sys
+import pytest
+import torch
+
+# Locate the installed comfy package (machine-specific; overridable via env). ComfyUI-desktop keeps
+# the code tree outside the repo venv, so it is not importable by default.
+_CANDIDATES = [
+    os.environ.get("ASFP8_COMFY_PATH"),
+    "/Users/pawelma/ComfyUI-Installs/ComfyUI/ComfyUI",
+]
+for _c in _CANDIDATES:
+    if _c and os.path.isdir(os.path.join(_c, "comfy")) and _c not in sys.path:
+        sys.path.insert(0, _c)
+
+fm = pytest.importorskip("comfy.ldm.flux.math")
+ll = pytest.importorskip("comfy.text_encoders.llama")
+from comfy.text_encoders.llama import precompute_freqs_cis  # noqa: E402
+
+from _patches import rope_fast_mps as m  # noqa: E402
+
+mps = pytest.mark.skipif(not torch.backends.mps.is_available(), reason="needs MPS")
+
+
+@pytest.fixture
+def comfy_patched():
+    """Capture + patch the comfy targets, then restore. Leaves m._orig_comfy populated with the REAL
+    functions (the oracle) for the duration of the test."""
+    m._backend_events.clear()
+    m._install_comfy()
+    try:
+        yield
+    finally:
+        m._uninstall_comfy()
+        m._backend_events.clear()
+
+
+def _flux_pe(L, D, device, theta=10000):
+    """comfy flux rotation table: rope()->(1,L,halfD,2,2); unsqueeze(1) for head-broadcast as the
+    live probe saw (1,1,L,halfD,2,2)."""
+    pos = torch.arange(L, device=device).float()[None, :]
+    return fm.rope(pos, D, theta).unsqueeze(1)
+
+
+def _events(name):
+    return [e for e in m._backend_events if e[0] == name]
+
+
+# ---------------------------------------------------------------------------
+# FLUX -- comfy.ldm.flux.math.apply_rope (interleaved 2x2, split=0)
+# ---------------------------------------------------------------------------
+@mps
+@pytest.mark.parametrize("dtype,atol,rtol", [
+    (torch.float32, 2e-5, 2e-5),
+    (torch.bfloat16, 2e-2, 2e-2),
+])
+def test_flux_apply_rope_matches_real(comfy_patched, dtype, atol, rtol):
+    torch.manual_seed(0)
+    B, H, L, D = 1, 32, 512, 128          # probe shape, shorter L for test speed
+    x = torch.randn(B, H, L, D, device="mps", dtype=dtype)
+    pe = _flux_pe(L, D, "mps")
+    ref_q, ref_k = m._orig_comfy["flux.apply_rope"](x.clone(), x.clone(), pe)   # REAL oracle
+    m._backend_events.clear()
+    out_q, out_k = fm.apply_rope(x.clone(), x.clone(), pe)                      # patched -> kernel
+    torch.mps.synchronize()
+    kinds = [e[1] for e in _events("flux.apply_rope")]
+    assert kinds == ["kernel", "kernel"], f"flux pair must run kernel for both, got {kinds}"
+    assert out_q.dtype == dtype and out_q.shape == x.shape
+    assert torch.allclose(out_q.float(), ref_q.float(), atol=atol, rtol=rtol)
+    assert torch.allclose(out_k.float(), ref_k.float(), atol=atol, rtol=rtol)
+
+
+@mps
+def test_flux_apply_rope1_matches_real(comfy_patched):
+    torch.manual_seed(1)
+    B, H, L, D = 1, 24, 256, 128
+    x = torch.randn(B, H, L, D, device="mps", dtype=torch.bfloat16)
+    pe = _flux_pe(L, D, "mps")
+    ref = m._orig_comfy["flux.apply_rope1"](x.clone(), pe)
+    m._backend_events.clear()
+    out = fm.apply_rope1(x.clone(), pe)
+    torch.mps.synchronize()
+    assert [e[1] for e in _events("flux.apply_rope1")] == ["kernel"]
+    assert torch.allclose(out.float(), ref.float(), atol=2e-2, rtol=2e-2)
+
+
+@mps
+def test_flux_kernel_actually_fires_poison(comfy_patched):
+    """Poison the captured REAL flux original so any fallback RAISES; the call must still succeed
+    (kernel fired) and the trace must show kernel."""
+    torch.manual_seed(2)
+    x = torch.randn(1, 32, 256, 128, device="mps", dtype=torch.bfloat16)
+    pe = _flux_pe(256, 128, "mps")
+    poison = lambda *a, **k: (_ for _ in ()).throw(AssertionError("flux fell back: kernel did not fire"))
+    saved = dict(m._orig_comfy)
+    m._orig_comfy["flux.apply_rope"] = poison
+    m._orig_comfy["flux.apply_rope1"] = poison
+    m._backend_events.clear()
+    try:
+        out_q, out_k = fm.apply_rope(x.clone(), x.clone(), pe)
+        torch.mps.synchronize()
+    finally:
+        m._orig_comfy.update(saved)
+    assert [e[1] for e in _events("flux.apply_rope")] == ["kernel", "kernel"]
+
+
+# ---------------------------------------------------------------------------
+# LLAMA / IDEOGRAM4 -- comfy.text_encoders.llama.apply_rope (half-split, (cos,sin,nsin))
+# ---------------------------------------------------------------------------
+@mps
+@pytest.mark.parametrize("dtype,atol,rtol", [
+    (torch.float32, 2e-5, 2e-5),
+    (torch.float16, 3e-3, 3e-3),
+    (torch.bfloat16, 2e-2, 2e-2),
+])
+@pytest.mark.parametrize("head_dim,seq,heads", [(128, 256, 8), (64, 512, 16)])
+def test_llama_apply_rope_matches_real(comfy_patched, dtype, atol, rtol, head_dim, seq, heads):
+    torch.manual_seed(3)
+    pos_ids = torch.arange(seq, device="mps")[None, :]
+    freqs = precompute_freqs_cis(head_dim, pos_ids, 10000.0, device="mps")
+    assert isinstance(freqs, tuple) and len(freqs) == 3      # (cos, sin, nsin)
+    xq = torch.randn(1, heads, seq, head_dim, device="mps", dtype=dtype)
+    xk = torch.randn(1, heads, seq, head_dim, device="mps", dtype=dtype)
+    ref_q, ref_k = m._orig_comfy["llama.apply_rope"](xq.clone(), xk.clone(), freqs)   # REAL oracle
+    m._backend_events.clear()
+    out_q, out_k = ll.apply_rope(xq.clone(), xk.clone(), freqs)
+    torch.mps.synchronize()
+    kinds = [e[1] for e in _events("llama.apply_rope")]
+    assert kinds == ["kernel", "kernel"], f"llama pair must run kernel for both, got {kinds}"
+    assert out_q.dtype == dtype and out_q.shape == xq.shape
+    assert torch.allclose(out_q.float(), ref_q.float(), atol=atol, rtol=rtol)
+    assert torch.allclose(out_k.float(), ref_k.float(), atol=atol, rtol=rtol)
+
+
+@mps
+def test_llama_kernel_actually_fires_poison(comfy_patched):
+    torch.manual_seed(4)
+    head_dim, seq, heads = 128, 256, 8
+    pos_ids = torch.arange(seq, device="mps")[None, :]
+    freqs = precompute_freqs_cis(head_dim, pos_ids, 10000.0, device="mps")
+    xq = torch.randn(1, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+    xk = torch.randn(1, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+    poison = lambda *a, **k: (_ for _ in ()).throw(AssertionError("llama fell back: kernel did not fire"))
+    saved = dict(m._orig_comfy)
+    m._orig_comfy["llama.apply_rope"] = poison
+    m._backend_events.clear()
+    try:
+        _ = ll.apply_rope(xq, xk, freqs)
+        torch.mps.synchronize()
+    finally:
+        m._orig_comfy.update(saved)
+    assert [e[1] for e in _events("llama.apply_rope")] == ["kernel", "kernel"]
+
+
+@mps
+def test_ideogram4_alias_is_retargeted():
+    """comfy.ldm.ideogram4.model.apply_rope IS llama.apply_rope (alias import). _install_comfy must
+    reroute it by object identity, and the rerouted fn must run the kernel and match the real llama
+    apply_rope."""
+    ig = pytest.importorskip("comfy.ldm.ideogram4.model")
+    assert ig.apply_rope is ll.apply_rope, "precondition: ideogram4 imports llama's apply_rope"
+    real = ll.apply_rope
+    m._backend_events.clear()
+    m._install_comfy()
+    try:
+        assert ig.apply_rope is m._llama_apply_rope_fused, "alias not rerouted by identity"
+        assert ig.apply_rope is not real
+        head_dim, seq, heads = 128, 128, 4
+        pos_ids = torch.arange(seq, device="mps")[None, :]
+        freqs = precompute_freqs_cis(head_dim, pos_ids, 10000.0, device="mps")
+        xq = torch.randn(1, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+        xk = torch.randn(1, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+        ref_q, ref_k = m._orig_comfy["llama.apply_rope"](xq.clone(), xk.clone(), freqs)
+        m._backend_events.clear()
+        out_q, out_k = ig.apply_rope(xq.clone(), xk.clone(), freqs)   # via ideogram alias
+        torch.mps.synchronize()
+        assert [e[1] for e in _events("llama.apply_rope")] == ["kernel", "kernel"]
+        assert torch.allclose(out_q.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
+        assert torch.allclose(out_k.float(), ref_k.float(), atol=2e-2, rtol=2e-2)
+    finally:
+        m._uninstall_comfy()
+        # identity restore
+        assert ig.apply_rope is real, "uninstall must restore the alias"
+
+
+# ---------------------------------------------------------------------------
+# Fallback regimes -- valid comfy, unsupported kernel -> fall back & match real
+# ---------------------------------------------------------------------------
+@mps
+def test_llama_true_batch_falls_back_and_matches(comfy_patched):
+    """A real batch>1 freqs table (cos rows = B*L != L) cannot use the kernel's row%L indexing.
+    Must fall back to the real comfy apply_rope and match it exactly."""
+    torch.manual_seed(5)
+    head_dim, seq, heads, B = 128, 64, 4, 2
+    pos_ids = torch.arange(seq, device="mps")[None, :].expand(B, -1).contiguous()
+    freqs = precompute_freqs_cis(head_dim, pos_ids, 10000.0, device="mps")
+    xq = torch.randn(B, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+    xk = torch.randn(B, heads, seq, head_dim, device="mps", dtype=torch.bfloat16)
+    ref_q, ref_k = m._orig_comfy["llama.apply_rope"](xq.clone(), xk.clone(), freqs)
+    m._backend_events.clear()
+    out_q, out_k = ll.apply_rope(xq.clone(), xk.clone(), freqs)
+    assert [e[1] for e in _events("llama.apply_rope")] == ["fallback"]
+    assert torch.allclose(out_q.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
+    assert torch.allclose(out_k.float(), ref_k.float(), atol=2e-2, rtol=2e-2)
+
+
+@mps
+def test_flux_non_broadcast_table_falls_back_and_matches(comfy_patched):
+    """A flux pe with real (non-1) batch/head leading dims is valid comfy but unsupported by the
+    kernel -> fall back and match."""
+    torch.manual_seed(6)
+    B, H, L, D = 2, 4, 128, 64
+    x = torch.randn(B, H, L, D, device="mps", dtype=torch.bfloat16)
+    pe = torch.randn(B, H, L, D // 2, 2, 2, device="mps", dtype=torch.float32)  # leading dims != 1
+    ref_q, ref_k = m._orig_comfy["flux.apply_rope"](x.clone(), x.clone(), pe)
+    m._backend_events.clear()
+    out_q, out_k = fm.apply_rope(x.clone(), x.clone(), pe)
+    assert [e[1] for e in _events("flux.apply_rope")] == ["fallback"]
+    assert torch.allclose(out_q.float(), ref_q.float(), atol=2e-2, rtol=2e-2)
+    assert torch.allclose(out_k.float(), ref_k.float(), atol=2e-2, rtol=2e-2)

--- a/tests/test_scaled_mm_fp8.py
+++ b/tests/test_scaled_mm_fp8.py
@@ -131,8 +131,29 @@ def test_fast_ineligible_non_mps(monkeypatch):
     assert scaled_mm_fp8._fast_eligible(inp, other) is False
 
 
-def test_fast_ineligible_when_opt_out(monkeypatch):
+def test_fast_ineligible_when_explicitly_off(monkeypatch):
+    # Explicit opt-out wins over capability + shape, even on supported hardware.
+    from _patches import _caps
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setenv("ASFP8_FP8_EXT", "off")
+    inp, other = _operands(K=12288, N=3072)
+    assert scaled_mm_fp8._fast_eligible(inp, other) is False
+
+
+def test_default_on_when_capable(monkeypatch):
+    # DEFAULT ON: unset + Tier-B capable -> eligible (no explicit flag needed).
+    from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    inp, other = _operands(K=12288, N=3072)
+    assert scaled_mm_fp8._fast_eligible(inp, other) is True
+
+
+def test_default_off_when_not_capable(monkeypatch):
+    # DEFAULT gated: unset + unsupported hardware -> inert (the promise).
+    from _patches import _caps
+    monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
+    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
     inp, other = _operands(K=12288, N=3072)
     assert scaled_mm_fp8._fast_eligible(inp, other) is False
 

--- a/tests/test_torch_compile_fusion.py
+++ b/tests/test_torch_compile_fusion.py
@@ -1,0 +1,247 @@
+"""Tests for Issue A: torch.compile (Inductor MPS) fusion sweep.
+
+Correctness tests only — timing is in dev/bench_torch_compile_fusion.py.
+
+Tests are skipped on non-MPS machines. The compile step is guarded with
+try/except: if Inductor MPS raises BackendCompilerFailed (immature backend),
+the test is skipped with reason="inductor MPS compile failed" rather than
+crashing the test runner. Never fatal.
+
+NOTE: Do NOT run with ASFP8_PROFILE=1 — the mps_profile wrappers
+(F.rms_norm, F.linear, torch.matmul, etc.) are not transparent to Dynamo
+and will introduce graph breaks that mask the real fusion result.
+"""
+import pytest
+import torch
+import torch.nn.functional as F
+
+_MPS = pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="needs MPS"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_inputs(B=2, S=4096, D=1536, seed=0, device="mps", dtype=torch.float16):
+    """Return (x, weight, W) for the representative DiT-block tail."""
+    g = torch.Generator(device=device).manual_seed(seed)
+    x = torch.randn(B, S, D, device=device, dtype=dtype, generator=g)
+    weight = torch.randn(D, device=device, dtype=dtype, generator=g)
+    W = torch.randn(D, D, device=device, dtype=dtype, generator=g)
+    return x, weight, W
+
+
+def _bw_tail(x, weight, W):
+    """Bandwidth-bound tail only: rms_norm + silu + residual (NO linear).
+
+    This is the sub-chain where fusion delivers maximum benefit. The linear
+    is excluded because it is compute-bound and breaks the pointwise fusion
+    chain — measured separately in the full-block test.
+    """
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = F.silu(h)
+    return x + h
+
+
+def _full_block(x, weight, W):
+    """Full DiT block tail: rms_norm -> linear -> silu -> residual."""
+    h = F.rms_norm(x, (x.shape[-1],), weight, 1e-6)
+    h = (h.reshape(-1, h.shape[-1]) @ W.T).reshape(x.shape)
+    h = F.silu(h)
+    return x + h
+
+
+def _try_compile(fn, **compile_kwargs):
+    """Compile fn with Inductor MPS. Returns (compiled_fn, error_str_or_None)."""
+    try:
+        compiled = torch.compile(fn, backend="inductor", **compile_kwargs)
+        return compiled, None
+    except Exception as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# A.1.a — bandwidth-bound tail (no linear): compiled matches eager
+# ---------------------------------------------------------------------------
+
+@_MPS
+def test_bw_tail_compiled_matches_eager():
+    """rms_norm + silu + residual: Inductor MPS compiled output must match eager.
+
+    Tolerance: atol=1e-2, rtol=1e-2 (empirical fp16 fusion noise for this chain).
+    Also asserts against manual fp32 reference to verify rms_norm accumulation.
+    """
+    x, weight, W = _make_inputs()
+
+    compiled_fn, err = _try_compile(_bw_tail)
+    if err is not None:
+        pytest.skip(f"inductor MPS compile failed — hand-kernels D/E at full scope. Error: {err}")
+
+    eager_out = _bw_tail(x, weight, W)
+    # First call compiles; second call uses the cached kernel.
+    _ = compiled_fn(x, weight, W)
+    compiled_out = compiled_fn(x, weight, W)
+    torch.mps.synchronize()
+
+    assert compiled_out.shape == eager_out.shape, (
+        f"shape mismatch: compiled={compiled_out.shape} eager={eager_out.shape}"
+    )
+
+    # Primary: compiled vs eager fp16
+    torch.testing.assert_close(
+        compiled_out, eager_out, atol=1e-2, rtol=1e-2,
+        msg=lambda m: f"compiled vs eager fp16: {m}",
+    )
+
+    # Secondary: compiled vs fp32 reference for rms_norm accumulation
+    x_cpu = x.float().cpu()
+    w_cpu = weight.float().cpu()
+    eps = 1e-6
+    rms_ref_cpu = (
+        x_cpu * torch.rsqrt(x_cpu.pow(2).mean(-1, keepdim=True) + eps)
+        * w_cpu
+    )
+    rms_ref_cpu = torch.sigmoid(rms_ref_cpu) * rms_ref_cpu  # silu
+    ref_fp32 = x_cpu + rms_ref_cpu
+    compiled_cpu = compiled_out.float().cpu()
+    torch.testing.assert_close(
+        compiled_cpu, ref_fp32, atol=5e-2, rtol=5e-2,
+        msg=lambda m: f"compiled vs fp32 manual reference: {m}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# A.1.b — full block (with linear): compiled matches eager
+# ---------------------------------------------------------------------------
+
+@_MPS
+def test_full_block_compiled_matches_eager():
+    """Full block (rms_norm -> linear -> silu -> residual): same correctness check."""
+    x, weight, W = _make_inputs()
+
+    compiled_fn, err = _try_compile(_full_block)
+    if err is not None:
+        pytest.skip(f"inductor MPS compile failed (full block). Error: {err}")
+
+    eager_out = _full_block(x, weight, W)
+    _ = compiled_fn(x, weight, W)
+    compiled_out = compiled_fn(x, weight, W)
+    torch.mps.synchronize()
+
+    # GEMM (h @ W.T) accumulates larger fp16 errors than norm+act alone.
+    # bw_tail (no GEMM) passes at atol=1e-2; full_block needs atol=0.1 for GEMM noise.
+    # 0.07 absolute difference is within normal fp16 1536-wide matmul bounds.
+    torch.testing.assert_close(
+        compiled_out, eager_out, atol=0.1, rtol=0.1,
+        msg=lambda m: f"full_block compiled vs eager: {m}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# A.1.c — fullgraph=True: confirm no graph breaks AND compile actually succeeds
+# ---------------------------------------------------------------------------
+
+@_MPS
+def test_bw_tail_no_graph_breaks():
+    """Verify 0 graph breaks via dynamo.explain AND fullgraph=True compile succeeds.
+
+    graph_count == 1 from explain() is necessary but not sufficient (does not
+    prove fullgraph=True will succeed or that Inductor emits a fused kernel).
+    Both checks are performed:
+      1. dynamo.explain: graph_count == 1
+      2. torch.compile(..., fullgraph=True): compiles and runs without error
+    """
+    import torch._dynamo as dynamo
+
+    x, weight, W = _make_inputs()
+
+    # Check 1: dynamo.explain graph count
+    explanation = dynamo.explain(_bw_tail)(x, weight, W)
+    assert explanation.graph_count == 1, (
+        f"Expected 1 graph (no breaks), got {explanation.graph_count}. "
+        f"Break reasons: {[str(r) for r in explanation.break_reasons]}"
+    )
+
+    # Check 2: fullgraph=True compile + execute
+    torch._dynamo.reset()
+    compiled_fg, err = _try_compile(_bw_tail, fullgraph=True)
+    if err is not None:
+        pytest.fail(
+            f"dynamo.explain showed graph_count=1 but fullgraph=True FAILED. "
+            f"Error: {err}"
+        )
+    out = compiled_fg(x, weight, W)
+    torch.mps.synchronize()
+    assert out is not None, "fullgraph=True compile returned None output"
+
+
+# ---------------------------------------------------------------------------
+# A.1.d — correctness at small shapes (fast, no-warmup shapes for CI)
+# ---------------------------------------------------------------------------
+
+@_MPS
+@pytest.mark.parametrize("B,S,D", [
+    (1, 256, 512),
+    (2, 1024, 768),
+    (1, 4096, 1536),  # production DiT shape
+])
+def test_bw_tail_shapes(B, S, D):
+    """Correctness across a range of shapes including the production shape."""
+    x, weight, W = _make_inputs(B=B, S=S, D=D)
+
+    # Reset Dynamo state before the one compile to avoid shape cache pollution.
+    torch._dynamo.reset()
+    compiled_fn, err = _try_compile(_bw_tail)
+    if err is not None:
+        pytest.skip(f"compile failed: {err}")
+
+    eager_out = _bw_tail(x, weight, W)
+    _ = compiled_fn(x, weight, W)
+    compiled_out = compiled_fn(x, weight, W)
+    torch.mps.synchronize()
+
+    torch.testing.assert_close(
+        compiled_out, eager_out, atol=1e-2, rtol=1e-2,
+        msg=lambda m: f"B={B} S={S} D={D}: {m}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# A.1.e — fp16 rms_norm precision: stress inputs + fp32 reference comparison
+# ---------------------------------------------------------------------------
+
+@_MPS
+def test_compiled_rms_norm_fp32_reference():
+    """Compiled rms_norm must not deviate from fp32 reference on stress inputs.
+
+    Uses large-magnitude inputs (x10 scale) to amplify fp16 vs fp32 difference.
+    Absence of NaN on random data is not evidence of fp32 accumulation.
+    """
+    x, weight, W = _make_inputs()
+
+    compiled_fn, err = _try_compile(_bw_tail)
+    if err is not None:
+        pytest.skip(f"compile failed: {err}")
+
+    # Large-magnitude stress input
+    x_stress = x * 10.0
+    _ = compiled_fn(x_stress, weight, W)
+    compiled_out = compiled_fn(x_stress, weight, W)
+    torch.mps.synchronize()
+
+    assert not torch.isnan(compiled_out).any(), "NaN in compiled output on stress inputs"
+    assert not torch.isinf(compiled_out).any(), "Inf in compiled output on stress inputs"
+
+    # fp32 reference for the rms_norm step
+    xf = x_stress.float().cpu()
+    wf = weight.float().cpu()
+    eps = 1e-6
+    h_ref = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps) * wf
+    h_ref = torch.sigmoid(h_ref) * h_ref  # silu
+    ref_out = xf + h_ref
+
+    torch.testing.assert_close(
+        compiled_out.float().cpu(), ref_out, atol=5e-2, rtol=5e-2,
+        msg=lambda m: f"compiled vs fp32 manual ref (stress inputs): {m}",
+    )


### PR DESCRIPTION
## Summary

Brings the Apple Silicon **FP8/INT8 acceleration** work on `integration/asfp8-accel` to a mergeable state. The compatibility layer (FP8/INT8 models that used to crash on MPS now run) plus the bit-exact Metal matmul / fused-norm / RoPE / conv kernels are all here; the **capstone in this final commit** flips every performance patch to **default-on, gated on the hardware/software that can actually run it** — honoring the promise that a fix only engages where it's supported.

## The gating model (new `_patches/_caps.py`)

A single three-state env gate shared by every perf patch:
- **unset** → on iff a memoized capability probe passes
- **`off`/`0`** → force off
- **`1`/`on`** → force on (power-user override; the kernel's own loader still no-ops if it can't build)

Capability tiers:
- **A** `has_compile_shader()` — fp32 kernels, no Metal-4.1 needed → **#18 fused RMSNorm**, **#21 fused RoPE**
- **B** `has_tensor_ops_matmul2d()` (reuses the proven `na_gemm` matmul2d compile) → **#19 conv3d im2col**
- **B + ninja** `tier_b_ready()` — ObjC++ `cpp_extension` kernels → **#3 fp8_ext**, **#17 int8 W8A8**, **#20 fp8-native Linear**

`__init__.py` prints a one-line capability banner at startup so users see which tier is active.

### Flag changes
| Patch | Was | Now |
|---|---|---|
| #18 / #21 / #17 / #3 | opt-in `=1` | default-on, `=off` to disable |
| #20 / #19 | default-on, ungated | default-on, capability-gated |
| **#21b** (retarget onto real comfy flux/llama rope) | rode #21's gate, no control | **opt-in behind new `ASFP8_ROPE_COMFY_RETARGET=1`** |

On M1–M4 / older macOS the Tier-B kernels self-detect as unsupported and never build — no failed-compile noise, no config.

## Versioning + ComfyUI Manager

- `pyproject.toml` **1.1.0 → 1.2.0**, `[tool.comfy].Icon` wired to a new self-contained `icon.svg`.
- `.comfyignore` keeps session docs / dev / tests out of the published package.
- `.github/workflows/publish_action.yml` auto-publishes to the Comfy Registry on every `pyproject.toml` version bump to `main` (requires a one-time `REGISTRY_ACCESS_TOKEN` repo secret).

## Testing

- New `tests/test_caps.py` pins the three-state gate contract (host-side, CI-safe).
- The two tests that asserted "no-op when unset" now assert the explicit-off / capability-gated contract; added #21b opt-in gate tests.
- **Full suite: 215 passed, 42 skipped** (M5 Max / macOS 27 / torch 2.11).
- Live ComfyUI-style import smoke: banner correct, Tier-A patches active, Tier-B no-ops gracefully when unsupported.

## Notes for review

- README rewritten so default-on/gating and every flag are documented.
- Behavior on unsupported hardware is unchanged (patches stay inert); only supported machines see new default-active kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-aware acceleration for Apple Silicon, including optimized FP8/INT8 matmul, convolution, normalization, and rotary embedding operations.
  * Added automatic runtime fallbacks to preserve compatibility when hardware or inputs are unsupported.
  * Added environment controls to enable, disable, or selectively activate acceleration features.
  * Added automated package publishing and a cleaner published distribution.

* **Documentation**
  * Updated installation, acceleration, configuration, verification, and compatibility guidance.
  * Updated project metadata and version to 1.2.0.

* **Bug Fixes**
  * Improved activation handling, kernel validation, fallback behavior, and profiling coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->