### PR TITLE
fix: int8 kernel routing + once-at-load dequant

### DIFF
--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -307,10 +307,20 @@ def _try_int8_kernel_forward(self, input):
         w = self.weight
         if not isinstance(w, QuantizedTensor) or getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
             return None
+        # Offloaded weight (comfy parks it on CPU between uses): fall back to the
+        # comfy forward, which casts it in. Reaching _int8_linear_kernel with a
+        # CPU weight would throw in its own fallback and latch mark_kernel_failed,
+        # killing the kernel for the session over a transient condition.
+        if w.device.type != "mps":
+            return None
         if getattr(self, "_full_precision_mm", False):
             return None
-        if getattr(self, "comfy_force_cast_weights", False):
-            return None
+        # comfy_force_cast_weights on an int8 QuantizedTensor only means "storage
+        # dtype != compute dtype, cast at use" -- and for a quantized weight that
+        # cast IS the per-call W8A16 dequant/un-rotation this path exists to
+        # bypass, so it must not disqualify the kernel route. (MiniMax Music 3's
+        # text encoder sets it on every layer, which silently forced the slow
+        # path for the whole model.)
         if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
             return None
 
@@ -339,6 +349,130 @@ def _try_int8_kernel_forward(self, input):
                   f"for the rest of this session.")
         _caps.mark_kernel_failed("int8")
         return None
+
+
+_DEQUANT_MODE = None
+
+
+def _dequant_enabled():
+    """Opt-in gate for once-at-load weight dequant: ASFP8_INT8_DEQUANT=1 enables,
+    subject to a >= 48 GiB total-RAM safety check; unset or off stays off.
+
+    Opt-in because the plain copy (~16 GB for an 8B int8 model) lands AFTER
+    comfy's model_management has budgeted around the loaded int8 size, so
+    auto-enabling near the threshold risks thrash/OOM comfy can't see coming."""
+    global _DEQUANT_MODE
+    if _DEQUANT_MODE is None:
+        import os
+        v = os.environ.get("ASFP8_INT8_DEQUANT", "").strip().lower()
+        _DEQUANT_MODE = False
+        if v in ("1", "on", "true"):
+            try:
+                import psutil
+                _DEQUANT_MODE = psutil.virtual_memory().total >= 48 * (1 << 30)
+                if not _DEQUANT_MODE:
+                    print(f"{TAG} ASFP8_INT8_DEQUANT=1 ignored: needs >= 48 GiB RAM "
+                          f"for the dequantised weight copy.")
+            except Exception:
+                _DEQUANT_MODE = False
+    return _DEQUANT_MODE
+
+
+def _maybe_dequant_weight(self, input):
+    """One-off per layer: replace an eligible int8 QuantizedTensor weight with its
+    dequantised (un-rotated) plain tensor in the compute dtype, resident on MPS.
+
+    Rationale: single-token AR decode is memory-bandwidth-bound, and every
+    quantised route (kernel W8A8 or comfy's per-call W8A16 dequant) pays a
+    per-call rotate/quant/rescale op chain whose MPS dispatch overhead dominates
+    at M=1..2 (measured 3-10x the matmul cost on MiniMax Music 3 AR decode).
+    Paying the dequant once and running single-dispatch F.linear is both faster
+    and numerically identical to comfy's stock W8A16 path. fp16 weights with a
+    different compute dtype get the same treatment: manual_cast otherwise copies
+    the full tensor every call (MiniMax's 134 MB audio_heads dominate a decode
+    profile through aten::copy_)."""
+    if getattr(self, "_asfp8_deq_done", False):
+        return
+    try:
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        # Transient conditions (properties of this call's input) leave the flag
+        # unset so a later MPS-resident call can still dequantise. Everything
+        # past the flag is a stable property of the layer, decided once.
+        if not isinstance(input, torch.Tensor) or isinstance(input, QuantizedTensor):
+            return
+        if input.device.type != "mps":
+            return
+        # Half-precision compute only: an fp32 activation would balloon the
+        # dequantised copy to 2x the size the >= 48 GiB gate budgets for.
+        if input.dtype not in (torch.float16, torch.bfloat16):
+            return
+        self._asfp8_deq_done = True
+        if getattr(self, "_full_precision_mm", False):
+            return
+        if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
+            return
+
+        w = self.weight
+        if isinstance(w, QuantizedTensor):
+            if getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
+                return
+            if getattr(w._params, "transposed", False):
+                return
+            plain = w.dequantize()
+        elif isinstance(w, torch.Tensor) and w.dtype == torch.float16 and w.dtype != input.dtype:
+            plain = w.detach()
+        else:
+            return
+        if plain.dtype != input.dtype:
+            plain = plain.to(input.dtype)
+        if plain.device.type != "mps":
+            plain = plain.to("mps")
+        self.weight = torch.nn.Parameter(plain.contiguous(), requires_grad=False)
+        b = getattr(self, "bias", None)
+        if isinstance(b, torch.Tensor) and not isinstance(b, QuantizedTensor) and b.dtype != input.dtype:
+            self.bias = torch.nn.Parameter(b.detach().to(device="mps", dtype=input.dtype), requires_grad=False)
+        self.comfy_force_cast_weights = False
+    except Exception as e:
+        # Latch on failure too: retrying an identical dequant every call would
+        # just repeat the error (and the print) for the rest of the session.
+        self._asfp8_deq_done = True
+        print(f"{TAG} weight dequant skipped ({e!r})")
+
+
+def _maybe_dequant_embedding(self, dtype_hint):
+    """One-off per Embedding: replace an int8 QuantizedTensor (or fp16) table with
+    a plain tensor in the compute dtype so per-call cast/dequant of the whole
+    table disappears (cast_bias_weight casts the full weight every lookup)."""
+    if getattr(self, "_asfp8_deq_done", False):
+        return
+    try:
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = self.weight
+        # Off-MPS is transient (offload); leave the flag unset for a later call.
+        if w is None or w.device.type != "mps":
+            return
+        self._asfp8_deq_done = True
+        if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
+            return
+        # The hint comes from Embedding.forward's out_dtype (kwarg or first
+        # positional); anything that isn't a half-precision dtype is ignored,
+        # not trusted (same memory-budget reasoning as _maybe_dequant_weight).
+        if dtype_hint not in (torch.float16, torch.bfloat16):
+            dtype_hint = None
+        target = dtype_hint if dtype_hint is not None else torch.bfloat16
+        if isinstance(w, QuantizedTensor):
+            plain = w.dequantize().to(target)
+        elif isinstance(w, torch.Tensor) and w.dtype == torch.float16 and w.dtype != target:
+            plain = w.detach().to(target)
+        else:
+            return
+        self.weight = torch.nn.Parameter(plain.contiguous(), requires_grad=False)
+        self.comfy_force_cast_weights = False
+    except Exception as e:
+        self._asfp8_deq_done = True
+        print(f"{TAG} embedding dequant skipped ({e!r})")
 
 
 def install():
