### PR TITLE
fix(fp8): keep LoRA re-quant on the GPU (#29)

### DIFF
--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -19,10 +19,21 @@ Step 3 crashes on MPS via two possible sub-paths:
      manual_stochastic_round_to_float8 returns a float16 MPS tensor;
      copy_ then has to convert float16→FP8 on-device — also unsupported.
 
-Fix: wrap comfy.float.stochastic_rounding so that, when the input is on
-MPS and the target dtype is FP8, the entire computation is moved to CPU
-(where FP8 casts are fully supported). The resulting FP8 CPU tensor is
-then moved back to MPS — storage works fine.
+Fix: wrap comfy.float.stochastic_rounding and keep the work on the GPU where
+possible. Only the *last* step of the re-quant is unsupported on MPS — the
+float→FP8 cast — and patch #8 (tensor_to_fp8) already routes that single op via
+a LUT/CPU hop, so on path (a) the whole function runs on MPS and returns
+byte-identical FP8.
+
+Path (b) still needs the old treatment: it writes through
+``output[i:].copy_(...)``, a strided FP8 copy patch #8 does not cover (it wraps
+``.to``, not ``copy_``). So we try the native path once, and latch onto the CPU
+round-trip for the session if it raises.
+
+This matters because LoRA application re-quantises every weight it touches.
+Sending each one to the CPU in full measured ~5.6x slower at per-weight
+granularity (11.3 → 2.0 ms/weight, M5 Max), which is why loading an fp8 DiT with
+a LoRA took 80–200 s while the same model without one loaded fast (issue #29).
 
 The same module's `to_blocked` needs the same treatment (issue #8). It is the
 swizzle at the end of the NVFP4 *quantize* direction, which an ordinary NVFP4
@@ -56,6 +67,46 @@ TAG = "[AppleSilicon-FP8/stochastic_round]"
 
 _installed = False
 
+# None = untried, True = the GPU path works here, False = this stack needs the CPU
+# round-trip. Latched: a LoRA re-quantises every weight it touches, so probing per
+# weight would put the exception cost straight back on the path #29 is about.
+_native_ok = None
+
+
+def _requant(original, value, dtype, seed=0):
+    """Re-quantise `value` to an fp8 `dtype`, keeping the maths on the GPU if it can.
+
+    Only ONE step of the re-quant has no MPS kernel -- the final float->fp8 cast.
+    Patch #8 (tensor_to_fp8) already routes that single op via a LUT/CPU hop, so
+    on a stack where it is installed the whole function runs on the GPU and
+    returns byte-identical fp8. Sending the entire tensor to the CPU instead, as
+    this patch did from S1 until #29, costs ~5.6x at per-weight granularity
+    (11.3 -> 2.0 ms/weight on an M5 Max) and is why loading an fp8 DiT with a
+    LoRA took minutes while the same model without one loaded fast.
+
+    The CPU round-trip stays reachable because it is still needed: comfy's own
+    fallback implementation writes through ``output[i:].copy_(...)``, a strided
+    fp8 copy that patch #8 does not cover (it wraps ``.to``, not ``copy_``).
+    """
+    global _native_ok
+    if value.device.type != "mps" or dtype not in FP8_DTYPES:
+        return original(value, dtype, seed=seed)
+
+    if _native_ok is not False:
+        try:
+            out = original(value, dtype, seed=seed)
+            _native_ok = True
+            return out
+        except Exception as e:
+            if _native_ok is None:
+                print(f"{TAG} fp8 re-quant cannot run on MPS here ({e!r}); "
+                      f"using the CPU round-trip for the rest of this session.")
+            _native_ok = False
+
+    # float->fp8 casts are fully supported on CPU; the fp8 result moves back as
+    # plain storage, which MPS handles.
+    return original(value.cpu(), dtype, seed=seed).to(value.device)
+
 
 def install():
     global _installed
@@ -79,12 +130,7 @@ def install():
     _original = float_mod.stochastic_rounding
 
     def _mps_safe_stochastic_rounding(value, dtype, seed=0):
-        if value.device.type == "mps" and dtype in FP8_DTYPES:
-            # Perform the full rounding on CPU where float→FP8 casts are
-            # supported, then move the FP8 result back to MPS for storage.
-            cpu_result = _original(value.cpu(), dtype, seed=seed)
-            return cpu_result.to(value.device)
-        return _original(value, dtype, seed=seed)
+        return _requant(_original, value, dtype, seed)
 
     float_mod.stochastic_rounding = _mps_safe_stochastic_rounding
 

--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -73,20 +73,40 @@ _installed = False
 _native_ok = None
 
 
+def _is_transient(e):
+    """Memory pressure rather than a missing kernel.
+
+    Worth separating: a missing fp8 kernel is a property of the stack and will
+    fail for every weight, so latching is right. An allocator failure is a
+    property of the moment, and condemning the session to the 4.6x-slower path
+    over one of them would be the same silent regression #29 was.
+    """
+    oom = getattr(torch, "OutOfMemoryError", None)
+    if oom is not None and isinstance(e, oom):
+        return True
+    return "out of memory" in str(e).lower()
+
+
 def _requant(original, value, dtype, seed=0):
     """Re-quantise `value` to an fp8 `dtype`, keeping the maths on the GPU if it can.
 
-    Only ONE step of the re-quant has no MPS kernel -- the final float->fp8 cast.
-    Patch #8 (tensor_to_fp8) already routes that single op via a LUT/CPU hop, so
-    on a stack where it is installed the whole function runs on the GPU and
-    returns byte-identical fp8. Sending the entire tensor to the CPU instead, as
-    this patch did from S1 until #29, costs ~5.6x at per-weight granularity
-    (11.3 -> 2.0 ms/weight on an M5 Max) and is why loading an fp8 DiT with a
-    LoRA took minutes while the same model without one loaded fast.
+    Which operations lack an MPS kernel depends on which implementation comfy
+    calls, and the two differ:
 
-    The CPU round-trip stays reachable because it is still needed: comfy's own
-    fallback implementation writes through ``output[i:].copy_(...)``, a strided
-    fp8 copy that patch #8 does not cover (it wraps ``.to``, not ``copy_``).
+    - comfy_kitchen's ``stochastic_rounding_fp8`` has exactly one, the final
+      float->fp8 cast, and patch #8 (tensor_to_fp8) already routes that single op
+      via a LUT/CPU hop -- so wherever patch #8 is installed the whole function
+      runs on the GPU and returns byte-identical fp8.
+    - comfy's own fallback has a different one: it writes through
+      ``output[i:].copy_(...)``, a strided fp8 copy patch #8 does NOT cover (it
+      wraps ``.to``, not ``copy_``), so that path genuinely needs the CPU.
+
+    Since we cannot tell which one this stack will run, try the GPU once and
+    latch onto the CPU round-trip for the session if it raises. Sending every
+    tensor to the CPU unconditionally, as this patch did from S1 until #29, costs
+    ~4.6x at per-weight granularity (11.1 -> 2.4 ms/weight on an M5 Max) and is
+    why loading an fp8 DiT with a LoRA took minutes while the same model without
+    one loaded fast.
     """
     global _native_ok
     if value.device.type != "mps" or dtype not in FP8_DTYPES:
@@ -98,6 +118,13 @@ def _requant(original, value, dtype, seed=0):
             _native_ok = True
             return out
         except Exception as e:
+            # Deliberately broad. The alternative -- re-raising what we don't
+            # recognise -- turns a logged slowdown into a failed model load, and
+            # every fp8 path in this node is a compatibility shim whose first
+            # duty is not to break the load. The exception is reported, not
+            # swallowed, and the CPU result below is bit-exact either way.
+            if _is_transient(e):
+                return original(value.cpu(), dtype, seed=seed).to(value.device)
             if _native_ok is None:
                 print(f"{TAG} fp8 re-quant cannot run on MPS here ({e!r}); "
                       f"using the CPU round-trip for the rest of this session.")

--- a/tests/test_stochastic_round_fp8.py
+++ b/tests/test_stochastic_round_fp8.py
@@ -115,3 +115,33 @@ def test_native_requant_is_bit_exact_vs_the_cpu_round_trip():
     assert torch.equal(
         native.cpu().view(torch.uint8), reference.cpu().view(torch.uint8)
     ), "GPU re-quant differs from the CPU round-trip it replaces"
+
+
+@requires_mps
+@pytest.mark.parametrize("exc", [
+    torch.OutOfMemoryError("MPS backend out of memory (MPS allocated: 90.00 GB)"),
+    RuntimeError("MPS backend out of memory (MPS allocated: 90.00 GB)"),
+])
+def test_a_transient_oom_does_not_condemn_the_session(exc):
+    """Memory pressure is not a missing kernel. Latching the whole session onto
+    the 4.6x-slower path because one weight hit the allocator would be the same
+    silent regression #29 was -- the next weight must try the GPU again."""
+    calls = []
+
+    def original(value, dtype, seed=0):
+        calls.append(value.device.type)
+        if value.device.type == "mps" and len(calls) == 1:
+            raise exc
+        return torch.zeros(value.shape, dtype=dtype, device=value.device)
+
+    x = torch.randn(64, device="mps")
+
+    first = patch._requant(original, x, torch.float8_e4m3fn, 0)
+    second = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert first.device.type == "mps", "the failed weight must still get a result"
+    assert second.device.type == "mps"
+    assert calls == ["mps", "cpu", "mps"], (
+        f"expected a per-call fallback then a fresh GPU attempt, got {calls}"
+    )
+    assert patch._native_ok is not False, "a transient OOM latched the session off the GPU"

--- a/tests/test_stochastic_round_fp8.py
+++ b/tests/test_stochastic_round_fp8.py
@@ -1,0 +1,117 @@
+"""Tests for patch #7: FP8 re-quant on MPS (LoRA applied to an fp8 base model).
+
+Issue #29: loading an fp8 DiT with a LoRA took 80-200s, while the same model with
+no LoRA loaded fast and int8 convrot was unaffected. LoRA application re-quantises
+every weight it touches, and this patch was sending each of those to the CPU in
+full -- because ONE operation inside the re-quant, the final float->fp8 cast, has
+no MPS kernel. Patch #8 (tensor_to_fp8) already routes exactly that cast via a
+LUT/CPU hop, so the rest of the maths can stay on the GPU. Measured 5.6x at
+per-weight granularity (11.3 -> 2.0 ms/weight), bit-exact.
+
+The CPU round-trip has to stay reachable: comfy's own fallback implementation
+writes through `output[i:].copy_(...)`, a strided fp8 copy that patch #8 does not
+cover (it wraps `.to`, not `copy_`).
+"""
+import torch
+
+import pytest
+
+from conftest import requires_mps
+
+from _patches import stochastic_round_fp8 as patch
+
+
+@pytest.fixture(autouse=True)
+def _forget_native_probe(monkeypatch):
+    """The native/CPU verdict is memoised per session; don't leak it between tests."""
+    monkeypatch.setattr(patch, "_native_ok", None, raising=False)
+
+
+def _recorder(fail_on_mps=False):
+    """Stand-in for comfy.float.stochastic_rounding that records operand devices."""
+    seen = []
+
+    def original(value, dtype, seed=0):
+        seen.append(value.device.type)
+        if fail_on_mps and value.device.type == "mps":
+            raise TypeError("Trying to convert Float8_e4m3fn to the MPS backend")
+        return torch.zeros(value.shape, dtype=dtype, device=value.device)
+
+    original.seen = seen
+    return original
+
+
+@requires_mps
+def test_native_mps_path_is_preferred():
+    """The whole point of #29: don't ship the tensor to the CPU when the GPU can
+    do the maths and patch #8 can handle the one unsupported cast."""
+    original = _recorder()
+    x = torch.randn(256, device="mps")
+
+    out = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen == ["mps"], f"re-quant left the GPU: {original.seen}"
+    assert out.device.type == "mps"
+
+
+@requires_mps
+def test_falls_back_to_the_cpu_round_trip_when_native_raises():
+    """comfy's own fallback implementation writes through a strided fp8 copy_,
+    which patch #8 doesn't cover -- that path still needs the CPU hop."""
+    original = _recorder(fail_on_mps=True)
+    x = torch.randn(256, device="mps")
+
+    out = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen == ["mps", "cpu"], f"expected a CPU retry: {original.seen}"
+    assert out.device.type == "mps", "result must come back to the caller's device"
+    assert out.dtype is torch.float8_e4m3fn
+
+
+@requires_mps
+def test_a_failed_native_path_is_not_retried_per_weight():
+    """A LoRA re-quantises every weight it touches. Re-raising and re-catching on
+    each one would put the exception cost back on the hot path #29 is about."""
+    original = _recorder(fail_on_mps=True)
+    x = torch.randn(256, device="mps")
+
+    for _ in range(5):
+        patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen.count("mps") == 1, (
+        f"native path retried {original.seen.count('mps')}x across 5 weights"
+    )
+    assert original.seen.count("cpu") == 5
+
+
+def test_non_fp8_targets_are_passed_straight_through():
+    original = _recorder()
+    x = torch.randn(16)
+
+    patch._requant(original, x, torch.bfloat16, 0)
+
+    assert original.seen == ["cpu"]
+
+
+@requires_mps
+def test_native_requant_is_bit_exact_vs_the_cpu_round_trip():
+    """The anchor for the whole change: moving the maths back onto the GPU must
+    not move the numbers. Compared byte-for-byte in the stored fp8 encoding."""
+    import comfy_kitchen.backends.eager.quantization as q
+    from _patches import tensor_to_fp8
+
+    tensor_to_fp8.install()   # supplies the float->fp8 cast the GPU path needs
+
+    rng = torch.rand(8192, dtype=torch.float16)
+
+    def original(value, dtype, seed=0):
+        return q.stochastic_rounding_fp8(value, rng.to(value.device), dtype)
+
+    x = (torch.randn(8192) * 3).to("mps")
+
+    native = patch._requant(original, x, torch.float8_e4m3fn, 0)
+    reference = original(x.cpu(), torch.float8_e4m3fn).to("mps")
+
+    assert torch.equal(
+        native.cpu().view(torch.uint8), reference.cpu().view(torch.uint8)
+    ), "GPU re-quant differs from the CPU round-trip it replaces"


### PR DESCRIPTION
Closes #29.

Loading an fp8 DiT with a LoRA took 80–200 s; the same model with no LoRA loaded fast, and int8 convrot was unaffected. LoRA application re-quantises every weight it touches, and patch #7 sent each of those to the CPU in full.

It only ever needed to dodge one operation. Of everything comfy's fp8 re-quant does — `log2`, `floor`, `clamp`, `where`, the mantissa calc — only the final `float→fp8` cast has no MPS kernel. Patch #8 (`tensor_to_fp8`) has routed exactly that cast via a LUT/CPU hop since S1, but patch #7 wraps the *outer* call, so it short-circuited to the CPU before patch #8 could ever see the cast. Two of our own patches solving the same problem, and the more expensive one won.

Confirmed directly:

```
bare MPS       -> TypeError: Trying to convert Float8_e4m3fn to the MPS backend
with patch #8  -> works, dtype=float8_e4m3fn, device=mps:0, bit-exact vs the CPU path
```

## Measured (M5 Max, 3.5M-param weights, through the patched seam)

| | per weight | per 1200 weights |
|---|---|---|
| CPU round-trip (before) | 11.10 ms | 13.3 s |
| GPU path (after) | 2.43 ms | 2.9 s |

**4.6×**, bit-exact — the test compares both paths byte-for-byte in the stored fp8 encoding.

## Why the CPU path stays

comfy has two sub-paths here. comfy_kitchen's `stochastic_rounding_fp8` runs fine on MPS once patch #8 supplies the cast. comfy's own fallback writes through `output[i:].copy_(...)` — a strided fp8 copy that patch #8 does *not* cover, since it wraps `.to`, not `copy_`. Which one a given stack takes isn't knowable up front, so we try the GPU path once and latch onto the CPU round-trip for the session if it raises. Latched rather than probed per call because a LoRA touches every weight, and re-raising on each would put the exception cost back on the hot path this fixes.

The `to_blocked` half of patch #7 is unrelated NVFP4 work and is untouched.

## Tests

Patch #7 had none. Now five: GPU path preferred; CPU fallback when native raises; a failed native path not retried per weight; non-fp8 targets passed through; and the anchor — GPU and CPU results byte-identical.

372 passed, 3 skipped on M5 Max / macOS 27 / torch 2.11.

## Caveat

This model predicts ~15–40 s of re-quant for a 12B DiT, and @rsamerica reports 80–200 s. So this is a large component but may not be all of it — worth their measurement on the real workload before we call #29 closed.

## Summary by Sourcery

Prefer GPU-based FP8 re-quantization for MPS LoRA workflows while retaining compatible CPU fallbacks and recovery for transient memory failures.

Bug Fixes:
- Keep FP8 LoRA re-quantization on MPS when the native path is supported, avoiding unnecessary full CPU round-trips.
- Fall back to CPU re-quantization when the MPS implementation is unsupported while preserving transient out-of-memory recovery.

Enhancements:
- Cache the native-path capability decision per session to avoid repeated exception overhead during multi-weight LoRA application.

Tests:
- Add coverage for GPU preference, CPU fallback, capability caching, non-FP8 passthrough, transient OOM handling, and byte-identical GPU/CPU FP8 results.