### PR TITLE
fix(int8): don't dequantise an offloaded weight onto the GPU

### DIFF
--- a/_patches/int8_linear_kernel_mps.py
+++ b/_patches/int8_linear_kernel_mps.py
@@ -407,13 +407,21 @@ def _maybe_dequant_weight(self, input):
         # dequantised copy to 2x the size the >= 48 GiB gate budgets for.
         if input.dtype not in (torch.float16, torch.bfloat16):
             return
+        # Offloaded weight: comfy is deliberately keeping it off-device, so
+        # dequantising would pull a bigger, full-precision copy onto the GPU and
+        # pin it there -- undoing the offload and inflating residency past what
+        # the >= 48 GiB gate budgeted for. Transient like the checks above, so
+        # the flag stays unset and a later resident call can still dequantise.
+        # _maybe_dequant_embedding already treats its weight this way.
+        w = getattr(self, "weight", None)
+        if w is None or getattr(w, "device", None) is None or w.device.type != "mps":
+            return
         self._asfp8_deq_done = True
         if getattr(self, "_full_precision_mm", False):
             return
         if len(getattr(self, "weight_function", [])) or len(getattr(self, "bias_function", [])):
             return
 
-        w = self.weight
         if isinstance(w, QuantizedTensor):
             if getattr(w, "_layout_cls", None) != "TensorWiseINT8Layout":
                 return

--- a/_patches/stochastic_round_fp8.py
+++ b/_patches/stochastic_round_fp8.py
@@ -173,4 +173,5 @@ def install():
         extra = " + to_blocked"
 
     _installed = True
-    print(f"{TAG} stochastic_rounding{extra} FP8 re-quant routed via CPU on MPS.")
+    print(f"{TAG} stochastic_rounding{extra} FP8 re-quant runs on the GPU where "
+          f"the stack allows it, with a CPU round-trip as the fallback.")

--- a/tests/test_int8_linear_kernel.py
+++ b/tests/test_int8_linear_kernel.py
@@ -874,3 +874,42 @@ def test_offloaded_cpu_weight_does_not_latch_the_kernel_off(monkeypatch):
     assert _caps._kernel_ready.get("int8") is not False, (
         "an offloaded weight latched the int8 kernel off for the session"
     )
+
+
+@requires_mps
+def test_dequant_leaves_an_offloaded_weight_on_the_cpu(monkeypatch):
+    """comfy parks weights on CPU to keep them out of memory. Dequantising one
+    pulls a bigger, full-precision copy onto the GPU and pins it there, undoing
+    the offload and inflating residency past what the >= 48 GiB gate budgeted for.
+
+    The flag must stay unset too: being offloaded is transient, so the layer
+    should still dequantise once comfy brings the weight back -- the same
+    treatment _maybe_dequant_embedding already gives this case.
+    """
+    from comfy_kitchen.tensor import QuantizedTensor
+
+    monkeypatch.setattr(patch, "_DEQUANT_MODE", True, raising=False)
+
+    qw_cpu = QuantizedTensor.from_float(
+        (torch.randn(64, 128) * 0.1).to(torch.bfloat16), "TensorWiseINT8Layout"
+    )
+    assert qw_cpu.device.type == "cpu", "fixture must stay offloaded"
+
+    class Holder:
+        _full_precision_mm = False
+        comfy_force_cast_weights = True
+        weight_function = []
+        bias_function = []
+
+    layer = Holder()
+    layer.weight = qw_cpu
+    layer.bias = None
+
+    x = torch.randn(1, 128, dtype=torch.bfloat16, device="mps")
+    patch._maybe_dequant_weight(layer, x)
+
+    assert isinstance(layer.weight, QuantizedTensor), "offloaded weight was dequantised"
+    assert layer.weight.device.type == "cpu", "offloaded weight was pulled onto the GPU"
+    assert not getattr(layer, "_asfp8_deq_done", False), (
+        "a transient offload latched the layer out of ever dequantising"
+    )


### PR DESCRIPTION
Follow-up to #26, found in review.

`_maybe_dequant_weight` gates on the *activation's* device but never the weight's. A layer whose weight comfy has parked on CPU therefore still gets dequantised, and the full-precision copy is pinned to MPS — which undoes the offload and inflates residency past what the `>= 48 GiB` gate budgeted for. The dequantised copy is larger than the int8 weight it replaces, and comfy had already decided it shouldn't be resident at all.

Reproduced before fixing — a CPU-resident `TensorWiseINT8Layout` weight came back as:

```
Parameter containing: tensor([...], device='mps:0', dtype=torch.bfloat16)
```

The new check joins the other transient conditions, **above** the `_asfp8_deq_done` latch, so being offloaded doesn't permanently disqualify the layer: once comfy brings the weight back, a later call dequantises normally. `_maybe_dequant_embedding` already treats its weight exactly this way — the Linear path just missed it.

Only reachable with `ASFP8_INT8_DEQUANT=1`, so no default-path behaviour changes.

375 passed, 3 skipped on M5 Max / macOS 27 / torch 2.11.

## Summary by Sourcery

Preserve CPU offloading for int8 linear weights during optional dequantisation.

Bug Fixes:
- Prevent int8 weights offloaded to CPU from being dequantised and pulled onto MPS, while allowing dequantisation after the weights become resident again.

Tests:
- Add MPS coverage verifying offloaded weights remain quantised on CPU and do not set the dequantisation latch.

Chores:
- Clarify stochastic FP8 re-quantisation logging to describe GPU execution with CPU fallback.