@@ -382,6 +516,8 @@ def install():
                 orig_forward = linear_cls.forward
 
                 def forward(self, input, *args, **kwargs):
+                    if _dequant_enabled():
+                        _maybe_dequant_weight(self, input)
                     res = _try_int8_kernel_forward(self, input)
                     if res is not None:
                         return res
@@ -389,18 +525,49 @@ def install():
 
                 linear_cls.forward = forward
                 linear_cls._asfp8_int8_patched = True
+            emb_cls = getattr(cls, "Embedding", None)
+            if emb_cls is not None and not getattr(emb_cls, "_asfp8_int8_patched", False):
+                orig_emb_forward = emb_cls.forward
+
+                def emb_forward(self, input, *args, **kwargs):
+                    if _dequant_enabled():
+                        hint = kwargs.get("out_dtype", args[0] if args else None)
+                        _maybe_dequant_embedding(self, hint)
+                    return orig_emb_forward(self, input, *args, **kwargs)
+
+                emb_cls.forward = emb_forward
+                emb_cls._asfp8_int8_patched = True
             return cls
 
         wrapped_factory._asfp8_wrapped = True
         ops.mixed_precision_ops = wrapped_factory
+
+        # down_proj is invoked via ops.linear_input_act (fused swiglu path), which
+        # reads linear.weight directly and never calls Linear.forward -- so the
+        # once-at-load dequant must hook here too or those layers stay int8.
+        # getattr, not attribute access: a comfy without linear_input_act must not
+        # abort install() here -- mixed_precision_ops is already wrapped above and
+        # the except below would leave _installed False with a misleading message.
+        orig_lia = getattr(ops, "linear_input_act", None)
+        if orig_lia is not None and not getattr(orig_lia, "_asfp8_deq_wrapped", False):
+            def linear_input_act(linear, x, input_act):
+                if _dequant_enabled():
+                    _maybe_dequant_weight(linear, x)
+                return orig_lia(linear, x, input_act)
+
+            linear_input_act._asfp8_deq_wrapped = True
+            ops.linear_input_act = linear_input_act
     except Exception as e:
         print(f"{TAG} could not wrap mixed_precision_ops: {e!r}")
         return
 
     _installed = True
