### PR TITLE
Release/v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,24 @@ are satisfied:
 - **GPU:** the **int8** kernel needs Metal 4 cooperative TensorOps; the **fp8**
   kernel needs Metal 4.1's fp8 format type — in practice an **M5**.
 
-**How the probe actually decides.** There is no chip-model check anywhere in the
-code. The gate is `tier_b_ready()`: it (a) tries to compile a small
-`mpp::tensor_ops::matmul2d` Metal shader via `torch.mps.compile_shader` and (b)
-looks for `ninja`. Both must succeed. Because (a) depends on your macOS, Metal
-SDK and PyTorch build as much as on the GPU, the answer is not strictly "M5 =
-yes, M1–M4 = no": an M5 on some stacks probes `tensor_ops=no`, and an M4 on a
-recent macOS + PyTorch nightly has probed `tensor_ops=yes`. The startup log's
-`capabilities:` line prints exactly what your machine resolved to — trust that
-over the chip name.
+**How the gate actually decides.** Two cheap checks, then a real one. The gate
+(`kernel_gate()`) reads the chip name from `sysctl machdep.cpu.brand_string` and
+requires an **M5 or newer** plus `ninja`; a chip it cannot identify is allowed
+through rather than blocked. That only decides whether a build is *worth
+attempting*. What actually enables a kernel is the kernel itself: it builds, runs
+`warmup()`, and checks its output against a reference matmul, and the answer —
+including a failure — is remembered for the session.
 
