### PR TITLE
fix(ci): unbreak Comfy Registry publish (pinned comfy-cli, drop stale action)

### DIFF
--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -37,8 +37,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Publish custom node
-        # Pinned to a full commit SHA (supply-chain hardening); bump deliberately.
-        uses: Comfy-Org/publish-node-action@7578cdb0c1410f2515e6f9b1443c6859cab94f05  # 1.0.1
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+          python-version: "3.12"
+      # Publish via comfy-cli directly rather than Comfy-Org/publish-node-action:
+      # that wrapper is just `pip install comfy-cli; comfy env; comfy node publish`,
+      # but it hasn't been updated since 2025-05 and its release tag runs a comfy-cli
+      # flag (`--yes`) that current comfy-cli rejects. Pinning the CLI ourselves keeps
+      # this reproducible and immune to the wrapper's drift. Bump the pin deliberately.
+      - name: Install comfy-cli
+        run: pip install "comfy-cli==1.12.0"
+      - name: Publish to Comfy Registry
+        env:
+          COMFY_REGISTRY_TOKEN: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+        run: |
+          comfy --skip-prompt --no-enable-telemetry env
+          comfy node publish --token "$COMFY_REGISTRY_TOKEN"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-applesilicon-fp8"
 description = "Run FP8 and INT8 quantized models (FLUX, SD3.5, Ideogram 4, Krea2) on Apple Silicon / MPS — compatibility fixes plus bit-exact fp8/int8 Metal matmul kernels, plus a psutil fix for recent macOS betas."
-version = "1.2.0"
+version = "1.2.1"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
The 1.2.0 publish job failed with `No such option: --yes`. The action I pinned (`Comfy-Org/publish-node-action@7578cdb` / 1.0.1, 2024) runs `comfy --yes env`, which current `comfy-cli` no longer accepts.

That action is just a thin wrapper (`pip install comfy-cli; comfy env; comfy node publish`) and hasn't been updated since **2025-05** — even its `main` is 14 months stale. So instead of pinning to its main HEAD and re-litigating this on every comfy-cli flag change, this **inlines comfy-cli directly, pinned to `1.12.0`** (released 2026-07, verified locally that `comfy --skip-prompt --no-enable-telemetry env` and `comfy node publish --token <str>` are current).

- **No third-party action** now — only `actions/checkout` + `actions/setup-python`. (Nicely, this also retires the earlier 'unpinned third-party action' security finding.)
- Token passed via **env** (`COMFY_REGISTRY_TOKEN`), not inline.
- Bump `1.2.0 → 1.2.1` so merging re-fires the publish with a clean version (1.2.0 never reached the registry).

Merge → the job installs comfy-cli 1.12.0 and publishes 1.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing process to use a pinned Comfy CLI version with telemetry disabled.
  * Improved registry publishing configuration using a dedicated registry token.

* **Release**
  * Incremented the package version to 1.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->