+    deq = "on" if _dequant_enabled() else "off"
     print(
         f"{TAG} INT8 convrot Linear seam installed on MPS (clean W8A8: "
         f"rotate->per-row quant->int8 matmul; weight-only fp32 dequant/un-rotation "
         f"bypassed). The kernel builds and runs its bit-exact self-check on the "
-        f"first int8 layer, and only routes if that passes."
+        f"first int8 layer, and only routes if that passes. "
+        f"Once-at-load weight dequant: {deq} (opt-in: ASFP8_INT8_DEQUANT=1, "
+        f"needs >= 48 GiB RAM)."
     )

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -723,3 +723,121 @@ def test_install_banner_does_not_claim_an_unverified_kernel(monkeypatch, capsys)
     out = capsys.readouterr().out
     assert "routed through" not in out, f"banner claims a result it hasn't got: {out}"
     assert "self-check" in out.lower(), f"banner doesn't mention verification: {out}"
+
+
+@requires_mps
+def test_force_cast_weights_does_not_disqualify_the_kernel(monkeypatch):
+    """comfy sets comfy_force_cast_weights on int8 layers where storage dtype !=
+    compute dtype; for a QuantizedTensor that cast is the per-call W8A16 dequant
+    this kernel bypasses, so the flag must not push the layer off the kernel route
+    (regression: it silently forced MiniMax Music 3's whole TE onto the slow path)."""
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_kernel", object(), raising=False)
+    monkeypatch.setattr(patch, "_kernel_tried", True, raising=False)
+    monkeypatch.setattr(patch, "_self_checked", True, raising=False)
+    monkeypatch.setattr(patch, "_self_ok", True, raising=False)
+
+    out = torch.full((1,), 7.0)
+    monkeypatch.setattr(patch, "_int8_linear_kernel", lambda *a, **k: out, raising=False)
+
+    qw = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    ).to("mps")
+
+    class Holder:
+        weight = qw
+        bias = None
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    x = torch.randn(8, 128, dtype=torch.bfloat16, device="mps")
+    assert patch._try_int8_kernel_forward(Holder(), x) is out, (
+        "comfy_force_cast_weights pushed an int8 layer off the kernel route"
+    )
+
+
+@requires_mps
+def test_dequant_retries_after_a_transient_off_mps_call(monkeypatch):
+    """An off-MPS first call must not latch _asfp8_deq_done: the same layer can be
+    called later with MPS input (offload/warmup) and should still dequantise then."""
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", True, raising=False)
+
+    qw = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    ).to("mps")
+
+    class Holder:
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    layer = Holder()
+    layer.weight = qw
+    layer.bias = None
+
+    patch._maybe_dequant_weight(layer, torch.randn(1, 128, dtype=torch.bfloat16))
+    assert isinstance(layer.weight, QuantizedTensor), "dequantised from a CPU-input call"
+    assert not getattr(layer, "_asfp8_deq_done", False), "off-MPS call latched the flag"
+
+    x = torch.randn(1, 128, dtype=torch.bfloat16, device="mps")
+    patch._maybe_dequant_weight(layer, x)
+    assert not isinstance(layer.weight, QuantizedTensor), "MPS call did not dequantise"
+    assert layer.weight.dtype == torch.bfloat16
+    assert layer.weight.device.type == "mps"
+    assert layer._asfp8_deq_done is True
+
+    ref = qw.dequantize().to(torch.bfloat16)
+    assert torch.equal(layer.weight.detach().cpu(), ref.cpu()), (
+        "dequantised weight differs from QuantizedTensor.dequantize()"
+    )
+
+
+# --- the ASFP8_INT8_DEQUANT gate: the switch people actually touch --------------
+
+
+def _resolve_dequant_gate(monkeypatch, env, total_ram):
+    import psutil
+
+    class _VM:
+        total = total_ram
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", None, raising=False)
+    if env is None:
+        monkeypatch.delenv("ASFP8_INT8_DEQUANT", raising=False)
+    else:
+        monkeypatch.setenv("ASFP8_INT8_DEQUANT", env)
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: _VM())
+    return patch._dequant_enabled()
+
+
+def test_dequant_gate_is_opt_in(monkeypatch):
+    """Unset stays OFF regardless of RAM: the plain copy lands after comfy's
+    model_management has already budgeted around the int8 size."""
+    assert _resolve_dequant_gate(monkeypatch, None, 128 * (1 << 30)) is False
+
+
+def test_dequant_gate_off_stays_off(monkeypatch):
+    assert _resolve_dequant_gate(monkeypatch, "off", 128 * (1 << 30)) is False
+
+
+def test_dequant_gate_on_with_enough_ram(monkeypatch):
+    assert _resolve_dequant_gate(monkeypatch, "1", 128 * (1 << 30)) is True
+
+
+def test_dequant_gate_ram_check_overrides_opt_in(monkeypatch, capsys):
+    """=1 on a small box is refused (safety), and says so."""
+    assert _resolve_dequant_gate(monkeypatch, "1", 16 * (1 << 30)) is False
+    assert "48 GiB" in capsys.readouterr().out
+
+
+def test_dequant_gate_memoises(monkeypatch):
+    """The gate resolves once; later env changes don't flip a live session."""
+    assert _resolve_dequant_gate(monkeypatch, "1", 128 * (1 << 30)) is True
+    monkeypatch.setenv("ASFP8_INT8_DEQUANT", "off")
+    assert patch._dequant_enabled() is True