-**M1 / M2 / M3 / M4 — nothing to do.** These normally fail the tensor-ops probe,
-so the M5-class matmul kernels stay inert and never build. You still get the full
+Until v1.3.2 the gate instead compiled a Metal shader through
+`torch.mps.compile_shader`. That call cannot request an MSL language version, so
+its result tracked your PyTorch build rather than your GPU, and it was wrong in
+both directions: `yes` on an M4 Pro where the int8 kernel computes garbage
+([#25](https://github.com/pawel-mazurkiewicz/ComfyUI-AppleSilicon-FP8/issues/25)),
+`no` on an M5 Max where the same kernel is bit-exact and 3.17x faster
+([#27](https://github.com/pawel-mazurkiewicz/ComfyUI-AppleSilicon-FP8/issues/27)).
+
+**M1 / M2 / M3 / M4 — nothing to do.** These have no Neural Accelerators, so the
+M5-class matmul kernels stay inert and never build. You still get the full
 compatibility layer plus the compile_shader speedups that *don't* need Metal 4.1
 (fused RMSNorm #18, fused RoPE #21): FP8 matmuls run accelerated via bf16 decode
 on `simdgroup_matrix`, and int8 runs comfy's (fixed) weight-only path.
@@ -190,7 +196,7 @@ At startup you'll see a capability summary (which acceleration tier is active on
 your machine), then only the patch lines relevant to it:
 
 ```
-[AppleSilicon-FP8] capabilities: macOS=27.0, torch=2.11.0, mps=yes, compile_shader=yes, tensor_ops(M5/Metal4)=yes, ninja=yes
+[AppleSilicon-FP8] capabilities: macOS=27.0, torch=2.11.0, mps=yes, compile_shader=yes, chip=Apple M5 Max, matrix_units(M5+)=yes, ninja=yes
 [AppleSilicon-FP8/psutil] psutil.virtual_memory() is broken on this OS — installed vm_stat fallback (...).
 [AppleSilicon-FP8/comfy_kitchen] patched comfy_kitchen eager FP8 dequantize/quantize for MPS.
 [AppleSilicon-FP8/scaled_mm] torch._scaled_mm FP8 on MPS via LUT decode + bf16 matrix-unit matmul. F.scaled_mm (v2 seam) wrapped too.
@@ -205,20 +211,21 @@ your machine), then only the patch lines relevant to it:
 [AppleSilicon-FP8/te_device] text_encoder_device redirected CPU->MPS on Apple Silicon (LLM/CLIP encoders run on GPU).
 [AppleSilicon-FP8/int_mm] torch._int_mm runs on GPU (float32) on MPS instead of falling back to CPU (INT8 models).
 [AppleSilicon-FP8/int8_linear] int8-fast wide-batch matmul routed via MPS native bf16 GEMM (was fp32 _int_mm).
-[AppleSilicon-FP8/int8_kernel] INT8 convrot Linear routed through bit-exact Metal kernel on MPS (clean W8A8; weight-only fp32 dequant/un-rotation bypassed).
+[AppleSilicon-FP8/int8_kernel] INT8 convrot Linear seam installed on MPS (clean W8A8; weight-only fp32 dequant/un-rotation bypassed). The kernel builds and runs its bit-exact self-check on the first int8 layer, and only routes if that passes.
 [AppleSilicon-FP8/int4_linear] ConvRot W4A4 (int4) Linear on MPS -> W4A16 rotated-basis fast path.
 [AppleSilicon-FP8/conv] conv im2col+matmul2d active on MPS (ranks=[3], tile=384MB).
 [AppleSilicon-FP8/rope-fast] fused RoPE active on MPS (eager apply_rope/apply_rope_split_half rerouted; interleaved + split-half; fp32 math, no Metal-4.1/M5 requirement).
 [AppleSilicon-FP8/mlx_textgen] TextGenerate routed through MLX on Apple Silicon (qwen3vl_4b -> mlx-community/Qwen3-VL-4B-Instruct-4bit; gemma3_12b -> mlx-community/gemma-3-12b-it-qat-abliterated-lm-4bit).
 ```
 
-> **Note:** the first line is the capability probe — `tensor_ops(M5/Metal4)` and
-> `ninja` both `yes` is what unlocks the fp8/int8 matmul kernels (#3/#17/#20). The
-> `conv` / `fused-norm` / `rope-fast` lines appear wherever their tier is
-> supported (conv needs Metal 4; fused-norm and rope-fast need only
-> `compile_shader`). The `int8_kernel` / fp8-native lines appear on an M5 with the
-> toolchain + `ninja`; elsewhere those patches silently stay inert and int8 stays
-> on comfy's weight-only path. The `mlx_textgen` line appears only when `mlx-vlm`
+> **Note:** the first line is the capability summary — `matrix_units(M5+)` and
+> `ninja` both `yes` is what lets the fp8/int8 matmul kernels (#3/#17/#20) attempt
+> their build; each still has to pass its own self-check before it routes
+> anything. The `conv` / `fused-norm` / `rope-fast` lines appear wherever their
+> tier is supported (conv needs a working `compile_shader` tensor-ops shader;
+> fused-norm and rope-fast need only `compile_shader`). The `int8_kernel` /
+> fp8-native lines appear on an M5 with the toolchain + `ninja`; elsewhere those
+> patches silently stay inert and int8 stays on comfy's weight-only path. The `mlx_textgen` line appears only when `mlx-vlm`
 > is installed (`pip install 'comfyui-applesilicon-fp8[mlx]'`); otherwise patch #14
 > no-ops.
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ your machine), then only the patch lines relevant to it:
   | Env var | Behaviour |
   |---|---|
   | `ASFP8_INT8_EXT` (default on where capable) | int8 W8A8 Metal kernel for int8 convrot Linears. Unset → on iff M5 + Metal 4.0 (macOS 26+) + `ninja`; `off`/`0` → force off; `1`/`on` → force the build attempt. |
+  | `ASFP8_INT8_DEQUANT` (default **off**) | Opt-in: dequantize int8 weights to plain bf16/fp16 **once at load** rather than per call. Trades memory (~16 GB for an 8B model) for a single-dispatch `F.linear`, which wins wherever dispatch overhead dominates the matmul — autoregressive text encoders at M=1 (measured ~19× on MiniMax Music 3 AR decode, contributed in [#26](https://github.com/pawel-mazurkiewicz/ComfyUI-AppleSilicon-FP8/pull/26)); no benefit for batched diffusion. `1`/`on` enables, and is still refused below 48 GiB RAM (it logs why) because the plain copy lands *after* comfy's model_management has budgeted around the loaded int8 size. Numerics match comfy's stock W8A16 path. |
   | `ASFP8_EXT_BUILD_TIMEOUT` (default `600`) | Seconds to wait for a Metal extension build (int8 #17, fp8 #3/#20, int4 #22) before giving up and falling back. An abandoned build lock is cleared once it is **twice** this old (twice the 600 s default when set to `0`), so a build that is merely slow is never disturbed. `0` disables the watchdog and waits indefinitely — not recommended, a wedged toolchain then hangs the render. |
 
 - **fused RMSNorm (#18) and fused RoPE (#21) are ON by default on any MPS with

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
   activates where it's supported; everywhere else it stays inert (nothing to
   configure, nothing breaks). The startup log prints a one-line capability summary
   so you can see exactly which tier is active on your machine. The heavier matmul
-  kernels need Metal-4 tensor ops — established by a runtime shader-compile probe,
-  in practice an **M5** — plus `ninja` to build, so on M1–M4 they normally don't
-  engage. The **int8/int4** kernels compile against **Metal 4.0** (macOS 26+); only
+  kernels need the **M5**'s matrix units plus `ninja` to build, and each one then
+  has to pass its own numeric self-check before it routes anything, so on M1–M4
+  they don't engage. The **int8/int4** kernels compile against **Metal 4.0** (macOS 26+); only
   the **fp8** kernel requires **Metal 4.1** (**macOS 27**), for its fp8 format type. The per-patch switches below (`ASFP8_FP8_EXT`, `ASFP8_INT8_EXT`
   and friends) take `off` to force a patch off and `1` to force it past the
   capability probe; forcing on buys only a *build attempt*, since callers still

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ Patches applied:
  13. int8-fast Linear via MPS bf16 GEMM           (INT8 wide-batch matmul was 3-5x too slow in fp32 _int_mm)
  14. MLX-backed TextGenerate on MPS (Qwen3-VL + Gemma3)  (Krea2 ~50s & LTX2 ~13h eager generate -> MLX)
  16. strided FP8 ops -> CPU on MPS (global)        (NVFP4/MXFP8 quant+dequant: reshape/contiguous of fp8 crashes MPS)
- 17. INT8 W8A8 via bit-exact Metal kernel on MPS   (DEFAULT ON, gated on M5/Metal-4.1 + ninja; ASFP8_INT8_EXT=off
+ 17. INT8 W8A8 via bit-exact Metal kernel on MPS   (DEFAULT ON, gated on M5+ matrix units + ninja; ASFP8_INT8_EXT=off
                                                     to disable: int8 matmul ~1.75x over bf16, bypasses per-step
                                                     fp32 weight dequant/un-rotation; Cider-derived kernel)
  18. fused RMSNorm+modulation+residual on MPS  (DEFAULT ON, gated on compile_shader; ASFP8_FUSED_NORM=off to disable:

--- a/_patches/__init__.py
+++ b/_patches/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
     "int8_linear_mps",      # patch #13 — int8-fast wide-batch Linear via MPS native bf16 GEMM
     "mlx_textgen",          # patch #14 — MLX-backed Qwen3-VL TextGenerate (prompt expansion)
     "fused_norm_mps",       # patch #18 — fused rmsnorm+modulation+residual MPS kernel (DEFAULT ON, compile_shader-gated)
-    "fp8_linear_kernel_mps", # patch #20 — fp8 e4m3 Linear via native Metal matmul2d (DEFAULT ON, Tier-B gated; ASFP8_FP8_NATIVE=off to disable)
+    "fp8_linear_kernel_mps", # patch #20 — fp8 e4m3 Linear via native Metal matmul2d (DEFAULT ON, gated on M5+ & ninja; ASFP8_FP8_NATIVE=off to disable)
     # patch #15 (fp8_linear_mps, opt-in fp8-native *F.linear*) RETIRED — wrong seam:
     #   real ComfyUI fp8 routes through torch._scaled_mm (QuantizedTensor hides the fp8
     #   dtype so the F.linear gate never fired), and weight-only fp8 only won at tiny M.
@@ -28,7 +28,7 @@ __all__ = [
     #   mixed_precision_ops.Linear.forward (the same factory seam patch #17 uses for int8),
     #   intercepting BEFORE the activation is fp8-quantized, so the F.linear-gate problem
     #   that retired #15 does not apply. DEFAULT ON (seam confirmed via a live Flux-2 probe),
-    #   gated on Tier B (M5/Metal-4.1 + ninja); ASFP8_FP8_NATIVE=off disables.
+    #   gated on M5-class matrix units + ninja; ASFP8_FP8_NATIVE=off disables.
     # Internal helpers (not patches):
     # "_common"             — decode_fp8, fp8_to_float_lut, FP8_DTYPES
     # "na_gemm"             — optional NA matmul2d backend (not wired into hot path)

--- a/_patches/_caps.py
+++ b/_patches/_caps.py
@@ -243,6 +243,13 @@ def reset_cache():
     global _compile_shader, _tensor_ops, _ninja, _chip_gen
     _compile_shader = _tensor_ops = _ninja = None
     _chip_gen = _UNPROBED
+    # has_tensor_ops_matmul2d() reads through to na_gemm's own memo, so clearing
+    # ours alone would hand back the stale verdict and re-probe nothing.
+    try:
+        from . import na_gemm
+        na_gemm.reset_cache()
+    except Exception:
+        pass
     with _kernel_lock:
         _kernel_ready.clear()
 

--- a/_patches/_caps.py
+++ b/_patches/_caps.py
@@ -18,7 +18,7 @@ Capability tiers:
   A+ na_gemm's tensor-ops shader computes right    -> compile_shader matmul kernels
      (has_tensor_ops_matmul2d)                         (#19 conv im2col)
   B  M5-class matrix units + `ninja`               -> ObjC++ cpp_extension kernels
-     (kernel_gate)                                     (#3 fp8_ext, #17 int8_ext, int4)
+     (kernel_gate)                                     (#3 fp8_ext, #17 int8_ext)
 
 A+ and B are separate ladders, not steps of one. A+ asks what
 `torch.mps.compile_shader` can build; B's kernels compile through
@@ -156,7 +156,8 @@ def has_neural_accelerators():
 
 def kernel_gate():
     """Default-on pre-filter for the ObjC++ tensor-ops extensions (#3 fp8_ext,
-    #17 int8_ext, int4): M5-class matrix units on MPS, plus a build toolchain.
+    #17 int8_ext): M5-class matrix units on MPS, plus a build toolchain. int4 is
+    opt-in and gates itself in its loader, so it does not use this.
 
     Deliberately does NOT consult has_tensor_ops_matmul2d(). That probe compiles
     a bf16 shader through `torch.mps.compile_shader`, which cannot request an MSL

--- a/_patches/_caps.py
+++ b/_patches/_caps.py
@@ -15,10 +15,16 @@ Three states per gate (see `resolve`):
 Capability tiers:
   A  `torch.mps.compile_shader` present            -> fp32 compile_shader kernels
      (has_compile_shader)                              (#18 fused-norm, #21 RoPE)
-  B  Metal-4 tensor-ops `matmul2d` compiles         -> M5 / Metal-4.1 matmul kernels
-     (has_tensor_ops_matmul2d, proven via na_gemm)     (#19 conv im2col)
-     ...plus `ninja` for the ObjC++ cpp_extensions  -> #3 fp8_ext, #17 int8_ext,
-     (tier_b_ready)                                     #20 fp8-native Linear
+  A+ na_gemm's tensor-ops shader computes right    -> compile_shader matmul kernels
+     (has_tensor_ops_matmul2d)                         (#19 conv im2col)
+  B  M5-class matrix units + `ninja`               -> ObjC++ cpp_extension kernels
+     (kernel_gate)                                     (#3 fp8_ext, #17 int8_ext, int4)
+
+A+ and B are separate ladders, not steps of one. A+ asks what
+`torch.mps.compile_shader` can build; B's kernels compile through
+`newLibraryWithSource` at an explicit MSL version and never touch compile_shader.
+Conflating them is issues #25 and #27 — the same probe answered yes on an M4 Pro
+that computes garbage and no on an M5 Max that is bit-exact.
 """
 
 import os
@@ -53,16 +59,18 @@ _tensor_ops = None
 
 
 def has_tensor_ops_matmul2d():
-    """Tier B runtime probe: does `mpp::tensor_ops::matmul2d` compile on this
-    OS/SDK/PyTorch/GPU? True only on M5-class / Metal-4.1 stacks. Delegates to
-    na_gemm's proven-correct kernel (memoised there) so we don't carry a second,
-    drift-prone copy of the MPP shader source.
+    """Does na_gemm's `mpp::tensor_ops::matmul2d` shader compile AND compute
+    correctly on this stack? Delegates to na_gemm (memoised there) so we don't
+    carry a second, drift-prone copy of the MPP shader source.
 
-    COARSE PRE-FILTER ONLY. This compiles na_gemm's bf16 shader, which is not the
-    shader any of our int8/int4/fp8 kernels use — different operand types,
-    different simdgroup counts. A pass proves the machine has Metal-4 tensor ops
-    in general, NOT that a given kernel builds. Issue #13 was precisely that gap.
-    Use kernel_ready() to find out whether a specific kernel actually works."""
+    Scope: this answers for shaders built through `torch.mps.compile_shader`,
+    which is conv_im2col (#19) and nothing else. It is NOT the gate for the
+    ObjC++ extensions -- see kernel_gate() for why compile_shader's verdict says
+    nothing about them.
+
+    The numeric self-check, not just the build, is what's consulted: issue #25 is
+    a machine where a tensor_ops shader compiles cleanly and computes garbage, so
+    "it compiled" was never enough to route real work through it."""
     global _tensor_ops
     if _tensor_ops is None:
         if not has_compile_shader():
@@ -70,7 +78,7 @@ def has_tensor_ops_matmul2d():
         else:
             try:
                 from . import na_gemm
-                _tensor_ops = bool(na_gemm.available())
+                _tensor_ops = bool(na_gemm.self_check_ok())
             except Exception:
                 _tensor_ops = False
     return _tensor_ops
@@ -98,14 +106,70 @@ def ninja_available():
     return _ninja
 
 
-def tier_b_ready():
-    """Metal-4 tensor ops present AND a build toolchain for the ObjC++ extensions.
+_UNPROBED = object()
+_chip_gen = _UNPROBED
 
-    A cheap pre-filter for "is it worth attempting a build at all", nothing more.
-    It green-lights every Tier-B kernel off one bf16 probe none of them use, so
-    it can and does approve a kernel that will not compile (#13, #14). Gate the
-    kernel itself on kernel_ready()."""
-    return has_tensor_ops_matmul2d() and ninja_available()
+# First Apple Silicon generation whose GPU cores carry Neural Accelerators, the
+# execution unit `mpp::tensor_ops::matmul2d` needs to produce correct results. On
+# M1-M4 the same shader compiles and dispatches, and returns garbage (#25).
+_MATRIX_UNIT_GEN = 5
+
+
+def _cpu_brand_string():
+    """The chip's marketing name ('Apple M5 Max'), or None if it can't be read."""
+    import subprocess
+    try:
+        out = subprocess.check_output(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            stderr=subprocess.DEVNULL, timeout=5,
+        )
+    except Exception:
+        return None
+    return out.decode(errors="replace").strip() or None
+
+
+def chip_generation():
+    """Apple Silicon generation as an int ('Apple M4 Pro' -> 4).
+
+    None when this isn't an Apple Silicon Mac or the name doesn't parse -- an
+    answer callers must read as "don't know", never as "no"."""
+    global _chip_gen
+    if _chip_gen is _UNPROBED:
+        import re
+        brand = _cpu_brand_string()
+        m = re.match(r"^Apple M(\d+)", brand) if brand else None
+        _chip_gen = int(m.group(1)) if m else None
+    return _chip_gen
+
+
+def has_neural_accelerators():
+    """Does this GPU have the M5-class matrix units the tensor-ops kernels need?
+
+    An unidentified chip answers True. The two failure modes are not symmetric: a
+    false negative silently disables every ObjC++ kernel on hardware that runs
+    them bit-exactly (#27), while a false positive costs one build that
+    kernel_ready()'s numeric self-check then rejects (#25). So only a chip we
+    positively identify as pre-M5 short-circuits."""
+    gen = chip_generation()
+    return gen is None or gen >= _MATRIX_UNIT_GEN
+
+
+def kernel_gate():
+    """Default-on pre-filter for the ObjC++ tensor-ops extensions (#3 fp8_ext,
+    #17 int8_ext, int4): M5-class matrix units on MPS, plus a build toolchain.
+
+    Deliberately does NOT consult has_tensor_ops_matmul2d(). That probe compiles
+    a bf16 shader through `torch.mps.compile_shader`, which cannot request an MSL
+    language version, so what it reports is the torch build's default MSL rather
+    than anything about the GPU -- it read yes on the M4 Pro of #25, where the
+    int8 kernel returns garbage, and no on the M5 Max of #27, where the same
+    kernel is bit-exact and 3.17x faster. These extensions compile through
+    `newLibraryWithSource` at an explicit version, so compile_shader's verdict was
+    never theirs to give.
+
+    A pre-filter only: it says a build is worth attempting, never that a given
+    kernel works. That stays kernel_ready()'s job."""
+    return is_mps() and has_neural_accelerators() and ninja_available()
 
 
 # name -> None (untried) | True (verified working) | False (verified broken)
@@ -121,7 +185,7 @@ _kernel_lock = threading.RLock()
 def kernel_ready(name, verify_fn):
     """Has THIS kernel been proven to work end to end on THIS machine?
 
-    tier_b_ready() answers a different, weaker question (see its docstring), so
+    kernel_gate() answers a different, weaker question (see its docstring), so
     a kernel that passes it can still fail to build. `verify_fn` must therefore
     do the real thing: build the extension, run its warmup(), and check its
     numerics. Only then is the kernel enabled.
@@ -176,19 +240,29 @@ def mark_kernel_failed(name):
 
 def reset_cache():
     """Test hook: forget memoised probe results so a test can re-probe."""
-    global _compile_shader, _tensor_ops, _ninja
+    global _compile_shader, _tensor_ops, _ninja, _chip_gen
     _compile_shader = _tensor_ops = _ninja = None
+    _chip_gen = _UNPROBED
     with _kernel_lock:
         _kernel_ready.clear()
 
 
 def summary():
-    """One-line capability banner for the startup log."""
+    """One-line capability banner for the startup log.
+
+    Reports the chip rather than the old `tensor_ops(M5/Metal4)=` field, which
+    named a GPU generation it never measured (yes on the M4 Pro of #25, no on the
+    M5 Max of #27) and cost a shader compile on the import thread to get wrong.
+    Every field here is cheap; na_gemm's probe is left to its one consumer to
+    evaluate lazily."""
+    matrix = "unknown" if chip_generation() is None else (
+        "yes" if has_neural_accelerators() else "no")
     return ", ".join((
         f"macOS={platform.mac_ver()[0] or '?'}",
         f"torch={torch.__version__}",
         f"mps={'yes' if is_mps() else 'no'}",
         f"compile_shader={'yes' if has_compile_shader() else 'no'}",
-        f"tensor_ops(M5/Metal4)={'yes' if has_tensor_ops_matmul2d() else 'no'}",
+        f"chip={_cpu_brand_string() or 'unknown'}",
+        f"matrix_units(M5+)={matrix}",
         f"ninja={'yes' if ninja_available() else 'no'}",
     ))

--- a/_patches/fp8_ext/loader.py
+++ b/_patches/fp8_ext/loader.py
@@ -53,12 +53,12 @@ def module():
     _tried = True
 
     # DEFAULT ON where capable: build when EITHER seam wants it. Each flag resolves
-    # via the shared three-state gate (unset -> on iff Tier B; off -> off; 1 -> force).
+    # via the shared three-state gate (unset -> on iff kernel_gate; off -> off; 1 -> force).
     # The callers (#3 _fast_eligible, #20 install) independently decide whether to USE
     # the built module; this only decides whether to attempt the (cached) build.
     from .. import _caps
-    if not (_caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.tier_b_ready) or
-            _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.tier_b_ready)):
+    if not (_caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.kernel_gate) or
+            _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.kernel_gate)):
         return None
     if shutil.which("xcrun") is None:
         print("[fp8_ext] no Metal toolchain (xcrun); fp8-native disabled.")

--- a/_patches/fp8_linear_kernel_mps.py
+++ b/_patches/fp8_linear_kernel_mps.py
@@ -221,11 +221,11 @@ def install():
         return
     if sys.platform != "darwin":
         return
-    # DEFAULT ON (seam confirmed via live Flux-2 probe), gated on Tier B (Metal-4 tensor
-    # ops + ninja for the ObjC++ fp8 extension). Unsupported HW -> default OFF (no build
+    # DEFAULT ON (seam confirmed via live Flux-2 probe), gated on M5-class matrix units
+    # + ninja for the ObjC++ fp8 extension. Unsupported HW -> default OFF (no build
     # attempt); ASFP8_FP8_NATIVE=off force-disables, =1 forces the build attempt anyway.
     from . import _caps
-    if not _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.tier_b_ready):
+    if not _caps.resolve("ASFP8_FP8_NATIVE", default_on=True, cap=_caps.kernel_gate):
         return
     if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         return

--- a/_patches/int4_linear_mps.py
+++ b/_patches/int4_linear_mps.py
@@ -141,7 +141,12 @@ def _w4a16_linear_mps(x, qweight, wscales, bias, convrot_groupsize, mod):
     x_rot = mod._rotate_activation(x2d, h, convrot_groupsize)
 
     from . import _caps
-    kernel = _load_kernel() if _caps.kernel_ready("int4", _verify) else None
+    # kernel_gate() first: on hardware without M5-class matrix units the build
+    # can only ever end in a self-check rejection, and int4 has no env gate in
+    # front of it, so every ConvRot layer would pay for that discovery (#25).
+    kernel = (_load_kernel()
+              if _caps.kernel_gate() and _caps.kernel_ready("int4", _verify)
+              else None)
     if kernel is not None:
         try:
             y = _w4a8_kernel_linear(x_rot, qweight, wscales, bias, kernel)

--- a/_patches/int4_linear_mps.py
+++ b/_patches/int4_linear_mps.py
@@ -141,12 +141,14 @@ def _w4a16_linear_mps(x, qweight, wscales, bias, convrot_groupsize, mod):
     x_rot = mod._rotate_activation(x2d, h, convrot_groupsize)
 
     from . import _caps
-    # kernel_gate() first: on hardware without M5-class matrix units the build
-    # can only ever end in a self-check rejection, and int4 has no env gate in
-    # front of it, so every ConvRot layer would pay for that discovery (#25).
-    kernel = (_load_kernel()
-              if _caps.kernel_gate() and _caps.kernel_ready("int4", _verify)
-              else None)
+    # No chip pre-filter here, unlike int8/fp8. int4 is opt-in: int4_ext's loader
+    # returns None before building unless ASFP8_INT4_EXT=1, so an unset install
+    # never reaches a build on any hardware and there is nothing for a pre-filter
+    # to save. The only case it could reach is a user who explicitly asked for the
+    # kernel, and an explicit env var is exactly what _caps promises will beat a
+    # probe -- gating it would lock that user out. The self-check still rejects a
+    # wrong result on pre-M5 hardware, which is #25's documented outcome.
+    kernel = _load_kernel() if _caps.kernel_ready("int4", _verify) else None
     if kernel is not None:
         try:
             y = _w4a8_kernel_linear(x_rot, qweight, wscales, bias, kernel)

--- a/_patches/int8_ext/loader.py
+++ b/_patches/int8_ext/loader.py
@@ -1,7 +1,7 @@
 """JIT loader for the bit-exact int8 matmul2d MPS extension.
 
 Builds _patches/int8_ext/int8_gemm.mm via torch.utils.cpp_extension.load (ObjC++,
-Metal 4.1). DEFAULT ON where capable (Tier B: M5 / Metal 4.1 + ninja, via the shared
+Metal 4.0). DEFAULT ON where capable (M5-class matrix units + ninja, via the shared
 three-state gate); guarded, cached; returns None on any failure so callers fall back
 to the fp32/bf16 _int_mm path.
 
@@ -50,10 +50,10 @@ def module():
         return _mod
     _tried = True
 
-    # DEFAULT ON where capable (Tier B: M5/Metal-4.1 + ninja). Three-state gate:
-    # unset -> on iff tier_b_ready; ASFP8_INT8_EXT=off -> off; =1 -> force the build.
+    # DEFAULT ON where capable (M5-class matrix units + ninja). Three-state gate:
+    # unset -> on iff kernel_gate; ASFP8_INT8_EXT=off -> off; =1 -> force the build.
     from .. import _caps
-    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.tier_b_ready):
+    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.kernel_gate):
         return None
     if shutil.which("xcrun") is None:
         print("[int8_ext] no Metal toolchain (xcrun); int8-native disabled.")

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -141,7 +141,7 @@ def _self_check():
 def _verify():
     """The contract _caps.kernel_ready expects: build, warmup, then numerics.
 
-    Nothing short of this proves the kernel works — tier_b_ready() only compiles
+    Nothing short of this proves the kernel works — kernel_gate() only checks
     na_gemm's bf16 shader, which shares no operand types with ours (#14).
     """
     return _ensure_kernel() is not None and _self_check()
@@ -346,11 +346,11 @@ def install():
         return
     if sys.platform != "darwin":
         return
-    # DEFAULT ON, gated on Tier B (Metal-4 tensor ops + ninja to build the ObjC++
+    # DEFAULT ON, gated on M5-class matrix units + ninja to build the ObjC++
     # extension). On unsupported HW the default resolves to OFF so we never attempt a
     # build; ASFP8_INT8_EXT=off force-disables, =1 forces the build attempt anyway.
     from . import _caps
-    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.tier_b_ready):
+    if not _caps.resolve("ASFP8_INT8_EXT", default_on=True, cap=_caps.kernel_gate):
         return
     if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
         return
@@ -398,7 +398,8 @@ def install():
 
     _installed = True
     print(
-        f"{TAG} INT8 convrot Linear routed through bit-exact Metal kernel on MPS "
-        f"(clean W8A8: rotate->per-row quant->int8 matmul; weight-only fp32 "
-        f"dequant/un-rotation bypassed). Kernel builds on first int8 layer, not now."
+        f"{TAG} INT8 convrot Linear seam installed on MPS (clean W8A8: "
+        f"rotate->per-row quant->int8 matmul; weight-only fp32 dequant/un-rotation "
+        f"bypassed). The kernel builds and runs its bit-exact self-check on the "
+        f"first int8 layer, and only routes if that passes."
     )

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -141,8 +141,9 @@ def _self_check():
 def _verify():
     """The contract _caps.kernel_ready expects: build, warmup, then numerics.
 
-    Nothing short of this proves the kernel works — kernel_gate() only checks
-    na_gemm's bf16 shader, which shares no operand types with ours (#14).
+    Nothing short of this proves the kernel works. kernel_gate() only checks that
+    the chip has matrix units and that ninja exists; it says nothing about whether
+    int8_gemm.mm builds here or what it computes (#14, #25, #27).
     """
     return _ensure_kernel() is not None and _self_check()
 

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -307,10 +307,20 @@ def _try_int8_kernel_forward(self, input):
         w = self.weight
         if not isinstance(w, QuantizedTensor) or getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
             return None
+        # Offloaded weight (comfy parks it on CPU between uses): fall back to the
+        # comfy forward, which casts it in. Reaching _int8_linear_kernel with a
+        # CPU weight would throw in its own fallback and latch mark_kernel_failed,
+        # killing the kernel for the session over a transient condition.
+        if w.device.type != "mps":
+            return None
         if getattr(self, "_full_precision_mm", False):
             return None
-        if getattr(self, "comfy_force_cast_weights", False):
-            return None
+        # comfy_force_cast_weights on an int8 QuantizedTensor only means "storage
+        # dtype != compute dtype, cast at use" -- and for a quantized weight that
+        # cast IS the per-call W8A16 dequant/un-rotation this path exists to
+        # bypass, so it must not disqualify the kernel route. (MiniMax Music 3's
+        # text encoder sets it on every layer, which silently forced the slow
+        # path for the whole model.)
         if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
             return None
 
@@ -339,6 +349,130 @@ def _try_int8_kernel_forward(self, input):
                   f"for the rest of this session.")
         _caps.mark_kernel_failed("int8")
         return None
+
+
+_DEQUANT_MODE = None
+
+
+def _dequant_enabled():
+    """Opt-in gate for once-at-load weight dequant: ASFP8_INT8_DEQUANT=1 enables,
+    subject to a >= 48 GiB total-RAM safety check; unset or off stays off.
+
+    Opt-in because the plain copy (~16 GB for an 8B int8 model) lands AFTER
+    comfy's model_management has budgeted around the loaded int8 size, so
+    auto-enabling near the threshold risks thrash/OOM comfy can't see coming."""
+    global _DEQUANT_MODE
+    if _DEQUANT_MODE is None:
+        import os
+        v = os.environ.get("ASFP8_INT8_DEQUANT", "").strip().lower()
+        _DEQUANT_MODE = False
+        if v in ("1", "on", "true"):
+            try:
+                import psutil
+                _DEQUANT_MODE = psutil.virtual_memory().total >= 48 * (1 << 30)
+                if not _DEQUANT_MODE:
+                    print(f"{TAG} ASFP8_INT8_DEQUANT=1 ignored: needs >= 48 GiB RAM "
+                          f"for the dequantised weight copy.")
+            except Exception:
+                _DEQUANT_MODE = False
+    return _DEQUANT_MODE
+
+
+def _maybe_dequant_weight(self, input):
+    """One-off per layer: replace an eligible int8 QuantizedTensor weight with its
+    dequantised (un-rotated) plain tensor in the compute dtype, resident on MPS.
+
+    Rationale: single-token AR decode is memory-bandwidth-bound, and every
+    quantised route (kernel W8A8 or comfy's per-call W8A16 dequant) pays a
+    per-call rotate/quant/rescale op chain whose MPS dispatch overhead dominates
+    at M=1..2 (measured 3-10x the matmul cost on MiniMax Music 3 AR decode).
+    Paying the dequant once and running single-dispatch F.linear is both faster
+    and numerically identical to comfy's stock W8A16 path. fp16 weights with a
+    different compute dtype get the same treatment: manual_cast otherwise copies
+    the full tensor every call (MiniMax's 134 MB audio_heads dominate a decode
+    profile through aten::copy_)."""
+    if getattr(self, "_asfp8_deq_done", False):
+        return
+    try:
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        # Transient conditions (properties of this call's input) leave the flag
+        # unset so a later MPS-resident call can still dequantise. Everything
+        # past the flag is a stable property of the layer, decided once.
+        if not isinstance(input, torch.Tensor) or isinstance(input, QuantizedTensor):
+            return
+        if input.device.type != "mps":
+            return
+        # Half-precision compute only: an fp32 activation would balloon the
+        # dequantised copy to 2x the size the >= 48 GiB gate budgets for.
+        if input.dtype not in (torch.float16, torch.bfloat16):
+            return
+        self._asfp8_deq_done = True
+        if getattr(self, "_full_precision_mm", False):
+            return
+        if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
+            return
+
+        w = self.weight
+        if isinstance(w, QuantizedTensor):
+            if getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
+                return
+            if getattr(w._params, "transposed", False):
+                return
+            plain = w.dequantize()
+        elif isinstance(w, torch.Tensor) and w.dtype == torch.float16 and w.dtype != input.dtype:
+            plain = w.detach()
+        else:
+            return
+        if plain.dtype != input.dtype:
+            plain = plain.to(input.dtype)
+        if plain.device.type != "mps":
+            plain = plain.to("mps")
+        self.weight = torch.nn.Parameter(plain.contiguous(), requires_grad=False)
+        b = getattr(self, "bias", None)
+        if isinstance(b, torch.Tensor) and not isinstance(b, QuantizedTensor) and b.dtype != input.dtype:
+            self.bias = torch.nn.Parameter(b.detach().to(device="mps", dtype=input.dtype), requires_grad=False)
+        self.comfy_force_cast_weights = False
+    except Exception as e:
+        # Latch on failure too: retrying an identical dequant every call would
+        # just repeat the error (and the print) for the rest of the session.
+        self._asfp8_deq_done = True
+        print(f"{TAG} weight dequant skipped ({e!r})")
+
+
+def _maybe_dequant_embedding(self, dtype_hint):
+    """One-off per Embedding: replace an int8 QuantizedTensor (or fp16) table with
+    a plain tensor in the compute dtype so per-call cast/dequant of the whole
+    table disappears (cast_bias_weight casts the full weight every lookup)."""
+    if getattr(self, "_asfp8_deq_done", False):
+        return
+    try:
+        from comfy_kitchen.tensor import QuantizedTensor
+
+        w = self.weight
+        # Off-MPS is transient (offload); leave the flag unset for a later call.
+        if w is None or w.device.type != "mps":
+            return
+        self._asfp8_deq_done = True
+        if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
+            return
+        # The hint comes from Embedding.forward's out_dtype (kwarg or first
+        # positional); anything that isn't a half-precision dtype is ignored,
+        # not trusted (same memory-budget reasoning as _maybe_dequant_weight).
+        if dtype_hint not in (torch.float16, torch.bfloat16):
+            dtype_hint = None
+        target = dtype_hint if dtype_hint is not None else torch.bfloat16
+        if isinstance(w, QuantizedTensor):
+            plain = w.dequantize().to(target)
+        elif isinstance(w, torch.Tensor) and w.dtype == torch.float16 and w.dtype != target:
+            plain = w.detach().to(target)
+        else:
+            return
+        self.weight = torch.nn.Parameter(plain.contiguous(), requires_grad=False)
+        self.comfy_force_cast_weights = False
+    except Exception as e:
+        self._asfp8_deq_done = True
+        print(f"{TAG} embedding dequant skipped ({e!r})")
 
 
 def install():
@@ -382,6 +516,8 @@ def install():
                 orig_forward = linear_cls.forward
 
                 def forward(self, input, *args, **kwargs):
+                    if _dequant_enabled():
+                        _maybe_dequant_weight(self, input)
                     res = _try_int8_kernel_forward(self, input)
                     if res is not None:
                         return res
@@ -389,18 +525,49 @@ def install():
 
                 linear_cls.forward = forward
                 linear_cls._asfp8_int8_patched = True
+            emb_cls = getattr(cls, "Embedding", None)
+            if emb_cls is not None and not getattr(emb_cls, "_asfp8_int8_patched", False):
+                orig_emb_forward = emb_cls.forward
+
+                def emb_forward(self, input, *args, **kwargs):
+                    if _dequant_enabled():
+                        hint = kwargs.get("out_dtype", args[0] if args else None)
+                        _maybe_dequant_embedding(self, hint)
+                    return orig_emb_forward(self, input, *args, **kwargs)
+
+                emb_cls.forward = emb_forward
+                emb_cls._asfp8_int8_patched = True
             return cls
 
         wrapped_factory._asfp8_wrapped = True
         ops.mixed_precision_ops = wrapped_factory
+
+        # down_proj is invoked via ops.linear_input_act (fused swiglu path), which
+        # reads linear.weight directly and never calls Linear.forward -- so the
+        # once-at-load dequant must hook here too or those layers stay int8.
+        # getattr, not attribute access: a comfy without linear_input_act must not
+        # abort install() here -- mixed_precision_ops is already wrapped above and
+        # the except below would leave _installed False with a misleading message.
+        orig_lia = getattr(ops, "linear_input_act", None)
+        if orig_lia is not None and not getattr(orig_lia, "_asfp8_deq_wrapped", False):
+            def linear_input_act(linear, x, input_act):
+                if _dequant_enabled():
+                    _maybe_dequant_weight(linear, x)
+                return orig_lia(linear, x, input_act)
+
+            linear_input_act._asfp8_deq_wrapped = True
+            ops.linear_input_act = linear_input_act
     except Exception as e:
         print(f"{TAG} could not wrap mixed_precision_ops: {e!r}")
         return
 
     _installed = True
+    deq = "on" if _dequant_enabled() else "off"
     print(
         f"{TAG} INT8 convrot Linear seam installed on MPS (clean W8A8: "
         f"rotate->per-row quant->int8 matmul; weight-only fp32 dequant/un-rotation "
         f"bypassed). The kernel builds and runs its bit-exact self-check on the "
-        f"first int8 layer, and only routes if that passes."
+        f"first int8 layer, and only routes if that passes. "
+        f"Once-at-load weight dequant: {deq} (opt-in: ASFP8_INT8_DEQUANT=1, "
+        f"needs >= 48 GiB RAM)."
     )

--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -407,13 +407,21 @@ def _maybe_dequant_weight(self, input):
         # dequantised copy to 2x the size the >= 48 GiB gate budgets for.
         if input.dtype not in (torch.float16, torch.bfloat16):
             return
+        # Offloaded weight: comfy is deliberately keeping it off-device, so
+        # dequantising would pull a bigger, full-precision copy onto the GPU and
+        # pin it there -- undoing the offload and inflating residency past what
+        # the >= 48 GiB gate budgeted for. Transient like the checks above, so
+        # the flag stays unset and a later resident call can still dequantise.
+        # _maybe_dequant_embedding already treats its weight this way.
+        w = getattr(self, "weight", None)
+        if w is None or getattr(w, "device", None) is None or w.device.type != "mps":
+            return
         self._asfp8_deq_done = True
         if getattr(self, "_full_precision_mm", False):
             return
         if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
             return
 
-        w = self.weight
         if isinstance(w, QuantizedTensor):
             if getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
                 return

--- a/_patches/na_gemm.py
+++ b/_patches/na_gemm.py
@@ -101,6 +101,17 @@ def available():
     return _get_lib() is not None
 
 
+def reset_cache():
+    """Test hook: drop the compile + numeric memos so the next call re-probes.
+
+    _caps.reset_cache() delegates here. Without it, clearing _caps' own memo just
+    re-reads this stale verdict and the promised re-probe never happens."""
+    global _lib, _compiled, _self_check
+    _lib = None
+    _compiled = None
+    _self_check = None
+
+
 def na_matmul(a, b):
     """C[M,N] f32 = A[M,K] @ B[K,N]; a,b are bf16, on MPS.
 
@@ -142,9 +153,12 @@ def self_check_ok():
         _self_check = False
         return False
     try:
-        torch.manual_seed(0)
-        a = (torch.randn(64, 256) * 0.5).to(torch.bfloat16).to("mps").contiguous()
-        b = (torch.randn(256, 96) * 0.5).to(torch.bfloat16).to("mps").contiguous()
+        # Local generator, never torch.manual_seed: this probe runs at plugin
+        # import (conv im2col's gate), and reseeding there would move the host's
+        # RNG under every later draw in the process.
+        g = torch.Generator().manual_seed(0)
+        a = (torch.randn(64, 256, generator=g) * 0.5).to(torch.bfloat16).to("mps").contiguous()
+        b = (torch.randn(256, 96, generator=g) * 0.5).to(torch.bfloat16).to("mps").contiguous()
         ref = (a.float() @ b.float())
         out = na_matmul(a, b)
         rel = (out - ref).abs().max() / (ref.abs().max() + 1e-9)

--- a/_patches/scaled_mm_fp8.py
+++ b/_patches/scaled_mm_fp8.py
@@ -78,11 +78,11 @@ def _min_dim():
 
 def _fast_eligible(input, other):
     """Shape/dtype/capability predicate (no per-call device work). The fp8_ext fast
-    path is DEFAULT ON, gated on Tier B (Metal-4 tensor ops + ninja for the ObjC++
-    extension). ASFP8_FP8_EXT=off force-disables; =1 forces it on. The capability
+    path is DEFAULT ON, gated on M5-class matrix units + ninja for the ObjC++
+    extension. ASFP8_FP8_EXT=off force-disables; =1 forces it on. The capability
     probes are memoised, so this stays cheap on the hot matmul path."""
     from . import _caps
-    if not _caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.tier_b_ready):
+    if not _caps.resolve("ASFP8_FP8_EXT", default_on=True, cap=_caps.kernel_gate):
         return False
     # The kernel decodes both operands as e4m3; only route when that's exact.
     if input.dtype != torch.float8_e4m3fn or other.dtype != torch.float8_e4m3fn:

--- a/_patches/scaled_mm_fp8.py
+++ b/_patches/scaled_mm_fp8.py
@@ -111,9 +111,12 @@ def _get_backend():
     if not _self_checked:
         _self_checked = True
         try:
-            torch.manual_seed(0)
-            a = (torch.randn(64, 8192) * 0.3).to(torch.float8_e4m3fn)
-            w = (torch.randn(8192, 8192) * 0.3).to(torch.float8_e4m3fn)   # [N,K]
+            # Local generator, never torch.manual_seed: this self-check runs
+            # lazily on the FIRST fp8 matmul, i.e. mid-render, where reseeding
+            # the process RNG would land in the middle of a user's sampling.
+            g = torch.Generator().manual_seed(0)
+            a = (torch.randn(64, 8192, generator=g) * 0.3).to(torch.float8_e4m3fn)
+            w = (torch.randn(8192, 8192, generator=g) * 0.3).to(torch.float8_e4m3fn)   # [N,K]
             a_u8 = a.view(torch.uint8).to("mps").contiguous()
             w_u8 = w.view(torch.uint8).to("mps").contiguous()
             ref = decode_fp8(a.to("mps"), torch.float32) @ decode_fp8(w.to("mps"), torch.float32).t()

--- a/_patches/sg_gemm.py
+++ b/_patches/sg_gemm.py
@@ -175,9 +175,9 @@ def self_check_ok():
         _self_check = False
         return False
     try:
-        torch.manual_seed(0)
-        a = (torch.randn(64, 256) * 0.5).to(torch.bfloat16).to("mps").contiguous()
-        b = (torch.randn(256, 96) * 0.5).to(torch.bfloat16).to("mps").contiguous()
+        g = torch.Generator().manual_seed(0)   # never seed the host's RNG
+        a = (torch.randn(64, 256, generator=g) * 0.5).to(torch.bfloat16).to("mps").contiguous()
+        b = (torch.randn(256, 96, generator=g) * 0.5).to(torch.bfloat16).to("mps").contiguous()
         ref = a.float() @ b.float()
         out = sg_matmul(a, b)
         rel = (out - ref).abs().max() / (ref.abs().max() + 1e-9)

--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -19,10 +19,21 @@ Step 3 crashes on MPS via two possible sub-paths:
      manual_stochastic_round_to_float8 returns a float16 MPS tensor;
      copy_ then has to convert float16→FP8 on-device — also unsupported.
 
-Fix: wrap comfy.float.stochastic_rounding so that, when the input is on
-MPS and the target dtype is FP8, the entire computation is moved to CPU
-(where FP8 casts are fully supported). The resulting FP8 CPU tensor is
-then moved back to MPS — storage works fine.
+Fix: wrap comfy.float.stochastic_rounding and keep the work on the GPU where
+possible. Only the *last* step of the re-quant is unsupported on MPS — the
+float→FP8 cast — and patch #8 (tensor_to_fp8) already routes that single op via
+a LUT/CPU hop, so on path (a) the whole function runs on MPS and returns
+byte-identical FP8.
+
+Path (b) still needs the old treatment: it writes through
+``output[i:].copy_(...)``, a strided FP8 copy patch #8 does not cover (it wraps
+``.to``, not ``copy_``). So we try the native path once, and latch onto the CPU
+round-trip for the session if it raises.
+
+This matters because LoRA application re-quantises every weight it touches.
+Sending each one to the CPU in full measured ~5.6x slower at per-weight
+granularity (11.3 → 2.0 ms/weight, M5 Max), which is why loading an fp8 DiT with
+a LoRA took 80–200 s while the same model without one loaded fast (issue #29).
 
 The same module's `to_blocked` needs the same treatment (issue #8). It is the
 swizzle at the end of the NVFP4 *quantize* direction, which an ordinary NVFP4
@@ -56,6 +67,46 @@ TAG = "[AppleSilicon-FP8/stochastic_round]"
 
 _installed = False
 
+# None = untried, True = the GPU path works here, False = this stack needs the CPU
+# round-trip. Latched: a LoRA re-quantises every weight it touches, so probing per
+# weight would put the exception cost straight back on the path #29 is about.
+_native_ok = None
+
+
+def _requant(original, value, dtype, seed=0):
+    """Re-quantise `value` to an fp8 `dtype`, keeping the maths on the GPU if it can.
+
+    Only ONE step of the re-quant has no MPS kernel -- the final float->fp8 cast.
+    Patch #8 (tensor_to_fp8) already routes that single op via a LUT/CPU hop, so
+    on a stack where it is installed the whole function runs on the GPU and
+    returns byte-identical fp8. Sending the entire tensor to the CPU instead, as
+    this patch did from S1 until #29, costs ~5.6x at per-weight granularity
+    (11.3 -> 2.0 ms/weight on an M5 Max) and is why loading an fp8 DiT with a
+    LoRA took minutes while the same model without one loaded fast.
+
+    The CPU round-trip stays reachable because it is still needed: comfy's own
+    fallback implementation writes through ``output[i:].copy_(...)``, a strided
+    fp8 copy that patch #8 does not cover (it wraps ``.to``, not ``copy_``).
+    """
+    global _native_ok
+    if value.device.type != "mps" or dtype not in FP8_DTYPES:
+        return original(value, dtype, seed=seed)
+
+    if _native_ok is not False:
+        try:
+            out = original(value, dtype, seed=seed)
+            _native_ok = True
+            return out
+        except Exception as e:
+            if _native_ok is None:
+                print(f"{TAG} fp8 re-quant cannot run on MPS here ({e!r}); "
+                      f"using the CPU round-trip for the rest of this session.")
+            _native_ok = False
+
+    # float->fp8 casts are fully supported on CPU; the fp8 result moves back as
+    # plain storage, which MPS handles.
+    return original(value.cpu(), dtype, seed=seed).to(value.device)
+
 
 def install():
     global _installed
@@ -79,12 +130,7 @@ def install():
     _original = float_mod.stochastic_rounding
 
     def _mps_safe_stochastic_rounding(value, dtype, seed=0):
-        if value.device.type == "mps" and dtype in FP8_DTYPES:
-            # Perform the full rounding on CPU where float→FP8 casts are
-            # supported, then move the FP8 result back to MPS for storage.
-            cpu_result = _original(value.cpu(), dtype, seed=seed)
-            return cpu_result.to(value.device)
-        return _original(value, dtype, seed=seed)
+        return _requant(_original, value, dtype, seed)
 
     float_mod.stochastic_rounding = _mps_safe_stochastic_rounding
 

--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -73,20 +73,40 @@ _installed = False
 _native_ok = None
 
 
+def _is_transient(e):
+    """Memory pressure rather than a missing kernel.
+
+    Worth separating: a missing fp8 kernel is a property of the stack and will
+    fail for every weight, so latching is right. An allocator failure is a
+    property of the moment, and condemning the session to the 4.6x-slower path
+    over one of them would be the same silent regression #29 was.
+    """
+    oom = getattr(torch, "OutOfMemoryError", None)
+    if oom is not None and isinstance(e, oom):
+        return True
+    return "out of memory" in str(e).lower()
+
+
 def _requant(original, value, dtype, seed=0):
     """Re-quantise `value` to an fp8 `dtype`, keeping the maths on the GPU if it can.
 
-    Only ONE step of the re-quant has no MPS kernel -- the final float->fp8 cast.
-    Patch #8 (tensor_to_fp8) already routes that single op via a LUT/CPU hop, so
-    on a stack where it is installed the whole function runs on the GPU and
-    returns byte-identical fp8. Sending the entire tensor to the CPU instead, as
-    this patch did from S1 until #29, costs ~5.6x at per-weight granularity
-    (11.3 -> 2.0 ms/weight on an M5 Max) and is why loading an fp8 DiT with a
-    LoRA took minutes while the same model without one loaded fast.
+    Which operations lack an MPS kernel depends on which implementation comfy
+    calls, and the two differ:
 
-    The CPU round-trip stays reachable because it is still needed: comfy's own
-    fallback implementation writes through ``output[i:].copy_(...)``, a strided
-    fp8 copy that patch #8 does not cover (it wraps ``.to``, not ``copy_``).
+    - comfy_kitchen's ``stochastic_rounding_fp8`` has exactly one, the final
+      float->fp8 cast, and patch #8 (tensor_to_fp8) already routes that single op
+      via a LUT/CPU hop -- so wherever patch #8 is installed the whole function
+      runs on the GPU and returns byte-identical fp8.
+    - comfy's own fallback has a different one: it writes through
+      ``output[i:].copy_(...)``, a strided fp8 copy patch #8 does NOT cover (it
+      wraps ``.to``, not ``copy_``), so that path genuinely needs the CPU.
+
+    Since we cannot tell which one this stack will run, try the GPU once and
+    latch onto the CPU round-trip for the session if it raises. Sending every
+    tensor to the CPU unconditionally, as this patch did from S1 until #29, costs
+    ~4.6x at per-weight granularity (11.1 -> 2.4 ms/weight on an M5 Max) and is
+    why loading an fp8 DiT with a LoRA took minutes while the same model without
+    one loaded fast.
     """
     global _native_ok
     if value.device.type != "mps" or dtype not in FP8_DTYPES:
@@ -98,6 +118,13 @@ def _requant(original, value, dtype, seed=0):
             _native_ok = True
             return out
         except Exception as e:
+            # Deliberately broad. The alternative -- re-raising what we don't
+            # recognise -- turns a logged slowdown into a failed model load, and
+            # every fp8 path in this node is a compatibility shim whose first
+            # duty is not to break the load. The exception is reported, not
+            # swallowed, and the CPU result below is bit-exact either way.
+            if _is_transient(e):
+                return original(value.cpu(), dtype, seed=seed).to(value.device)
             if _native_ok is None:
                 print(f"{TAG} fp8 re-quant cannot run on MPS here ({e!r}); "
                       f"using the CPU round-trip for the rest of this session.")

--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -173,4 +173,5 @@ def install():
         extra = " + to_blocked"
 
     _installed = True
-    print(f"{TAG} stochastic_rounding{extra} FP8 re-quant routed via CPU on MPS.")
+    print(f"{TAG} stochastic_rounding{extra} FP8 re-quant runs on the GPU where "
+          f"the stack allows it, with a CPU round-trip as the fallback.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-applesilicon-fp8"
 description = "Run FP8 and INT8 quantized models (FLUX, SD3.5, Ideogram 4, Krea2) on Apple Silicon / MPS — compatibility fixes plus bit-exact fp8/int8 Metal matmul kernels, plus a psutil fix for recent macOS betas."
-version = "1.3.1"
+version = "1.3.2"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_caps.py
+++ b/tests/test_caps.py
@@ -71,15 +71,6 @@ def test_unrecognised_value_falls_through_to_default(monkeypatch):
     assert _caps.resolve("ASFP8_CAPS_TEST", default_on=True, cap=_cap(False)) is False
 
 
-# --- tier B implies both the tensor-ops probe AND ninja ---------------------
-def test_tier_b_requires_both_probe_and_ninja(monkeypatch):
-    monkeypatch.setattr(_caps, "has_tensor_ops_matmul2d", lambda: True)
-    monkeypatch.setattr(_caps, "ninja_available", lambda: False)
-    assert _caps.tier_b_ready() is False
-    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
-    assert _caps.tier_b_ready() is True
-
-
 def test_summary_is_a_string():
     s = _caps.summary()
     assert isinstance(s, str)
@@ -151,11 +142,24 @@ def test_reset_cache_clears_the_kernel_results():
     assert len(calls) == 2, "reset_cache() must force a re-probe"
 
 
-def test_summary_banner_substrings_are_unchanged():
-    """Other tests (and users' bug reports) match on these exact substrings."""
+def test_summary_banner_reports_the_chip_and_matrix_units():
+    """The banner is what users paste into bug reports, so it has to name the
+    thing the kernels actually depend on. `tensor_ops(M5/Metal4)=` claimed a GPU
+    generation it never measured -- it read yes on the M4 Pro of #25 and no on the
+    M5 Max of #27."""
     s = _caps.summary()
-    for token in ("mps=", "tensor_ops(M5/Metal4)=", "ninja="):
+    for token in ("mps=", "chip=", "matrix_units(M5+)=", "ninja="):
         assert token in s, f"{token!r} missing from banner: {s}"
+    assert "tensor_ops(M5/Metal4)=" not in s
+
+
+def test_summary_says_unknown_when_the_chip_cannot_be_identified(monkeypatch):
+    """Permissive gate, honest banner: an unidentified chip still gets a build
+    attempt, but the banner must not claim matrix units we never confirmed."""
+    _caps.reset_cache()
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: None)
+    s = _caps.summary()
+    assert "matrix_units(M5+)=unknown" in s
 
 
 def test_kernel_ready_verifies_once_under_concurrency():
@@ -205,3 +209,151 @@ def test_mark_kernel_failed_disables_without_reverifying():
     _caps.mark_kernel_failed("latch")
     assert _caps.kernel_ready("latch", verify) is False
     assert len(calls) == 1, "a latched-off kernel was re-verified"
+
+
+# --- chip identification and the matrix-unit gate (issues #25, #27) ---------
+#
+# Both issues are the same defect: has_tensor_ops_matmul2d() compiles na_gemm's
+# bf16 shader through torch.mps.compile_shader, which cannot request an MSL
+# language version -- so its answer tracks the torch build's default MSL, not the
+# GPU. #25 got tensor_ops=yes on an M4 Pro (kernel builds, every element garbage);
+# #27 got tensor_ops=no on an M5 Max (kernel is bit-exact and 3.17x faster). The
+# ObjC++ kernels want one thing the probe never measured: M5-class matrix units.
+
+
+@pytest.mark.parametrize("brand,gen", [
+    ("Apple M1", 1),
+    ("Apple M2 Pro", 2),
+    ("Apple M4 Pro", 4),
+    ("Apple M5 Max", 5),
+    ("Apple M10 Ultra", 10),
+])
+def test_chip_generation_parses_the_brand_string(monkeypatch, brand, gen):
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: brand)
+    assert _caps.chip_generation() == gen
+
+
+@pytest.mark.parametrize("brand", [
+    "Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz",
+    "Apple silicon",
+    "",
+    None,
+])
+def test_chip_generation_is_none_when_the_chip_is_unrecognisable(monkeypatch, brand):
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: brand)
+    assert _caps.chip_generation() is None
+
+
+def test_chip_generation_is_memoised(monkeypatch):
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    calls = []
+
+    def brand():
+        calls.append(1)
+        return "Apple M5 Max"
+
+    monkeypatch.setattr(_caps, "_cpu_brand_string", brand)
+    assert _caps.chip_generation() == 5
+    assert _caps.chip_generation() == 5
+    assert len(calls) == 1, "the sysctl probe must run once per session"
+
+
+def test_m4_reports_no_neural_accelerators(monkeypatch):
+    """#25: the tensor_ops kernels compile on M4 and return garbage."""
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M4 Pro")
+    assert _caps.has_neural_accelerators() is False
+
+
+def test_m5_reports_neural_accelerators(monkeypatch):
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M5 Max")
+    assert _caps.has_neural_accelerators() is True
+
+
+def test_unidentified_chip_stays_permissive(monkeypatch):
+    """Never false-negative on hardware we cannot name -- that is #27's failure
+    mode. kernel_ready()'s build + numeric self-check is the real authority; the
+    chip check only short-circuits hardware we positively know cannot work."""
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: None)
+    assert _caps.has_neural_accelerators() is True
+
+
+# --- kernel_gate: the pre-filter the ObjC++ extensions actually want --------
+
+
+def test_kernel_gate_requires_neural_accelerators(monkeypatch):
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "has_neural_accelerators", lambda: False)
+    assert _caps.kernel_gate() is False
+
+
+def test_kernel_gate_requires_ninja(monkeypatch):
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(_caps, "has_neural_accelerators", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: False)
+    assert _caps.kernel_gate() is False
+
+
+def test_kernel_gate_requires_mps(monkeypatch):
+    monkeypatch.setattr(_caps, "has_neural_accelerators", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "is_mps", lambda: False)
+    assert _caps.kernel_gate() is False
+
+
+def test_kernel_gate_passes_on_m5_with_a_toolchain(monkeypatch):
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(_caps, "has_neural_accelerators", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    assert _caps.kernel_gate() is True
+
+
+def test_kernel_gate_ignores_the_na_gemm_compile_probe(monkeypatch):
+    """#27 in one assertion: the M5 Max where compile_shader could not build
+    na_gemm's bf16 shader is the same M5 Max where int8_gemm.mm is bit-exact.
+    The ObjC++ kernels compile through newLibraryWithSource at an explicit MSL
+    version, so what compile_shader can manage says nothing about them."""
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(_caps, "has_neural_accelerators", lambda: True)
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+
+    probed = []
+
+    def probe():
+        probed.append(1)
+        return False
+
+    monkeypatch.setattr(_caps, "has_tensor_ops_matmul2d", probe)
+    assert _caps.kernel_gate() is True
+    assert probed == [], "kernel_gate() must not consult the compile_shader probe"
+
+
+# --- the compile_shader probe must verify numerics, not just compilation ----
+
+
+def test_tensor_ops_probe_requires_a_passing_numeric_self_check(monkeypatch):
+    """na_gemm.available() only proves the shader compiled. #25 is a machine where
+    a tensor_ops shader compiles and computes garbage, so conv_im2col -- the one
+    consumer still gated on this probe -- needs the numeric check, not the build."""
+    import sys
+    import types
+
+    monkeypatch.setattr(_caps, "_tensor_ops", None)
+    monkeypatch.setattr(_caps, "has_compile_shader", lambda: True)
+
+    import _patches
+
+    fake = types.ModuleType("_patches.na_gemm")
+    fake.available = lambda: True
+    fake.self_check_ok = lambda: False
+    # `from . import na_gemm` resolves through the parent package attribute once
+    # the real module has been imported, so both bindings have to be replaced.
+    monkeypatch.setitem(sys.modules, "_patches.na_gemm", fake)
+    monkeypatch.setattr(_patches, "na_gemm", fake, raising=False)
+
+    assert _caps.has_tensor_ops_matmul2d() is False

--- a/tests/test_caps.py
+++ b/tests/test_caps.py
@@ -357,3 +357,21 @@ def test_tensor_ops_probe_requires_a_passing_numeric_self_check(monkeypatch):
     monkeypatch.setattr(_patches, "na_gemm", fake, raising=False)
 
     assert _caps.has_tensor_ops_matmul2d() is False
+
+
+def test_no_patch_seeds_the_global_rng():
+    """`torch.manual_seed()` inside a library is never right: it reseeds every
+    device for the whole host process. The capability probes and kernel
+    self-checks all need deterministic operands, which is what a local
+    torch.Generator is for -- scaled_mm_fp8's fp8 self-check runs lazily on the
+    *first fp8 matmul*, so seeding there lands in the middle of a render."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parent.parent / "_patches"
+    offenders = [
+        f"{p.relative_to(root.parent)}:{i}"
+        for p in sorted(root.rglob("*.py"))
+        for i, line in enumerate(p.read_text().splitlines(), 1)
+        if "torch.manual_seed(" in line and not line.lstrip().startswith("#")
+    ]
+    assert offenders == [], f"global RNG seeded by: {offenders}"

--- a/tests/test_fp8_linear_kernel.py
+++ b/tests/test_fp8_linear_kernel.py
@@ -19,7 +19,7 @@ def test_loader_gated_off_when_unsupported(monkeypatch):
     from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: False)
     _reset_loader(monkeypatch)
     assert loader.module() is None
 
@@ -27,7 +27,7 @@ def test_loader_gated_off_when_unsupported(monkeypatch):
 def test_loader_forced_off_beats_capability(monkeypatch):
     # Explicit off on both flags wins even on capable HW -> no build.
     from _patches import _caps
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_FP8_EXT", "off")
     monkeypatch.setenv("ASFP8_FP8_NATIVE", "off")
     _reset_loader(monkeypatch)
@@ -37,7 +37,7 @@ def test_loader_forced_off_beats_capability(monkeypatch):
 def test_loader_memo_resets_between_flag_states(monkeypatch):
     # Off -> None, then flip NATIVE on with a fresh reset; the gate must re-evaluate.
     from _patches import _caps
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: False)
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
     _reset_loader(monkeypatch)
@@ -66,7 +66,7 @@ def _clear_fp8_kernel_memo():
 def test_install_noop_when_explicitly_off(monkeypatch):
     # ASFP8_FP8_NATIVE=off force-disables even on capable hardware.
     from _patches import _caps
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_FP8_NATIVE", "off")
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
@@ -74,10 +74,10 @@ def test_install_noop_when_explicitly_off(monkeypatch):
 
 
 def test_install_noop_when_not_capable(monkeypatch):
-    # DEFAULT ON but Tier-B gated: unsupported hardware -> no build, stays inert.
+    # DEFAULT ON but hardware-gated: unsupported hardware -> no build, stays inert.
     from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: False)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
     assert patch._installed is False
@@ -90,7 +90,7 @@ def test_install_does_not_build_the_extension(monkeypatch):
     """install() runs at import time: it may wire the seam, never build the kernel."""
     from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     monkeypatch.setattr(patch, "_kernel", None, raising=False)
     monkeypatch.setattr(patch, "_kernel_tried", False, raising=False)
@@ -128,7 +128,7 @@ def test_loader_gives_up_when_the_build_stalls(monkeypatch):
 
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
     monkeypatch.delenv("ASFP8_FP8_NATIVE", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_EXT_BUILD_TIMEOUT", "0.5")
     _reset_loader(monkeypatch)
 
@@ -187,7 +187,7 @@ from _patches import fp8_linear_kernel_mps as _fp8patch
 # uses, so a kernel that stops compiling surfaces as a failure rather than a
 # silent skip (issue #13). ASFP8_FP8_NATIVE=0 turns them off with the feature.
 _fp8_enabled = torch.backends.mps.is_available() and _caps.resolve(
-    "ASFP8_FP8_NATIVE", default_on=True, cap=_caps.tier_b_ready
+    "ASFP8_FP8_NATIVE", default_on=True, cap=_caps.kernel_gate
 )
 
 

--- a/tests/test_int4_linear.py
+++ b/tests/test_int4_linear.py
@@ -237,21 +237,28 @@ def test_int4_dispatch_failure_latches_off_the_kernel(monkeypatch):
         _caps._kernel_ready.pop("int4", None)
 
 
-def test_int4_does_not_build_on_a_pre_m5_chip(monkeypatch):
-    """#25 applies to int4 too, and harder: it has no env gate at all, so every
-    ConvRot layer on an M1-M4 box reaches kernel_ready() and pays the build before
-    the self-check rejects it. W4A16 must still return the right answer."""
+@requires_mps
+def test_int4_explicit_opt_in_is_honoured_on_pre_m5_hardware(monkeypatch):
+    """int4 is opt-in (README: `ASFP8_INT4_EXT` default **off**) and its loader
+    returns None before building whenever the var is unset -- so a chip pre-filter
+    here would save no build at all, and would only be reachable in the one case
+    where the user has explicitly asked for the kernel.
+
+    _caps' standing promise is that an explicit env var beats any probe, "so
+    nothing here can lock a user out". Forcing the build on hardware we believe
+    cannot run it is the user's call to make; the self-check still rejects the
+    result, which is the outcome #25 documents.
+    """
     from _patches import _caps
 
-    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
     _caps._kernel_ready.pop("int4", None)
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
     monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M4 Pro")
-    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
-    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setenv("ASFP8_INT4_EXT", "1")
 
     verifies = []
     monkeypatch.setattr(int4_linear_mps, "_verify",
-                        lambda: verifies.append(1) or True)
+                        lambda: verifies.append(1) or False)
 
     _, qdata, wscales = _quantized_weight()
     x = torch.randn(8, K, dtype=torch.bfloat16, device="mps")
@@ -260,7 +267,9 @@ def test_int4_does_not_build_on_a_pre_m5_chip(monkeypatch):
         out = int4_linear_mps._w4a16_linear_mps(
             x, qdata.to("mps"), wscales.to("mps"), None, 256, ck_eager
         )
-        assert out.shape == (8, N)
-        assert verifies == [], "int4 attempted a kernel build on pre-M5 hardware"
+        assert out.shape == (8, N), "W4A16 must still answer when the kernel is out"
+        assert verifies == [1], (
+            "an explicit ASFP8_INT4_EXT=1 was overridden by the chip probe"
+        )
     finally:
         _caps._kernel_ready.pop("int4", None)

--- a/tests/test_int4_linear.py
+++ b/tests/test_int4_linear.py
@@ -235,3 +235,32 @@ def test_int4_dispatch_failure_latches_off_the_kernel(monkeypatch):
         assert _caps._kernel_ready["int4"] is False
     finally:
         _caps._kernel_ready.pop("int4", None)
+
+
+def test_int4_does_not_build_on_a_pre_m5_chip(monkeypatch):
+    """#25 applies to int4 too, and harder: it has no env gate at all, so every
+    ConvRot layer on an M1-M4 box reaches kernel_ready() and pays the build before
+    the self-check rejects it. W4A16 must still return the right answer."""
+    from _patches import _caps
+
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    _caps._kernel_ready.pop("int4", None)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M4 Pro")
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+
+    verifies = []
+    monkeypatch.setattr(int4_linear_mps, "_verify",
+                        lambda: verifies.append(1) or True)
+
+    _, qdata, wscales = _quantized_weight()
+    x = torch.randn(8, K, dtype=torch.bfloat16, device="mps")
+
+    try:
+        out = int4_linear_mps._w4a16_linear_mps(
+            x, qdata.to("mps"), wscales.to("mps"), None, 256, ck_eager
+        )
+        assert out.shape == (8, N)
+        assert verifies == [], "int4 attempted a kernel build on pre-M5 hardware"
+    finally:
+        _caps._kernel_ready.pop("int4", None)

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -723,3 +723,121 @@ def test_install_banner_does_not_claim_an_unverified_kernel(monkeypatch, capsys)
     out = capsys.readouterr().out
     assert "routed through" not in out, f"banner claims a result it hasn't got: {out}"
     assert "self-check" in out.lower(), f"banner doesn't mention verification: {out}"
+
+
+@requires_mps
+def test_force_cast_weights_does_not_disqualify_the_kernel(monkeypatch):
+    """comfy sets comfy_force_cast_weights on int8 layers where storage dtype !=
+    compute dtype; for a QuantizedTensor that cast is the per-call W8A16 dequant
+    this kernel bypasses, so the flag must not push the layer off the kernel route
+    (regression: it silently forced MiniMax Music 3's whole TE onto the slow path)."""
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_kernel", object(), raising=False)
+    monkeypatch.setattr(patch, "_kernel_tried", True, raising=False)
+    monkeypatch.setattr(patch, "_self_checked", True, raising=False)
+    monkeypatch.setattr(patch, "_self_ok", True, raising=False)
+
+    out = torch.full((1,), 7.0)
+    monkeypatch.setattr(patch, "_int8_linear_kernel", lambda *a, **k: out, raising=False)
+
+    qw = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    ).to("mps")
+
+    class Holder:
+        weight = qw
+        bias = None
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    x = torch.randn(8, 128, dtype=torch.bfloat16, device="mps")
+    assert patch._try_int8_kernel_forward(Holder(), x) is out, (
+        "comfy_force_cast_weights pushed an int8 layer off the kernel route"
+    )
+
+
+@requires_mps
+def test_dequant_retries_after_a_transient_off_mps_call(monkeypatch):
+    """An off-MPS first call must not latch _asfp8_deq_done: the same layer can be
+    called later with MPS input (offload/warmup) and should still dequantise then."""
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", True, raising=False)
+
+    qw = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    ).to("mps")
+
+    class Holder:
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    layer = Holder()
+    layer.weight = qw
+    layer.bias = None
+
+    patch._maybe_dequant_weight(layer, torch.randn(1, 128, dtype=torch.bfloat16))
+    assert isinstance(layer.weight, QuantizedTensor), "dequantised from a CPU-input call"
+    assert not getattr(layer, "_asfp8_deq_done", False), "off-MPS call latched the flag"
+
+    x = torch.randn(1, 128, dtype=torch.bfloat16, device="mps")
+    patch._maybe_dequant_weight(layer, x)
+    assert not isinstance(layer.weight, QuantizedTensor), "MPS call did not dequantise"
+    assert layer.weight.dtype == torch.bfloat16
+    assert layer.weight.device.type == "mps"
+    assert layer._asfp8_deq_done is True
+
+    ref = qw.dequantize().to(torch.bfloat16)
+    assert torch.equal(layer.weight.detach().cpu(), ref.cpu()), (
+        "dequantised weight differs from QuantizedTensor.dequantize()"
+    )
+
+
+# --- the ASFP8_INT8_DEQUANT gate: the switch people actually touch --------------
+
+
+def _resolve_dequant_gate(monkeypatch, env, total_ram):
+    import psutil
+
+    class _VM:
+        total = total_ram
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", None, raising=False)
+    if env is None:
+        monkeypatch.delenv("ASFP8_INT8_DEQUANT", raising=False)
+    else:
+        monkeypatch.setenv("ASFP8_INT8_DEQUANT", env)
+    monkeypatch.setattr(psutil, "virtual_memory", lambda: _VM())
+    return patch._dequant_enabled()
+
+
+def test_dequant_gate_is_opt_in(monkeypatch):
+    """Unset stays OFF regardless of RAM: the plain copy lands after comfy's
+    model_management has already budgeted around the int8 size."""
+    assert _resolve_dequant_gate(monkeypatch, None, 128 * (1 << 30)) is False
+
+
+def test_dequant_gate_off_stays_off(monkeypatch):
+    assert _resolve_dequant_gate(monkeypatch, "off", 128 * (1 << 30)) is False
+
+
+def test_dequant_gate_on_with_enough_ram(monkeypatch):
+    assert _resolve_dequant_gate(monkeypatch, "1", 128 * (1 << 30)) is True
+
+
+def test_dequant_gate_ram_check_overrides_opt_in(monkeypatch, capsys):
+    """=1 on a small box is refused (safety), and says so."""
+    assert _resolve_dequant_gate(monkeypatch, "1", 16 * (1 << 30)) is False
+    assert "48 GiB" in capsys.readouterr().out
+
+
+def test_dequant_gate_memoises(monkeypatch):
+    """The gate resolves once; later env changes don't flip a live session."""
+    assert _resolve_dequant_gate(monkeypatch, "1", 128 * (1 << 30)) is True
+    monkeypatch.setenv("ASFP8_INT8_DEQUANT", "off")
+    assert patch._dequant_enabled() is True

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -25,7 +25,7 @@ from _patches import _caps
 # compiling (issue #13) showed up as 34 silent skips. ASFP8_INT8_EXT=0 still turns
 # them off, exactly as it turns the feature off.
 _int8_enabled = torch.backends.mps.is_available() and _caps.resolve(
-    "ASFP8_INT8_EXT", default_on=True, cap=_caps.tier_b_ready
+    "ASFP8_INT8_EXT", default_on=True, cap=_caps.kernel_gate
 )
 
 
@@ -64,7 +64,7 @@ def _clear_int8_kernel_memo():
 def test_install_noop_when_explicitly_off(monkeypatch):
     """ASFP8_INT8_EXT=off force-disables even on capable hardware."""
     from _patches import _caps
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_INT8_EXT", "off")
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
@@ -75,7 +75,7 @@ def test_install_noop_when_not_capable(monkeypatch):
     """DEFAULT ON but gated: unsupported hardware -> no build attempt, stays inert."""
     from _patches import _caps
     monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: False)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     patch.install()
     assert patch._installed is False
@@ -92,7 +92,7 @@ def test_install_does_not_build_the_extension(monkeypatch):
     """install() runs at import time: it may wire the seam, never build the kernel."""
     from _patches import _caps
     monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setattr(patch, "_installed", False, raising=False)
     monkeypatch.setattr(patch, "_kernel", None, raising=False)
     monkeypatch.setattr(patch, "_kernel_tried", False, raising=False)
@@ -173,7 +173,7 @@ def test_loader_gives_up_when_the_build_stalls(monkeypatch):
         pytest.skip("needs the Metal toolchain + ninja to reach the build call")
 
     monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_EXT_BUILD_TIMEOUT", "0.5")
     monkeypatch.setattr(loader, "_tried", False, raising=False)
     monkeypatch.setattr(loader, "_mod", None, raising=False)
@@ -555,7 +555,7 @@ def test_int8_kernel_compiles_when_enabled():
 def test_failed_verification_disables_the_kernel_and_is_not_retried(monkeypatch):
     """A kernel that fails verification must cost one attempt, not one per layer.
 
-    This is the #14 gap: tier_b_ready() green-lights int8 off na_gemm's bf16
+    This is the #14 gap: kernel_gate() green-lights int8 off na_gemm's bf16
     probe, so a kernel that cannot build still reaches the forward path. The
     per-kernel memo is what stops that becoming a per-call rebuild.
     """
@@ -628,3 +628,98 @@ def test_a_forward_failure_after_verification_disables_the_kernel(monkeypatch):
 
     assert len(calls) == 1, f"kernel re-entered after a dispatch failure ({len(calls)}x)"
     assert _caps._kernel_ready["int8"] is False
+
+
+# --- the hardware gate: issues #25 and #27 ----------------------------------
+#
+# One defect, reported from both ends. The old gate (kernel_gate) asked
+# torch.mps.compile_shader to build na_gemm's bf16 shader, which measures the
+# torch build's default MSL rather than the GPU. It answered yes on the M4 Pro of
+# #25, where int8_gemm.mm builds and returns garbage, and no on the M5 Max of
+# #27, where the very same kernel is bit-exact and 3.17x faster.
+
+
+def test_install_is_inert_on_a_pre_m5_chip(monkeypatch):
+    """#25: on M1-M4 there are no Neural Accelerators, so the tensor-ops kernel
+    dispatches and computes garbage. _self_check() catches it -- but only after
+    every cold start has paid a ~7s ninja+clang build for a kernel that is then
+    discarded. A chip we can positively name as pre-M5 must not reach the seam.
+    """
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M4 Pro")
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+
+    patch.install()
+
+    assert patch._installed is False
+
+
+def _stub_comfy_ops(monkeypatch):
+    """Stand in for `comfy.ops`, which isn't importable from the repo root.
+
+    install() wraps ops.mixed_precision_ops, so without this the gate tests can
+    never observe a completed install -- install() bails on the import first.
+    """
+    import sys
+    import types
+
+    class _Linear:
+        def forward(self, x):
+            return x
+
+    def mixed_precision_ops(*a, **k):
+        return type("Ops", (), {"Linear": type("Linear", (_Linear,), {})})
+
+    comfy = types.ModuleType("comfy")
+    ops = types.ModuleType("comfy.ops")
+    ops.mixed_precision_ops = mixed_precision_ops
+    comfy.ops = ops
+    monkeypatch.setitem(sys.modules, "comfy", comfy)
+    monkeypatch.setitem(sys.modules, "comfy.ops", ops)
+    return ops
+
+
+def test_install_survives_a_failing_compile_shader_probe(monkeypatch):
+    """#27: macOS 26.6 + torch 2.10 on an M5 Max cannot compile na_gemm through
+    compile_shader ("use of undeclared identifier 'mpp'"), while int8_gemm.mm
+    builds fine via newLibraryWithSource at MSL 4.0 and passes its bit-exact
+    self-check. The probe's verdict must not disable the kernel."""
+    _stub_comfy_ops(monkeypatch)
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M5 Max")
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(_caps, "has_tensor_ops_matmul2d", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+    monkeypatch.setattr(patch, "_load_kernel", lambda: None, raising=False)
+
+    patch.install()
+
+    assert patch._installed is True
+
+
+def test_install_banner_does_not_claim_an_unverified_kernel(monkeypatch, capsys):
+    """#25's second cost: the startup line announced the kernel as routing before
+    anything had been built or numerically checked, and the retraction landed one
+    line deep in the sampling log. The banner must promise a check, not a result.
+    """
+    _stub_comfy_ops(monkeypatch)
+    monkeypatch.setattr(_caps, "_chip_gen", _caps._UNPROBED)
+    monkeypatch.delenv("ASFP8_INT8_EXT", raising=False)
+    monkeypatch.setattr(_caps, "_cpu_brand_string", lambda: "Apple M5 Max")
+    monkeypatch.setattr(_caps, "ninja_available", lambda: True)
+    monkeypatch.setattr(_caps, "is_mps", lambda: True)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    monkeypatch.setattr(patch, "_installed", False, raising=False)
+    monkeypatch.setattr(patch, "_load_kernel", lambda: None, raising=False)
+
+    patch.install()
+
+    out = capsys.readouterr().out
+    assert "routed through" not in out, f"banner claims a result it hasn't got: {out}"
+    assert "self-check" in out.lower(), f"banner doesn't mention verification: {out}"

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -841,3 +841,36 @@ def test_dequant_gate_memoises(monkeypatch):
     assert _resolve_dequant_gate(monkeypatch, "1", 128 * (1 << 30)) is True
     monkeypatch.setenv("ASFP8_INT8_DEQUANT", "off")
     assert patch._dequant_enabled() is True
+
+
+@requires_mps
+def test_offloaded_cpu_weight_does_not_latch_the_kernel_off(monkeypatch):
+    """comfy parks weights on CPU between uses and casts them back in via
+    comfy_force_cast_weights. Now that the force-cast bail is gone (#26), such a
+    layer reaches this path -- and if it got as far as _int8_linear_kernel, that
+    function's own fallback would hand an MPS input and a CPU weight to the eager
+    int8_linear, throw, and latch mark_kernel_failed. One offloaded layer would
+    then disable int8 for the rest of the session, over a transient condition.
+    """
+    from comfy_kitchen.tensor import QuantizedTensor
+    from _patches import _caps
+
+    qw_cpu = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    )
+    assert qw_cpu.device.type == "cpu", "fixture must stay off-device"
+
+    class Holder:
+        weight = qw_cpu
+        bias = None
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    x = torch.randn(8, 128, dtype=torch.bfloat16, device="mps")
+
+    assert patch._try_int8_kernel_forward(Holder(), x) is None
+    assert _caps._kernel_ready.get("int8") is not False, (
+        "an offloaded weight latched the int8 kernel off for the session"
+    )

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -555,9 +555,9 @@ def test_int8_kernel_compiles_when_enabled():
 def test_failed_verification_disables_the_kernel_and_is_not_retried(monkeypatch):
     """A kernel that fails verification must cost one attempt, not one per layer.
 
-    This is the #14 gap: kernel_gate() green-lights int8 off na_gemm's bf16
-    probe, so a kernel that cannot build still reaches the forward path. The
-    per-kernel memo is what stops that becoming a per-call rebuild.
+    This is the #14 gap: kernel_gate() clears int8 on chip + toolchain alone, so
+    a kernel that cannot build still reaches the forward path. The per-kernel
+    memo is what stops that becoming a per-call rebuild.
     """
     from comfy_kitchen.tensor import QuantizedTensor
     from _patches import _caps

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -874,3 +874,42 @@ def test_offloaded_cpu_weight_does_not_latch_the_kernel_off(monkeypatch):
     assert _caps._kernel_ready.get("int8") is not False, (
         "an offloaded weight latched the int8 kernel off for the session"
     )
+
+
+@requires_mps
+def test_dequant_leaves_an_offloaded_weight_on_the_cpu(monkeypatch):
+    """comfy parks weights on CPU to keep them out of memory. Dequantising one
+    pulls a bigger, full-precision copy onto the GPU and pins it there, undoing
+    the offload and inflating residency past what the >= 48 GiB gate budgeted for.
+
+    The flag must stay unset too: being offloaded is transient, so the layer
+    should still dequantise once comfy brings the weight back -- the same
+    treatment _maybe_dequant_embedding already gives this case.
+    """
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", True, raising=False)
+
+    qw_cpu = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    )
+    assert qw_cpu.device.type == "cpu", "fixture must stay offloaded"
+
+    class Holder:
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    layer = Holder()
+    layer.weight = qw_cpu
+    layer.bias = None
+
+    x = torch.randn(1, 128, dtype=torch.bfloat16, device="mps")
+    patch._maybe_dequant_weight(layer, x)
+
+    assert isinstance(layer.weight, QuantizedTensor), "offloaded weight was dequantised"
+    assert layer.weight.device.type == "cpu", "offloaded weight was pulled onto the GPU"
+    assert not getattr(layer, "_asfp8_deq_done", False), (
+        "a transient offload latched the layer out of ever dequantising"
+    )

--- a/tests/test_na_gemm.py
+++ b/tests/test_na_gemm.py
@@ -30,3 +30,42 @@ def test_self_check_caches_and_is_bool():
     v1 = na_gemm.self_check_ok()
     v2 = na_gemm.self_check_ok()
     assert isinstance(v1, bool) and v1 == v2
+
+
+@requires_mps
+def test_self_check_does_not_disturb_the_global_rng(monkeypatch):
+    """This probe became automatic in v1.3.2: conv im2col's gate runs it at plugin
+    import. Seeding the process RNG from inside a capability probe silently
+    changes every later torch.randn in the host application -- and ComfyUI is a
+    host whose whole output is a function of its seed."""
+    monkeypatch.setattr(na_gemm, "_self_check", None)
+    # Pin a distinctive state first. Neighbouring tests in this file seed 0 and
+    # draw the same two shapes the probe does, so capturing whatever they left
+    # behind makes this assertion vacuously true.
+    torch.manual_seed(4242)
+    before = torch.get_rng_state().clone()
+
+    na_gemm.self_check_ok()
+
+    assert torch.equal(torch.get_rng_state(), before), (
+        "self_check_ok() reseeded the global RNG"
+    )
+
+
+@requires_mps
+def test_self_check_reprobes_after_reset_cache(monkeypatch):
+    """_caps.reset_cache() promises tests a genuine re-probe. It clears its own
+    memo, so na_gemm has to drop the cached numeric verdict too -- otherwise the
+    reset returns the stale answer and a test's stubbed conditions never apply."""
+    from _patches import _caps
+
+    if not na_gemm.available():
+        pytest.skip("NA matmul2d not available on this OS/SDK/PyTorch build")
+
+    assert na_gemm.self_check_ok() is True
+    monkeypatch.setattr(na_gemm, "_self_check", False)   # poison the verdict
+
+    _caps.reset_cache()
+
+    assert na_gemm._self_check is None, "reset_cache() left a stale numeric verdict"
+    assert _caps.has_tensor_ops_matmul2d() is True

--- a/tests/test_scaled_mm_fp8.py
+++ b/tests/test_scaled_mm_fp8.py
@@ -134,17 +134,17 @@ def test_fast_ineligible_non_mps(monkeypatch):
 def test_fast_ineligible_when_explicitly_off(monkeypatch):
     # Explicit opt-out wins over capability + shape, even on supported hardware.
     from _patches import _caps
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     monkeypatch.setenv("ASFP8_FP8_EXT", "off")
     inp, other = _operands(K=12288, N=3072)
     assert scaled_mm_fp8._fast_eligible(inp, other) is False
 
 
 def test_default_on_when_capable(monkeypatch):
-    # DEFAULT ON: unset + Tier-B capable -> eligible (no explicit flag needed).
+    # DEFAULT ON: unset + capable hardware -> eligible (no explicit flag needed).
     from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: True)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: True)
     inp, other = _operands(K=12288, N=3072)
     assert scaled_mm_fp8._fast_eligible(inp, other) is True
 
@@ -153,7 +153,7 @@ def test_default_off_when_not_capable(monkeypatch):
     # DEFAULT gated: unset + unsupported hardware -> inert (the promise).
     from _patches import _caps
     monkeypatch.delenv("ASFP8_FP8_EXT", raising=False)
-    monkeypatch.setattr(_caps, "tier_b_ready", lambda: False)
+    monkeypatch.setattr(_caps, "kernel_gate", lambda: False)
     inp, other = _operands(K=12288, N=3072)
     assert scaled_mm_fp8._fast_eligible(inp, other) is False
 

--- a/tests/test_stochastic_round_fp8.py
+++ b/tests/test_stochastic_round_fp8.py
@@ -115,3 +115,33 @@ def test_native_requant_is_bit_exact_vs_the_cpu_round_trip():
     assert torch.equal(
         native.cpu().view(torch.uint8), reference.cpu().view(torch.uint8)
     ), "GPU re-quant differs from the CPU round-trip it replaces"
+
+
+@requires_mps
+@pytest.mark.parametrize("exc", [
+    torch.OutOfMemoryError("MPS backend out of memory (MPS allocated: 90.00 GB)"),
+    RuntimeError("MPS backend out of memory (MPS allocated: 90.00 GB)"),
+])
+def test_a_transient_oom_does_not_condemn_the_session(exc):
+    """Memory pressure is not a missing kernel. Latching the whole session onto
+    the 4.6x-slower path because one weight hit the allocator would be the same
+    silent regression #29 was -- the next weight must try the GPU again."""
+    calls = []
+
+    def original(value, dtype, seed=0):
+        calls.append(value.device.type)
+        if value.device.type == "mps" and len(calls) == 1:
+            raise exc
+        return torch.zeros(value.shape, dtype=dtype, device=value.device)
+
+    x = torch.randn(64, device="mps")
+
+    first = patch._requant(original, x, torch.float8_e4m3fn, 0)
+    second = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert first.device.type == "mps", "the failed weight must still get a result"
+    assert second.device.type == "mps"
+    assert calls == ["mps", "cpu", "mps"], (
+        f"expected a per-call fallback then a fresh GPU attempt, got {calls}"
+    )
+    assert patch._native_ok is not False, "a transient OOM latched the session off the GPU"

--- a/tests/test_stochastic_round_fp8.py
+++ b/tests/test_stochastic_round_fp8.py
@@ -1,0 +1,117 @@
+"""Tests for patch #7: FP8 re-quant on MPS (LoRA applied to an fp8 base model).
+
+Issue #29: loading an fp8 DiT with a LoRA took 80-200s, while the same model with
+no LoRA loaded fast and int8 convrot was unaffected. LoRA application re-quantises
+every weight it touches, and this patch was sending each of those to the CPU in
+full -- because ONE operation inside the re-quant, the final float->fp8 cast, has
+no MPS kernel. Patch #8 (tensor_to_fp8) already routes exactly that cast via a
+LUT/CPU hop, so the rest of the maths can stay on the GPU. Measured 5.6x at
+per-weight granularity (11.3 -> 2.0 ms/weight), bit-exact.
+
+The CPU round-trip has to stay reachable: comfy's own fallback implementation
+writes through `output[i:].copy_(...)`, a strided fp8 copy that patch #8 does not
+cover (it wraps `.to`, not `copy_`).
+"""
+import torch
+
+import pytest
+
+from conftest import requires_mps
+
+from _patches import stochastic_round_fp8 as patch
+
+
+@pytest.fixture(autouse=True)
+def _forget_native_probe(monkeypatch):
+    """The native/CPU verdict is memoised per session; don't leak it between tests."""
+    monkeypatch.setattr(patch, "_native_ok", None, raising=False)
+
+
+def _recorder(fail_on_mps=False):
+    """Stand-in for comfy.float.stochastic_rounding that records operand devices."""
+    seen = []
+
+    def original(value, dtype, seed=0):
+        seen.append(value.device.type)
+        if fail_on_mps and value.device.type == "mps":
+            raise TypeError("Trying to convert Float8_e4m3fn to the MPS backend")
+        return torch.zeros(value.shape, dtype=dtype, device=value.device)
+
+    original.seen = seen
+    return original
+
+
+@requires_mps
+def test_native_mps_path_is_preferred():
+    """The whole point of #29: don't ship the tensor to the CPU when the GPU can
+    do the maths and patch #8 can handle the one unsupported cast."""
+    original = _recorder()
+    x = torch.randn(256, device="mps")
+
+    out = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen == ["mps"], f"re-quant left the GPU: {original.seen}"
+    assert out.device.type == "mps"
+
+
+@requires_mps
+def test_falls_back_to_the_cpu_round_trip_when_native_raises():
+    """comfy's own fallback implementation writes through a strided fp8 copy_,
+    which patch #8 doesn't cover -- that path still needs the CPU hop."""
+    original = _recorder(fail_on_mps=True)
+    x = torch.randn(256, device="mps")
+
+    out = patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen == ["mps", "cpu"], f"expected a CPU retry: {original.seen}"
+    assert out.device.type == "mps", "result must come back to the caller's device"
+    assert out.dtype is torch.float8_e4m3fn
+
+
+@requires_mps
+def test_a_failed_native_path_is_not_retried_per_weight():
+    """A LoRA re-quantises every weight it touches. Re-raising and re-catching on
+    each one would put the exception cost back on the hot path #29 is about."""
+    original = _recorder(fail_on_mps=True)
+    x = torch.randn(256, device="mps")
+
+    for _ in range(5):
+        patch._requant(original, x, torch.float8_e4m3fn, 0)
+
+    assert original.seen.count("mps") == 1, (
+        f"native path retried {original.seen.count('mps')}x across 5 weights"
+    )
+    assert original.seen.count("cpu") == 5
+
+
+def test_non_fp8_targets_are_passed_straight_through():
+    original = _recorder()
+    x = torch.randn(16)
+
+    patch._requant(original, x, torch.bfloat16, 0)
+
+    assert original.seen == ["cpu"]
+
+
+@requires_mps
+def test_native_requant_is_bit_exact_vs_the_cpu_round_trip():
+    """The anchor for the whole change: moving the maths back onto the GPU must
+    not move the numbers. Compared byte-for-byte in the stored fp8 encoding."""
+    import comfy_kitchen.backends.eager.quantization as q
+    from _patches import tensor_to_fp8
+
+    tensor_to_fp8.install()   # supplies the float->fp8 cast the GPU path needs
+
+    rng = torch.rand(8192, dtype=torch.float16)
+
+    def original(value, dtype, seed=0):
+        return q.stochastic_rounding_fp8(value, rng.to(value.device), dtype)
+
+    x = (torch.randn(8192) * 3).to("mps")
+
+    native = patch._requant(original, x, torch.float8_e4m3fn, 0)
+    reference = original(x.cpu(), torch.float8_e4m3fn).to("mps")
+
+    assert torch.equal(
+        native.cpu().view(torch.uint8), reference.cpu().view(torch.uint8)
+    ), "GPU re-quant differs from the CPU round-trip it replaces"


### PR DESCRIPTION


## Summary by Sourcery

Release v1.3.2 with more reliable Apple Silicon kernel gating, verified native INT8/FP8 execution, and faster quantized-model loading paths.

New Features:
- Add opt-in one-time INT8 weight dequantization for memory-rich systems to accelerate small-batch inference.
- Use GPU-side FP8 stochastic re-quantization when supported, with adaptive CPU fallback for unsupported stacks.

Bug Fixes:
- Correct Metal kernel capability detection by separating chip hardware gating from compile_shader probing and requiring per-kernel numeric self-checks before routing.
- Prevent offloaded INT8 weights and comfy force-cast settings from incorrectly disabling or poisoning the native INT8 path.
- Avoid modifying the host process RNG during capability and kernel self-checks.
- Improve FP8 LoRA loading performance while retaining compatibility with fallback implementations.

Enhancements:
- Update capability reporting and documentation to describe M5-class matrix-unit gating, kernel verification, and the new INT8 dequantization option.

Build:
- Bump the package version to 1.3.2.

Documentation:
- Revise README capability guidance, startup output, kernel gating behavior, and environment-variable documentation.

Tests:
- Expand coverage for chip detection, hardware gating, numeric verification, cache resets, RNG isolation, INT8 dequantization, and FP8 re-quantization fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added M5+ hardware detection for eligible accelerated kernel builds.
  - Added optional `ASFP8_INT8_DEQUANT` support for one-time INT8 weight dequantization, subject to a 48 GiB RAM minimum.
  - INT8 kernels now perform a bit-exact self-check before routing workloads.

- **Bug Fixes**
  - Preserved global random-number-generator state during capability checks.
  - Improved handling of offloaded and force-cast quantized weights.
  - FP8 re-quantization now prefers the GPU, with safer CPU fallback handling.

- **Documentation**
  - Updated capability, hardware-support, and startup-log documentation.
  - Updated the version to 1.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->