### PR DESCRIPTION
Two changes to the int8 MPS path, found profiling MiniMax Music 3's text encoder (8B AR model, int8 convrot):

- Fix: `comfy_force_cast_weights` disqualified the int8 kernel route. On a quantized weight it just means storage != compute dtype; MiniMax's TE sets it on every layer, so the kernel never ran.
- Feat: once-at-load weight dequant to plain MPS tensors (`ASFP8_INT8_DEQUANT`, on when RAM >= 48 GiB). AR decode at M=1 is dispatch-bound; per-call quant chains lose to a single `F.linear`. Same numerics as comfy's stock W8A16 path, ~15 GB extra unified memory.

|                       | Before       | After                      | Speedup |
| --------------------- | ------------ | -------------------------- | ------- |
| AR decode             | 1.33 s/frame | ~0.07 s/frame (10-11 it/s) | ~19x    |
| 60s song text-encode  | ~35 min      | ~2 min                     | ~17x    |

- Tested on M5 Max 128GB, macOS 26.6.1, torch 2.13.0. 
- Test failures identical to clean v1.3.1 (pre-existing fp8/MSL 4.1 environment issues)

## Summary by Sourcery

Improve MPS int8 inference by restoring eligible kernel routing and adding an opt-in load-time dequantization path for dispatch-bound workloads.

New Features:
- Add opt-in once-at-load dequantization of eligible int8 linear and embedding weights for faster MPS inference on systems with at least 48 GiB of RAM.

Bug Fixes:
- Allow int8 MPS kernel routing when comfy_force_cast_weights is set, while avoiding kernel attempts for offloaded CPU weights.

Enhancements:
- Support dequantization for fused linear-input-activation paths and preserve retries after transient off-MPS calls.

Tests:
- Add MPS regression coverage for force-cast kernel routing and transient offload handling, plus unit tests for the dequantization opt-in and RAM safety gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved INT8 acceleration on Apple MPS devices for supported linear and embedding layers.
  * Added automatic weight preparation when needed, based on configuration and available unified memory.
  * Layers using forced weight casting can now use the optimized MPS path.

* **Bug Fixes**
  * Resolved compatibility issues that previously prevented certain layers from using MPS INT8 acceleration.
  * Improved recovery when weight preparation is temporarily attempted outside an MPS device.

* **Diagnostics**
  * Installation logging now indicates whether automatic dequantization is enabled and whether it is overridden by configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->